### PR TITLE
Fix a problem in command line option parsing.

### DIFF
--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -68,11 +68,10 @@ void PrintHelp(std::ostream* out) {
        << std::endl;
 }
 
-// Parses the argument for the option at index in argv. On success, returns
-// true and writes the parsed argument into option_argument. Returns false
-// if any error occurs. option is the expected option at argv[index].
-// After calling this function, index will be at the last command line
-// argument consumed.
+// Gets the option argument for the option at *index in argv in a way consistent
+// with clang/gcc. On success, returns true and writes the parsed argument into
+// *option_argument. Returns false if any errors occur. After calling this
+// function, *index will the index of the last command line argument consumed.
 bool GetOptionArgument(int argc, char** argv, int* index,
                        const std::string& option,
                        string_piece* option_argument) {
@@ -82,12 +81,13 @@ bool GetOptionArgument(int argc, char** argv, int* index,
     *option_argument = arg.substr(option.size());
     return true;
   } else {
-    if (++(*index) >= argc) {
-      return false;
-    } else {
-      *option_argument = argv[*index];
+    if (option.back() == '=') {
+      *option_argument = "";
       return true;
     }
+    if (++(*index) >= argc) return false;
+    *option_argument = argv[*index];
+    return true;
   }
 }
 

--- a/glslc/test/option_std.py
+++ b/glslc/test/option_std.py
@@ -29,6 +29,30 @@ def core_frag_shader_without_version():
 
 
 @inside_glslc_testsuite('OptionStd')
+class TestStdNoArg(expect.ErrorMessage):
+    """Tests -std alone."""
+
+    glslc_args = ['-std']
+    expected_error = ["glslc: error: unknown argument: '-std'\n"]
+
+
+@inside_glslc_testsuite('OptionStd')
+class TestStdEqNoArg(expect.ErrorMessage):
+    """Tests -std= with no argument."""
+
+    glslc_args = ['-std=']
+    expected_error = ["glslc: error: invalid value '' in '-std='\n"]
+
+
+@inside_glslc_testsuite('OptionStd')
+class TestStdEqSpaceArg(expect.ErrorMessage):
+    """Tests -std= <version-profile>."""
+
+    shader = FileShader(core_frag_shader_without_version(), '.frag')
+    glslc_args = ['-c', '-std=', '450core', shader]
+    expected_error = ["glslc: error: invalid value '' in '-std='\n"]
+
+@inside_glslc_testsuite('OptionStd')
 class TestMissingVersionAndStd(expect.ErrorMessage):
     """Tests that missing both #version and -std results in errors."""
 


### PR DESCRIPTION
When a command line option ends with an equal sign, it's argument
is what follows that equal sign, even if it's empty.