### PR TITLE
Turn off debug build on Window temporarily

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ environment:
   PYTHON_PACKAGE_PATH: "C:/Python27/Scripts"
 
 configuration:
-  - Debug
+  #- Debug
   - Release
 
 branches:


### PR DESCRIPTION
There is an infinite loop when testing for the debug configuration
on Windows. We don't want to waste AppVeyor resources on this issue
for every commit. Will bring back once the infinite loop is solved.