### PR TITLE
Improve link-file tests in working_directory.py.

### DIFF
--- a/glslc/test/working_directory.py
+++ b/glslc/test/working_directory.py
@@ -167,7 +167,8 @@ class WorkDirDoesntAffectLinkedFile(expect.ValidNamedObjectFile):
     environment = Directory('.', [
         Directory('subdir', [
             File('shader.vert', 'void main(){}'),
-            # This bin/ is in the wrong location, so glslc should ignore it.
+            # Try to fake glslc into putting the linked file here, though it
+            # shouldn't (because -working-directory doesn't impact -o).
             Directory('bin', [])]),
         File('shader.vert', "fake file, doesn't compile."),
         Directory('bin', [])])

--- a/glslc/test/working_directory.py
+++ b/glslc/test/working_directory.py
@@ -161,7 +161,7 @@ class TestWorkDirCompileFileAbsolutePath(expect.ValidObjectFile):
 # The following tests ensure that.
 
 class WorkDirDoesntAffectLinkedFile(expect.ValidNamedObjectFile):
-    """A base class for tests asserting that -workind-directory has no impact
+    """A base class for tests asserting that -working-directory has no impact
     on the location of the output link file.
     """
     environment = Directory('.', [


### PR DESCRIPTION
The link-file tests currently follow closely the compile-file tests, which is incorrect because `-working-directory` _shouldn't_ impact the link-file location.  Pull them into their own section, make them cover only `-o` variations (without varying the `-working-directory` forms, which are tested elsewhere), and rename them so its obvious what's different between them.