### PR TITLE
Rework link-file tests in working_directory.py.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,6 @@
+ROOT_SHADERC_PATH := $(call my-dir)
+
+include $(ROOT_SHADERC_PATH)/third_party/Android.mk
+include $(ROOT_SHADERC_PATH)/libshaderc_util/Android.mk
+include $(ROOT_SHADERC_PATH)/libshaderc/Android.mk
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Shaderc
 
 A collection of tools, libraries and tests for shader compilation.
+At the moment it includes:
+
+- `glslc`, a command line compiler for GLSL to SPIR-V, and
+- `libshaderc` a library API for doing the same.
 
 ## Status
 
@@ -24,9 +28,17 @@ for more information. See also the [`AUTHORS`](AUTHORS) and
 - `third_party/`: third party open source packages; see below
 - `utils/`: utility scripts for Shaderc
 
-Shaderc depends on a [fork](https://github.com/google/glslang) of the Khronos
-reference GLSL compiler glslang. Shaderc also depends on the testing framework
-[Google Mock](https://code.google.com/p/googlemock/).
+Shaderc depends on `glslang`, the Khronos reference compiler for GLSL.
+Sometimes a change updates both Shaderc and glslang.  In that case the
+glslang change will appear in [google/glslang](https://github.com/google/glslang)
+before it appears upstream in
+[KhronosGroup/glslang](https://github.com/KhronosGroup/glslang).
+We intend to upstream all changes to glslang. We maintain the separate
+copy only to stage those changes for review, and to provide something for
+Shaderc to build against in the meantime.
+
+Shaderc also depends on the
+[Google Mock](https://code.google.com/p/googlemock/) testing framework.
 
 In the following sections, `$SOURCE_DIR` is the directory you intend to clone
 Shaderc into.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ for more information. See also the [`AUTHORS`](AUTHORS) and
 
 ## File organization
 
+- `android_test/` : a small Android application to verify compilation
 - `cmake/`: CMake utility functions and configuration for Shaderc
 - `glslc/`: an executable to compile GLSL to SPIR-V
 - `libshaderc/`: a library for compiling shader strings into SPIR-V

--- a/android_test/Android.mk
+++ b/android_test/Android.mk
@@ -1,0 +1,12 @@
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_CPP_EXTENSION := .cc .cpp .cxx
+LOCAL_SRC_FILES:=test.cpp
+LOCAL_MODULE:=shaderc_test
+LOCAL_LDLIBS:=-landroid
+LOCAL_STATIC_LIBRARIES=shaderc android_native_app_glue
+include $(BUILD_SHARED_LIBRARY)
+
+include $(LOCAL_PATH)/../Android.mk
+$(call import-module,android/native_app_glue)

--- a/android_test/jni/Android.mk
+++ b/android_test/jni/Android.mk
@@ -1,0 +1,2 @@
+LOCAL_PATH := $(call my-dir)
+include $(LOCAL_PATH)/../Android.mk

--- a/android_test/jni/Application.mk
+++ b/android_test/jni/Application.mk
@@ -1,0 +1,5 @@
+#APP_MODULES:=shaderc_shared
+APP_ABI:=all
+APP_BUILD_SCRIPT:=Android.mk
+APP_STL := c++_shared
+APP_PLATFORM := android-9

--- a/android_test/test.cpp
+++ b/android_test/test.cpp
@@ -1,0 +1,10 @@
+#include "shaderc.hpp"
+#include <android_native_app_glue.h>
+
+void android_main(struct android_app* state) {
+  app_dummy();
+  shaderc::Compiler compiler;
+  const char* test_program = "void main() {}";
+  compiler.CompileGlslToSpv(test_program, strlen(test_program),
+                            shaderc_glsl_vertex_shader);
+}

--- a/cmake/setup_build.cmake
+++ b/cmake/setup_build.cmake
@@ -21,7 +21,15 @@ if(WIN32)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 endif(WIN32)
 
+if (ANDROID)
+# For android let's preemptively find the correct packages so that
+# child projects (glslang, googletest) do not fail to find them.
+find_host_program(PYTHON_EXE python REQUIRED)
+find_host_package(PythonInterp)
+find_host_package(BISON)
+else()
 find_program(PYTHON_EXE python REQUIRED)
+endif()
 
 option(ENABLE_CODE_COVERAGE "Enable collecting code coverage." OFF)
 if (ENABLE_CODE_COVERAGE)

--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -111,6 +111,8 @@ Output files will be generated into the current working directory if no
 <<compilation-stage-selection-options,compilation stage selection option>> is
 given.
 
+WARNING: Interaction with `#include` and `-I` is not implemented yet.
+
 === Language and Mode Selection Options
 
 [[option-f-shader-stage]]
@@ -210,6 +212,8 @@ empty value.
 ==== `-I`
 
 `-I` adds the specified directory to the search path for include files.
+
+WARNING: Implementation is not complete yet.
 
 === Code Generation Options
 

--- a/glslc/test/option_std.py
+++ b/glslc/test/option_std.py
@@ -79,9 +79,8 @@ class TestMissingVersionAndWrongStd(expect.ErrorMessage):
     shader = FileShader(core_frag_shader_without_version(), '.frag')
     glslc_args = ['-c', '-std=310es', shader]
     expected_error = [
-        shader, ":1: error: 'gl_SampleID' : undeclared identifier\n",
-        shader, ":1: error: '=' :  cannot convert from 'temp float' to ",
-        "'temp mediump int'\n2 errors generated.\n"]
+        shader, ":1: error: 'gl_SampleID' : required extension not requested: "
+        'GL_OES_sample_variables\n1 error generated.\n']
 
 
 @inside_glslc_testsuite('OptionStd')

--- a/glslc/test/working_directory.py
+++ b/glslc/test/working_directory.py
@@ -53,16 +53,6 @@ class TestWorkDirEqNoArgCompileFile(expect.ValidNamedObjectFile):
 
 
 @inside_glslc_testsuite('WorkDir')
-class TestWorkDirEqNoArgLinkFile(expect.ValidNamedObjectFile):
-    """Tests -working-directory=<empty> when linking input file."""
-
-    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
-    glslc_args = ['-working-directory=', 'subdir/shader.vert']
-    # Output file should be generated into the current directory, not
-    # subdir/, where the source is.
-    expected_object_filenames = ('a.spv',)
-
-@inside_glslc_testsuite('WorkDir')
 class TestWorkDirCompileFile(expect.ValidNamedObjectFile):
     """Tests -working-directory=<dir> when compiling input file."""
 
@@ -70,17 +60,6 @@ class TestWorkDirCompileFile(expect.ValidNamedObjectFile):
     glslc_args = ['-c', '-working-directory=subdir', 'shader.vert']
     # Output file should be generated into subdir/.
     expected_object_filenames = ('subdir/shader.vert.spv',)
-
-
-@inside_glslc_testsuite('WorkDir')
-class TestWorkDirLinkFile(expect.ValidNamedObjectFile):
-    """Tests -working-directory=<dir> when linking input file."""
-
-    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
-    glslc_args = ['-working-directory=subdir', 'shader.vert']
-    # Output file should be generated into the current directory, not
-    # subdir/, where the source is.
-    expected_object_filenames = ('a.spv',)
 
 
 @inside_glslc_testsuite('WorkDir')
@@ -98,34 +77,6 @@ class TestWorkDirCompileFileOutput(expect.ValidNamedObjectFile):
                   'shader.vert']
     # Output file should be generated into subdir/bin/.
     expected_object_filenames = ('subdir/bin/spv',)
-
-
-@inside_glslc_testsuite('WorkDir')
-class TestWorkDirLinkFileOutput(expect.ValidNamedObjectFile):
-    """Tests -working-directory=<dir> when linking input file and specifying
-    output filename."""
-
-    environment = Directory('.', [
-        EMPTY_SHADER_IN_SUBDIR,
-        Directory('bin', [])
-    ])
-    glslc_args = ['-o', 'bin/spv', '-working-directory=subdir',
-                  'shader.vert']
-    # Output file should be generated into bin/, not subdir/bin/.
-    expected_object_filenames = ('bin/spv',)
-
-
-@inside_glslc_testsuite('WorkDir')
-class TestWorkDirLinkFileOutputNotExist(expect.ErrorMessage):
-    """Tests -working-directory=<dir> when linking input file and specifying
-    filename in non-existing directory."""
-
-    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
-    glslc_args = ['-o', 'bin/spv', '-working-directory=subdir',
-                  'shader.vert']
-    # Output file should be generated into bin/, which does not exist.
-    expected_error = ['glslc: error: cannot open output file: ',
-                      "'bin/spv': No such file or directory\n"]
 
 
 @inside_glslc_testsuite('WorkDir')
@@ -157,11 +108,63 @@ class TestWorkDirCompileFileAbsolutePath(expect.ValidObjectFile):
     glslc_args = ['-c', '-working-directory=subdir', shader]
 
 
-@inside_glslc_testsuite('WorkDir')
-class TestWorkDirLinkFileAbsolutePath(expect.ValidNamedObjectFile):
-    """Tests -working-directory=<dir> when linking input file with absolute
-    path."""
+# The -working-directory flag should not affect the placement of the link file.
+# The following tests ensure that.
 
-    shader = FileShader('void main() {}', '.vert')
-    glslc_args = ['-working-directory=subdir', shader]
+class WorkDirDoesntAffectLinkedFile(expect.ValidNamedObjectFile):
+    """A base class for tests asserting that -workind-directory has no impact
+    on the location of the output link file.
+    """
+    environment = Directory('.', [
+        Directory('subdir', [
+            File('shader.vert', 'void main(){}'),
+            # This bin/ is in the wrong location, so glslc should ignore it.
+            Directory('bin', [])]),
+        File('shader.vert', "fake file, doesn't compile."),
+        Directory('bin', [])])
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirLinkFileDefaultLocation(WorkDirDoesntAffectLinkedFile):
+    """Tests that -working-directory doesn't impact the default link-file
+    location.
+    """
+    glslc_args = ['-working-directory=subdir', 'shader.vert']
     expected_object_filenames = ('a.spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirLinkFileExplicit(WorkDirDoesntAffectLinkedFile):
+    """Tests that -working-directory doesn't impact the named link-file
+    location.
+    """
+    glslc_args = ['-o', 'b.spv', '-working-directory=subdir', 'shader.vert']
+    expected_object_filenames = ('b.spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirLinkFileInSubdir(WorkDirDoesntAffectLinkedFile):
+    """Tests that -working-directory doesn't impact the link-file sent into an
+    existing subdirectory.
+    """
+    glslc_args = ['-o', 'bin/spv', '-working-directory=subdir', 'shader.vert']
+    expected_object_filenames = ('bin/spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirLinkFileInvalidPath(expect.ErrorMessage):
+    """Tests that -working-directory doesn't impact the error generated for an
+    invalid -o path.
+    """
+
+    environment = Directory('.', [
+        Directory('subdir', [
+            File('shader.vert', 'void main(){}'),
+            Directory('missing', [])]),  # Present here, but missing in parent.
+        File('shader.vert', "fake file, doesn't compile.")])
+
+    glslc_args = [
+        '-o', 'missing/spv', '-working-directory=subdir', 'shader.vert']
+
+    expected_error = ['glslc: error: cannot open output file: ',
+                      "'missing/spv': No such file or directory\n"]

--- a/glslc/test/working_directory.py
+++ b/glslc/test/working_directory.py
@@ -53,6 +53,30 @@ class TestWorkDirEqNoArgCompileFile(expect.ValidNamedObjectFile):
 
 
 @inside_glslc_testsuite('WorkDir')
+class TestMultipleWorkDir(expect.ValidNamedObjectFile):
+    """Tests that if there are multiple -working-directory=<dir> specified,
+    only the last one takes effect."""
+
+    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
+    glslc_args = ['-c', '-working-directory=i-dont-exist',
+                  '-working-directory', 'i-think/me-neither',
+                  '-working-directory=subdir', 'shader.vert']
+    # Output file should be generated into subdir/.
+    expected_object_filenames = ('subdir/shader.vert.spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
+class TestWorkDirPosition(expect.ValidNamedObjectFile):
+    """Tests that -working-directory=<dir> affects all files including the
+    one before it."""
+
+    environment = Directory('.', [EMPTY_SHADER_IN_SUBDIR])
+    glslc_args = ['-c', 'shader.vert', '-working-directory=subdir']
+    # Output file should be generated into subdir/.
+    expected_object_filenames = ('subdir/shader.vert.spv',)
+
+
+@inside_glslc_testsuite('WorkDir')
 class TestWorkDirCompileFile(expect.ValidNamedObjectFile):
     """Tests -working-directory=<dir> when compiling input file."""
 

--- a/libshaderc/Android.mk
+++ b/libshaderc/Android.mk
@@ -1,0 +1,13 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_CPP_EXTENSION := .cc .cpp .cxx
+LOCAL_MODULE:=shaderc
+LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)/include
+LOCAL_SRC_FILES:=src/shaderc.cc
+LOCAL_C_INCLUDES:=$(LOCAL_PATH)/include
+LOCAL_STATIC_LIBRARIES=shaderc_util
+LOCAL_CXXFLAGS:=-std=c++11
+LOCAL_EXPORT_CPPFLAGS:=-std=c++11
+LOCAL_EXPORT_LDFLAGS:=-latomic
+include $(BUILD_STATIC_LIBRARY)

--- a/libshaderc/CMakeLists.txt
+++ b/libshaderc/CMakeLists.txt
@@ -14,10 +14,26 @@ target_link_libraries(shaderc PRIVATE
 target_link_libraries(shaderc PRIVATE shaderc_util)
 target_link_libraries(shaderc PRIVATE SPIRV)
 
+
 add_shaderc_tests(
   TEST_PREFIX shaderc
   LINK_LIBS shaderc
   INCLUDE_DIRS include ${glslang_SOURCE_DIR}
-  TEST_NAMES 
+  TEST_NAMES
     shaderc
     shaderc_cpp)
+
+
+if (NOT "${MSVC}")
+  # If we are not on windows, then create a single static library
+  # that contains everything needed to use shaderc.
+  combine_static_lib(shaderc_combined shaderc)
+  add_shaderc_tests(
+    TEST_PREFIX shaderc_combined
+    LINK_LIBS shaderc_combined ${CMAKE_THREAD_LIBS_INIT}
+    INCLUDE_DIRS include ${glslang_SOURCE_DIR}
+    TEST_NAMES
+      shaderc
+      shaderc_cpp)
+endif()
+

--- a/libshaderc/README.md
+++ b/libshaderc/README.md
@@ -5,13 +5,13 @@ A library for compiling shader strings into SPIR-V.
 ## Build Artifacts
 
 There are two main shaderc libraries that are created during a CMake
-compilation. The first is `libshaderc` which is a static library 
+compilation. The first is `libshaderc`, which is a static library 
 containing just the functionality exposed by libshaderc. It depends 
 on other compilation targets `glslang`, `OSDependent`, `OGLCompiler`,
 `shaderc_util` and `SPIRV`.
 
-The other is `libshaderc_combined` which is a static library containing
-libshaderc and all of it's dependencies.
+The other is `libshaderc_combined`, which is a static library containing
+libshaderc and all of its dependencies.
 
 
 ## Integrating libshaderc
@@ -22,14 +22,17 @@ There are several ways of integrating libshaderc into external projects.
 included into the external project's CMake configuration and shaderc can be used
 as a link target.
 This is the simplest way to use libshaderc in an external project.
+
 2. If the external project uses CMake and is building for Linux or Android,
 `target_link_libraries(shaderc_combined)` can instead be specified. This is
 functionally identical to the previous option.
-3. If the external project does not use CMake then the external project can
-instead directly use the generated libraries.  
-`shaderc/libshaderc/include` should be added to the include path, and
+
+3. If the external project does not use CMake, then the external project can
+instead directly use the generated libraries.  `shaderc/libshaderc/include`
+should be added to the include path, and
 `build/libshaderc/libshaderc_combined.a` should be linked. Note that on some
 platforms `-lpthread` should also be specified.
+
 4. If the external project does not use CMake and cannot use
 libshaderc_combined, the following libraries or their platform-dependent
 counterparts should be linked in the order specified.
@@ -40,6 +43,7 @@ counterparts should be linked in the order specified.
  `build/third_party/glslang/libglslang.a`  
  `build/shaderc_util/libshaderc_util.a`  
  `build/third_party/glslang/SPIRV/libSPIRV.a`
+
 5. If building for Android using the Android NDK, `shaderc/Android.mk` can be
 included in the application's `Android.mk` and `LOCAL_STATIC_LIBRARIES:=shaderc`
 can be specified. See `shaderc/android_test` for an example.

--- a/libshaderc/README.md
+++ b/libshaderc/README.md
@@ -1,0 +1,45 @@
+# libshaderc
+
+A library for compiling shader strings into SPIR-V.
+
+## Build Artifacts
+
+There are two main shaderc libraries that are created during a CMake
+compilation. The first is `libshaderc` which is a static library 
+containing just the functionality exposed by libshaderc. It depends 
+on other compilation targets `glslang`, `OSDependent`, `OGLCompiler`,
+`shaderc_util` and `SPIRV`.
+
+The other is `libshaderc_combined` which is a static library containing
+libshaderc and all of it's dependencies.
+
+
+## Integrating libshaderc
+
+There are several ways of integrating libshaderc into external projects.
+
+1. If the external project uses CMake, then `shaderc/CMakeLists.txt` can be
+included into the external project's CMake configuration and shaderc can be used
+as a link target.
+This is the simplest way to use libshaderc in an external project.
+2. If the external project uses CMake and is building for Linux or Android,
+`target_link_libraries(shaderc_combined)` can instead be specified. This is
+functionally identical to the previous option.
+3. If the external project does not use CMake then the external project can
+instead directly use the generated libraries.  
+`shaderc/libshaderc/include` should be added to the include path, and
+`build/libshaderc/libshaderc_combined.a` should be linked. Note that on some
+platforms `-lpthread` should also be specified.
+4. If the external project does not use CMake and cannot use
+libshaderc_combined, the following libraries or their platform-dependent
+counterparts should be linked in the order specified.
+ `build/libshaderc/libshaderc.a`  
+ `build/third_party/glslang/glslang/glslang.a`  
+ `build/third_party/glslang/glslang/OSDependent/{Platform}/libOSDependent.a`  
+ `build/third_party/glslang/OGLCompilersDLL/libOGLCompiler.a`  
+ `build/third_party/glslang/libglslang.a`  
+ `build/shaderc_util/libshaderc_util.a`  
+ `build/third_party/glslang/SPIRV/libSPIRV.a`
+5. If building for Android using the Android NDK, `shaderc/Android.mk` can be
+included in the application's `Android.mk` and `LOCAL_STATIC_LIBRARIES:=shaderc`
+can be specified. See `shaderc/android_test` for an example.

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -63,16 +63,6 @@ bool CompilationSuccess(const shaderc::Compiler& compiler,
       .GetSuccess();
 }
 
-// Compiles a shader with the given options and returns true on success, false
-// on failure.
-bool CompilationSuccess(const shaderc::Compiler& compiler,
-                        const std::string& shader, shaderc_shader_kind kind,
-                        const shaderc::CompileOptions& options) {
-  return compiler.CompileGlslToSpv(shader.c_str(), shader.length(), kind,
-                                   options)
-      .GetSuccess();
-}
-
 // Compiles a shader and returns true if the result is valid SPIR-V.
 bool CompilesToValidSpv(const shaderc::Compiler& compiler,
                         const std::string& shader, shaderc_shader_kind kind) {

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -27,7 +27,6 @@ using testing::Each;
 using testing::HasSubstr;
 
 const char kMinimalShader[] = "void main(){}";
-
 TEST(CppInterface, MultipleCalls) {
   shaderc::Compiler compiler1, compiler2, compiler3;
   EXPECT_TRUE(compiler1.IsValid());

--- a/libshaderc_util/Android.mk
+++ b/libshaderc_util/Android.mk
@@ -1,0 +1,16 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE:=shaderc_util
+LOCAL_CXXFLAGS:=-std=c++11
+LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)/include
+LOCAL_SRC_FILES:=src/compiler.cc \
+		src/file_finder.cc \
+		src/io.cc \
+		src/message.cc \
+		src/resources.cc \
+		src/shader_stage.cc \
+		src/version_profile.cc
+LOCAL_STATIC_LIBRARIES:=glslang
+LOCAL_C_INCLUDES:=$(LOCAL_PATH)/include
+include $(BUILD_STATIC_LIBRARY)

--- a/libshaderc_util/src/version_profile.cc
+++ b/libshaderc_util/src/version_profile.cc
@@ -15,6 +15,7 @@
 #include "libshaderc_util/version_profile.h"
 
 #include <cctype>
+#include <sstream>
 
 namespace {
 
@@ -34,12 +35,12 @@ bool ParseVersionProfile(const std::string& version_profile, int* version,
       !::isdigit(version_profile.front()))
     return false;
 
-  size_t split_point;
-  int version_number = std::stoi(version_profile, &split_point);
-  if (!IsKnownVersion(version_number)) return false;
-  *version = version_number;
+  std::string profile_string;
+  std::istringstream(version_profile) >> *version >> profile_string;
 
-  const std::string profile_string = version_profile.substr(split_point);
+  if (!IsKnownVersion(*version)) {
+    return false;
+  }
   if (profile_string.empty()) {
     *profile = ENoProfile;
   } else if (profile_string == "core") {

--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -1,0 +1,82 @@
+LOCAL_PATH := $(call my-dir)/glslang
+GLSLANG_LOCAL_PATH := $(call my-dir)/glslang
+
+include $(CLEAR_VARS)
+LOCAL_MODULE:=SPIRV
+LOCAL_CXXFLAGS:=-std=c++11
+LOCAL_EXPORT_C_INCLUDES:=$(GLSLANG_LOCAL_PATH)
+LOCAL_SRC_FILES:= \
+	SPIRV/GlslangToSpv.cpp \
+	SPIRV/SpvBuilder.cpp \
+	SPIRV/SPVRemapper.cpp \
+	SPIRV/doc.cpp \
+	SPIRV/disassemble.cpp
+
+LOCAL_C_INCLUDES:=$(GLSLANG_LOCAL_PATH) $(GLSLANG_LOCAL_PATH)/glslang/SPIRV
+LOCAL_EXPORT_C_INCLUDES:=$(GLSLANG_LOCAL_PATH)/glslang/SPIRV
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE:=OSDependent
+LOCAL_CXXFLAGS:=-std=c++11
+LOCAL_EXPORT_C_INCLUDES:=$(GLSLANG_LOCAL_PATH)
+LOCAL_SRC_FILES:=glslang/OSDependent/Linux/ossource.cpp
+LOCAL_C_INCLUDES:=$(GLSLANG_LOCAL_PATH) $(GLSLANG_LOCAL_PATH)/glslang/OSDependent/Linux/
+LOCAL_EXPORT_C_INCLUDES:=$(GLSLANG_LOCAL_PATH)/glslang/OSDependent/Linux/
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE:=OGLCompiler
+LOCAL_CXXFLAGS:=-std=c++11
+LOCAL_EXPORT_C_INCLUDES:=$(GLSLANG_LOCAL_PATH)
+LOCAL_SRC_FILES:=OGLCompilersDLL/InitializeDll.cpp
+LOCAL_C_INCLUDES:=$(GLSLANG_LOCAL_PATH)/OGLCompiler
+LOCAL_STATIC_LIBRARIES:=OSDependent
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE:=glslang
+LOCAL_CXXFLAGS:=-std=c++11
+LOCAL_EXPORT_C_INCLUDES:=$(GLSLANG_LOCAL_PATH)
+#TODO(awoloszyn) This creates the glslang_tab.cpp/h files in the source tree.
+#                Figure out if there is a way in the android build system
+#                to put them somewhere else.
+$(GLSLANG_LOCAL_PATH)/glslang/MachineIndependent/glslang_tab.cpp : $(GLSLANG_LOCAL_PATH)/glslang/MachineIndependent/glslang.y
+	@bison --defines=$(GLSLANG_LOCAL_PATH)/glslang/MachineIndependent/glslang_tab.cpp.h -t $(GLSLANG_LOCAL_PATH)/glslang/MachineIndependent/glslang.y -o $(GLSLANG_LOCAL_PATH)/glslang/MachineIndependent/glslang_tab.cpp
+	@echo "[$(TARGET_ARCH_ABI)] Grammar: glslang_tab.cc <= glslang.y"
+
+$(GLSLANG_LOCAL_PATH)/glslang/MachineIndependent/Scan.cpp:$(GLSLANG_LOCAL_PATH)/glslang/MachineIndependent/glslang_tab.cpp
+
+LOCAL_SRC_FILES:= \
+		glslang/MachineIndependent/glslang_tab.cpp \
+		glslang/GenericCodeGen/CodeGen.cpp \
+		glslang/GenericCodeGen/Link.cpp \
+		glslang/MachineIndependent/Constant.cpp \
+		glslang/MachineIndependent/InfoSink.cpp \
+		glslang/MachineIndependent/Initialize.cpp \
+		glslang/MachineIndependent/Intermediate.cpp \
+		glslang/MachineIndependent/intermOut.cpp \
+		glslang/MachineIndependent/IntermTraverse.cpp \
+		glslang/MachineIndependent/limits.cpp \
+		glslang/MachineIndependent/linkValidate.cpp \
+		glslang/MachineIndependent/parseConst.cpp \
+		glslang/MachineIndependent/ParseHelper.cpp \
+		glslang/MachineIndependent/PoolAlloc.cpp \
+		glslang/MachineIndependent/reflection.cpp \
+		glslang/MachineIndependent/RemoveTree.cpp \
+		glslang/MachineIndependent/Scan.cpp \
+		glslang/MachineIndependent/ShaderLang.cpp \
+		glslang/MachineIndependent/SymbolTable.cpp \
+		glslang/MachineIndependent/Versions.cpp \
+		glslang/MachineIndependent/preprocessor/PpAtom.cpp \
+		glslang/MachineIndependent/preprocessor/PpContext.cpp \
+		glslang/MachineIndependent/preprocessor/Pp.cpp \
+		glslang/MachineIndependent/preprocessor/PpMemory.cpp \
+		glslang/MachineIndependent/preprocessor/PpScanner.cpp \
+		glslang/MachineIndependent/preprocessor/PpSymbols.cpp \
+		glslang/MachineIndependent/preprocessor/PpTokens.cpp
+
+LOCAL_C_INCLUDES:=$(GLSLANG_LOCAL_PATH)
+LOCAL_STATIC_LIBRARIES:=OSDependent OGLCompiler SPIRV
+include $(BUILD_STATIC_LIBRARY)
+

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -36,10 +36,8 @@ if (CMAKE_CONFIGURATION_TYPES)
   set(GLSLANG_CONFIGURATION_DIR ${CMAKE_CFG_INTDIR})
 endif()
 
-find_program(PYTHON python REQUIRED)
-
 add_custom_target(copy-tests-if-necessary ALL
-  COMMAND ${PYTHON} ${shaderc_SOURCE_DIR}/utils/copy-tests-if-necessary.py
+  COMMAND ${PYTHON_EXE} ${shaderc_SOURCE_DIR}/utils/copy-tests-if-necessary.py
     ${GLSLANG_TEST_SRC_DIR} ${GLSLANG_TEST_BIN_DIR} ${GLSLANG_CONFIGURATION_DIR}
   COMMENT "Copying and patching glslang tests if needed")
 


### PR DESCRIPTION
The link-file tests currently follow closely the compile-file tests, which is incorrect because `-working-directory` _shouldn't_ impact the link-file location.  Pull them into their own section, make them cover only `-o` variations (without varying the `-working-directory` forms, which are tested elsewhere), and rename them so its obvious what's different between them.