### PR TITLE
glslc: avoid crash on failure to open the output file stream

### DIFF
--- a/glslc/src/file_compiler.cc
+++ b/glslc/src/file_compiler.cc
@@ -46,6 +46,10 @@ bool FileCompiler::CompileShaderFile(const std::string& input_file,
   std::ofstream potential_file_stream;
   std::ostream* output_stream =
       shaderc_util::GetOutputStream(output_name, &potential_file_stream);
+  if (!output_stream) {
+    // An error message has already been emitted to the stderr stream.
+    return false;
+  }
   string_piece error_file_name = input_file;
 
   if (error_file_name == "-") {

--- a/libshaderc_util/include/libshaderc_util/io.h
+++ b/libshaderc_util/include/libshaderc_util/io.h
@@ -34,9 +34,9 @@ bool ReadFile(const std::string& input_file_name,
 
 // Returns and initializes the file_stream parameter if the output_filename
 // refers to a file, or returns &std::cout if the output_filename is "-".
-// Returns nullptr if the file could not be opened for writing.
-// If the output refers to a file, and the open failed for writing, file_stream
-// is left with its fail_bit set.
+// Returns nullptr and emits an error message to std::cout if the file could
+// not be opened for writing.  If the output refers to a file, and the open
+// failed for writing, file_stream is left with its fail_bit set.
 std::ostream* GetOutputStream(const string_piece& output_filename,
                               std::ofstream* file_stream);
 


### PR DESCRIPTION
Also, update the glslc test framework so that any test will fail if the subprocess was terminated by a signal.  This is especially important to distinguish for a test where the subprocess is expected to exist with non-zero status code.