### PR TITLE
Support for -working-directory

### DIFF
--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -95,6 +95,22 @@ Otherwise,
 `-o` lets you specify the output file's name. It cannot be used when there are
 multiple files generated. A filename of `-` represents standard output.
 
+==== `-working-directory`
+
+`-working-directory[=]` sets the working directory for the compilation.
+Paths/filenames in the following categories will be resolved against the
+argument of `-working-directory`:
+
+* Input files under *relative* paths.
+* Intermediate output files (files generated via the `-c` or `-S` option).
+** Including the filename under *relative* paths given by the `-o` option.
+* Non-system include files (files ``#include``d using double-quotation marks)
+  under *relative* paths.
+
+Output files will be generated into the current working directory if no
+<<compilation-stage-selection-options,compilation stage selection option>> is
+given.
+
 === Language and Mode Selection Options
 
 [[option-f-shader-stage]]
@@ -151,6 +167,7 @@ follow the version specified by `-std=`.
 `-x` lets you specify the language of the input shader files. Right now, the
 only accepted argument is `glsl`.
 
+[[compilation-stage-selection-options]]
 === Compilation Stage Selection Options
 
 ==== `-c`

--- a/glslc/src/file_compiler.cc
+++ b/glslc/src/file_compiler.cc
@@ -33,7 +33,11 @@ namespace glslc {
 bool FileCompiler::CompileShaderFile(const std::string& input_file,
                                      EShLanguage shader_stage) {
   std::vector<char> input_data;
-  if (!shaderc_util::ReadFile(input_file, &input_data)) {
+  std::string path = input_file;
+  if (!workdir_.empty() && !shaderc_util::IsAbsolutePath(path)) {
+    path = workdir_ + path;
+  }
+  if (!shaderc_util::ReadFile(path, &input_data)) {
     return false;
   }
 
@@ -70,6 +74,11 @@ bool FileCompiler::CompileShaderFile(const std::string& input_file,
     }
   }
   return compilation_success;
+}
+
+void FileCompiler::SetWorkingDirectory(const std::string& dir) {
+  workdir_ = dir;
+  if (!dir.empty() && dir.back() != '/') workdir_.push_back('/');
 }
 
 void FileCompiler::AddIncludeDirectory(const std::string& path) {
@@ -138,6 +147,10 @@ std::string FileCompiler::GetOutputFileName(std::string input_filename) {
     }
   }
   if (!output_file_name_.empty()) output_file = output_file_name_.str();
+  if (!needs_linking_ && !workdir_.empty() &&
+      !shaderc_util::IsAbsolutePath(input_filename)) {
+    output_file = workdir_ + output_file;
+  }
   return output_file;
 }
 

--- a/glslc/src/file_compiler.h
+++ b/glslc/src/file_compiler.h
@@ -42,6 +42,9 @@ class FileCompiler : public shaderc_util::Compiler {
   bool CompileShaderFile(const std::string& input_file,
                          EShLanguage shader_stage);
 
+  // Sets the working directory for the compilation.
+  void SetWorkingDirectory(const std::string& dir);
+
   // Adds a directory to be searched when processing #include directives.
   //
   // Best practice: if you add an empty string before any other path, that will
@@ -74,6 +77,10 @@ class FileCompiler : public shaderc_util::Compiler {
  private:
   // Returns the name of the output file, given the input_filename string.
   std::string GetOutputFileName(std::string input_filename);
+
+  // Resolves relative paths against this working directory. Must always end
+  // in '/'.
+  std::string workdir_;
 
   // A FileFinder used to substitute #include directives in the source code.
   shaderc_util::FileFinder include_file_finder_;

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -62,6 +62,9 @@ void PrintHelp(std::ostream* out) {
        << "  -S                Only run preprocess and compilation steps.\n"
        << "  -w                Suppresses all warning messages.\n"
        << "  -Werror           Treat all warnings as errors.\n"
+       << "  -working-directory <dir>\n"
+       << "                    Resolve file paths relative to the specified "
+       << "directory.\n"
        << "  -x <language>     Treat subsequent input files as having type "
        << "<language>.\n"
        << "                    The only supported language is glsl."
@@ -116,6 +119,18 @@ int main(int argc, char** argv) {
         return 1;
       }
       compiler.SetOutputFileName(file_name);
+    } else if (arg.starts_with("-working-directory")) {
+      // Following Clang, both -working-directory and -working-directory= are
+      // accepted.
+      std::string option = "-working-directory";
+      if (arg[option.size()] == '=') option = "-working-directory=";
+      string_piece workdir;
+      if (!GetOptionArgument(argc, argv, &i, option, &workdir)) {
+        std::cerr << "glslc: error: argument to '-working-directory' is "
+                     "missing (expected 1 value)"
+                  << std::endl;
+      }
+      compiler.SetWorkingDirectory(workdir.str());
     } else if (arg.starts_with("-fshader-stage=")) {
       const string_piece stage = arg.substr(std::strlen("-fshader-stage="));
       force_shader_stage = glslc::GetShaderStageFromCmdLine(arg);

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -71,6 +71,8 @@ Options:
   -S                Only run preprocess and compilation steps.
   -w                Suppresses all warning messages.
   -Werror           Treat all warnings as errors.
+  -working-directory <dir>
+                    Resolve file paths relative to the specified directory.
   -x <language>     Treat subsequent input files as having type <language>.
                     The only supported language is glsl.
 '''

--- a/glslc/test/working_directory.py
+++ b/glslc/test/working_directory.py
@@ -1,0 +1,167 @@
+# Copyright 2015 The Shaderc Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os.path
+
+import expect
+from environment import File, Directory
+from glslc_test_framework import inside_glslc_testsuite
+from placeholder import FileShader
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirNoArg(expect.ErrorMessage):
+    """Tests -working-directory. Behavior cribbed from Clang."""
+
+    glslc_args = ['-working-directory']
+    expected_error = [
+        "glslc: error: argument to '-working-directory' is missing "
+        '(expected 1 value)\n',
+        'glslc: error: no input files\n']
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirEqNoArg(expect.ErrorMessage):
+    """Tests -working-directory=<empty>. Behavior cribbed from Clang."""
+
+    glslc_args = ['-working-directory=']
+    expected_error = ['glslc: error: no input files\n']
+
+
+EMPTY_SHADER_IN_SUBDIR = Directory(
+    'subdir', [File('shader.vert', 'void main() {}')])
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirEqNoArgCompileFile(expect.ValidNamedObjectFile):
+    """Tests -working-directory=<empty> when compiling input file."""
+
+    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
+    glslc_args = ['-c', '-working-directory=', 'subdir/shader.vert']
+    # Output file should be generated into subdir/.
+    expected_object_filenames = ('subdir/shader.vert.spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirEqNoArgLinkFile(expect.ValidNamedObjectFile):
+    """Tests -working-directory=<empty> when linking input file."""
+
+    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
+    glslc_args = ['-working-directory=', 'subdir/shader.vert']
+    # Output file should be generated into the current directory, not
+    # subdir/, where the source is.
+    expected_object_filenames = ('a.spv',)
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirCompileFile(expect.ValidNamedObjectFile):
+    """Tests -working-directory=<dir> when compiling input file."""
+
+    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
+    glslc_args = ['-c', '-working-directory=subdir', 'shader.vert']
+    # Output file should be generated into subdir/.
+    expected_object_filenames = ('subdir/shader.vert.spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirLinkFile(expect.ValidNamedObjectFile):
+    """Tests -working-directory=<dir> when linking input file."""
+
+    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
+    glslc_args = ['-working-directory=subdir', 'shader.vert']
+    # Output file should be generated into the current directory, not
+    # subdir/, where the source is.
+    expected_object_filenames = ('a.spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirCompileFileOutput(expect.ValidNamedObjectFile):
+    """Tests -working-directory=<dir> when compiling input file and specifying
+    output filename."""
+
+    environment = Directory('.', [
+        Directory('subdir', [
+            Directory('bin', []),
+            File('shader.vert', 'void main() {}')
+        ])
+    ])
+    glslc_args = ['-c', '-o', 'bin/spv', '-working-directory=subdir',
+                  'shader.vert']
+    # Output file should be generated into subdir/bin/.
+    expected_object_filenames = ('subdir/bin/spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirLinkFileOutput(expect.ValidNamedObjectFile):
+    """Tests -working-directory=<dir> when linking input file and specifying
+    output filename."""
+
+    environment = Directory('.', [
+        EMPTY_SHADER_IN_SUBDIR,
+        Directory('bin', [])
+    ])
+    glslc_args = ['-o', 'bin/spv', '-working-directory=subdir',
+                  'shader.vert']
+    # Output file should be generated into bin/, not subdir/bin/.
+    expected_object_filenames = ('bin/spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirLinkFileOutputNotExist(expect.ErrorMessage):
+    """Tests -working-directory=<dir> when linking input file and specifying
+    filename in non-existing directory."""
+
+    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
+    glslc_args = ['-o', 'bin/spv', '-working-directory=subdir',
+                  'shader.vert']
+    # Output file should be generated into bin/, which does not exist.
+    expected_error = ['glslc: error: cannot open output file: ',
+                      "'bin/spv': No such file or directory\n"]
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirArgNoEq(expect.ValidNamedObjectFile):
+    """Tests -working-directory <dir>."""
+
+    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
+    glslc_args = ['-working-directory', 'subdir', 'shader.vert']
+    expected_object_filenames = ('a.spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirEqInArg(expect.ValidNamedObjectFile):
+    """Tests -working-directory=<dir-with-equal-sign-inside>."""
+
+    environment = Directory('.', [
+        Directory('=subdir', [File('shader.vert', 'void main() {}')]),
+    ])
+    glslc_args = ['-working-directory==subdir', 'shader.vert']
+    expected_object_filenames = ('a.spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirCompileFileAbsolutePath(expect.ValidObjectFile):
+    """Tests -working-directory=<dir> when compiling input file with absolute
+    path."""
+
+    shader = FileShader('void main() {}', '.vert')
+    glslc_args = ['-c', '-working-directory=subdir', shader]
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirLinkFileAbsolutePath(expect.ValidNamedObjectFile):
+    """Tests -working-directory=<dir> when linking input file with absolute
+    path."""
+
+    shader = FileShader('void main() {}', '.vert')
+    glslc_args = ['-working-directory=subdir', shader]
+    expected_object_filenames = ('a.spv',)

--- a/libshaderc_util/include/libshaderc_util/io.h
+++ b/libshaderc_util/include/libshaderc_util/io.h
@@ -22,6 +22,9 @@
 
 namespace shaderc_util {
 
+// Returns true if the given path is an absolute path.
+bool IsAbsolutePath(const std::string& path);
+
 // Reads all of the characters in a given file into input_data.  Outputs an
 // error message to std::cerr if the file could not be read and returns false if
 // there was an error.  If the input_file is "-", then input is read from

--- a/libshaderc_util/src/io.cc
+++ b/libshaderc_util/src/io.cc
@@ -40,6 +40,11 @@ void OutputFileErrorMessage(int errno_value) {
 
 namespace shaderc_util {
 
+bool IsAbsolutePath(const std::string& path) {
+  // TODO(antiagainst): add support for Windows.
+  return !path.empty() && path.front() == '/';
+}
+
 bool ReadFile(const std::string& input_file_name,
               std::vector<char>* input_data) {
   std::istream* stream = &std::cin;

--- a/libshaderc_util/src/io_test.cc
+++ b/libshaderc_util/src/io_test.cc
@@ -20,6 +20,7 @@
 
 namespace {
 
+using shaderc_util::IsAbsolutePath;
 using shaderc_util::ReadFile;
 using shaderc_util::WriteFile;
 using shaderc_util::GetOutputStream;
@@ -33,6 +34,24 @@ class ReadFileTest : public testing::Test {
   // A vector to pass to ReadFile.
   std::vector<char> read_data;
 };
+
+TEST(IsAbsolutePathTest, Linux) {
+  EXPECT_FALSE(IsAbsolutePath(""));
+  EXPECT_TRUE(IsAbsolutePath("/"));
+  EXPECT_FALSE(IsAbsolutePath("."));
+  EXPECT_FALSE(IsAbsolutePath(".."));
+  EXPECT_TRUE(IsAbsolutePath("/bin/echo"));
+  EXPECT_TRUE(IsAbsolutePath("//etc/shadow"));
+  EXPECT_TRUE(IsAbsolutePath("/../../../lib"));
+  EXPECT_FALSE(IsAbsolutePath("./something"));
+  EXPECT_FALSE(IsAbsolutePath("input"));
+  EXPECT_FALSE(IsAbsolutePath("../test"));
+  EXPECT_FALSE(IsAbsolutePath(" /abc"));
+  EXPECT_TRUE(IsAbsolutePath("/abc def/ttt"));
+  EXPECT_FALSE(IsAbsolutePath("❤"));
+  EXPECT_TRUE(IsAbsolutePath("/☯"));
+  EXPECT_TRUE(IsAbsolutePath("/☢/g o/ogle"));
+}
 
 TEST_F(ReadFileTest, CorrectContent) {
   ASSERT_TRUE(ReadFile("include_file.1", &read_data));


### PR DESCRIPTION
This patch enables `glslc` to accept `-working-directory` as an option.
Input and output files are resolved against the working directory if
necessary. Setting working directory with the existence of the `#include`
directive is not implemented yet.