### PR TITLE
Sort command line options and class fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cd $SOURCE_DIR/
 cd $BUILD_DIR
 cmake -GNinja -DCMAKE_BUILD_TYPE={Debug|Release|RelWithDebInfo} $SOURCE_DIR
 ninja
-ctest #optional
+ctest # optional
 ```
 
 4b) Or build (and test) with MSVC on Windows:

--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -190,6 +190,10 @@ WARNING: Linking of multiple input shader files are not supported yet.
 files are preprocessed. If `value` is omitted, the macro is defined with an
 empty value.
 
+==== `-I`
+
+`-I` adds the specified directory to the search path for include files.
+
 === Code Generation Options
 
 ==== `-g`

--- a/glslc/src/file_compiler.h
+++ b/glslc/src/file_compiler.h
@@ -75,18 +75,19 @@ class FileCompiler : public shaderc_util::Compiler {
   // Returns the name of the output file, given the input_filename string.
   std::string GetOutputFileName(std::string input_filename);
 
-  bool needs_linking_;
+  // A FileFinder used to substitute #include directives in the source code.
   shaderc_util::FileFinder include_file_finder_;
+
+  // Indicates whether linking is needed to generate the final output.
+  bool needs_linking_;
 
   // Reflects the type of file being generated.
   std::string file_extension_;
-
   // Name of the file where the compilation output will go.
   shaderc_util::string_piece output_file_name_;
 
   // Counts warnings encountered in compilation.
   size_t total_warnings_;
-
   // Counts errors encountered in compilation.
   size_t total_errors_;
 };

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -50,12 +50,12 @@ class Compiler {
       // profile. But we want to default to a non-es profile.
       : default_version_(110),
         default_profile_(ENoProfile),
-        warnings_as_errors_(false),
-        disassemble_(false),
         force_version_profile_(false),
         preprocess_only_(false),
-        generate_debug_info_(false),
-        suppress_warnings_(false) {}
+        disassemble_(false),
+        warnings_as_errors_(false),
+        suppress_warnings_(false),
+        generate_debug_info_(false) {}
 
   // Instead of outputting object files, output the disassembled textual output.
   virtual void SetDisassemblyMode();
@@ -180,31 +180,27 @@ class Compiler {
 
   // Version to use when force_version_profile_ is true.
   int default_version_;
-
   // Profile to use when force_version_profile_ is true.
   EProfile default_profile_;
-
-  // When true, treat warnings as errors.
-  bool warnings_as_errors_;
-
-  // When true, compilation output will be disassembled SPIR-V.
-  bool disassemble_;
-
   // When true, use the default version and profile from eponymous data members.
   bool force_version_profile_;
 
   // When true, compilation output will be preprocessed source.
   bool preprocess_only_;
+  // When true, compilation output will be disassembled SPIR-V.
+  bool disassemble_;
+
+  // Macro definitions that must be available to reference in the shader source.
+  MacroDictionary predefined_macros_;
+
+  // When true, treat warnings as errors.
+  bool warnings_as_errors_;
+  // Supress warnings when true.
+  bool suppress_warnings_;
 
   // When true, compilation will generate debug info with the binary SPIR-V
   // output.
   bool generate_debug_info_;
-
-  // Supress warnings when true.
-  bool suppress_warnings_;
-
-  // Macro definitions that must be available to reference in the shader source.
-  MacroDictionary predefined_macros_;
 };
 
 }  // namespace shaderc_util


### PR DESCRIPTION
* Sort command line options in `main.c` to make it consistent with the manual.
* Sort and group fields in compiler-related classes.
* Add missing blurbs for some fields.
* Add the `-I` option in `glslc` manual.