### PR TITLE
Add missing shader kinds

### DIFF
--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -24,7 +24,11 @@ extern "C" {
 
 typedef enum {
   shaderc_glsl_vertex_shader,
-  shaderc_glsl_fragment_shader
+  shaderc_glsl_fragment_shader,
+  shaderc_glsl_compute_shader,
+  shaderc_glsl_geometry_shader,
+  shaderc_glsl_tess_control_shader,
+  shaderc_glsl_tess_evaluation_shader
 } shaderc_shader_kind;
 
 // Usage examples:

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -41,6 +41,14 @@ EShLanguage GetStage(shaderc_shader_kind kind) {
       return EShLangVertex;
     case shaderc_glsl_fragment_shader:
       return EShLangFragment;
+    case shaderc_glsl_compute_shader:
+      return EShLangCompute;
+    case shaderc_glsl_geometry_shader:
+      return EShLangGeometry;
+    case shaderc_glsl_tess_control_shader:
+      return EShLangTessControl;
+    case shaderc_glsl_tess_evaluation_shader:
+      return EShLangTessEvaluation;
   }
   assert(0 && "Unhandled shaderc_shader_kind");
   return EShLangVertex;

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -261,4 +261,77 @@ TEST(CompileString, MultipleThreadsCalling) {
   EXPECT_THAT(results, Each(true));
 }
 
+TEST(CompileKinds, Vertex) {
+  Compiler compiler;
+  ASSERT_NE(nullptr, compiler.get_compiler_handle());
+  const std::string kVertexShader = "void main(){ gl_Position = vec4(0);}";
+  EXPECT_TRUE(CompilationSuccess(compiler.get_compiler_handle(), kVertexShader,
+                                 shaderc_glsl_vertex_shader));
+}
+
+TEST(CompileKinds, Fragment) {
+  Compiler compiler;
+  ASSERT_NE(nullptr, compiler.get_compiler_handle());
+  const std::string kFragShader = "void main(){ gl_FragColor = vec4(0);}";
+  EXPECT_TRUE(CompilationSuccess(compiler.get_compiler_handle(), kFragShader,
+                                 shaderc_glsl_fragment_shader));
+}
+
+TEST(CompileKinds, Compute) {
+  Compiler compiler;
+  ASSERT_NE(nullptr, compiler.get_compiler_handle());
+  const std::string kCompShader =
+    R"(#version 310 es
+       void main() {}
+  )";
+  EXPECT_TRUE(CompilationSuccess(compiler.get_compiler_handle(), kCompShader,
+                                 shaderc_glsl_compute_shader));
+}
+
+TEST(CompileKinds, Geometry) {
+  Compiler compiler;
+  ASSERT_NE(nullptr, compiler.get_compiler_handle());
+  const std::string kGeoShader =
+    R"(#version 310 es
+       #extension GL_OES_geometry_shader : enable
+       layout(points) in;
+       layout(points, max_vertices=1) out;
+       void main() {
+         gl_Position = vec4(1.0);
+         EmitVertex();
+         EndPrimitive();
+       }
+  )";
+  EXPECT_TRUE(CompilationSuccess(compiler.get_compiler_handle(), kGeoShader,
+                                 shaderc_glsl_geometry_shader));
+}
+
+TEST(CompileKinds, TessControl) {
+  Compiler compiler;
+  ASSERT_NE(nullptr, compiler.get_compiler_handle());
+  const std::string kTCSShader =
+    R"(#version 310 es
+       #extension GL_OES_tessellation_shader : enable
+       layout(vertices=1) out;
+       void main() {}
+  )";
+  EXPECT_TRUE(CompilationSuccess(compiler.get_compiler_handle(), kTCSShader,
+                                 shaderc_glsl_tess_control_shader));
+}
+
+TEST(CompileKinds, TessEvaluation) {
+  Compiler compiler;
+  ASSERT_NE(nullptr, compiler.get_compiler_handle());
+  const std::string kTESShader =
+    R"(#version 310 es
+       #extension GL_OES_tessellation_shader : enable
+       layout(triangles, equal_spacing, ccw) in;
+       void main() {
+         gl_Position = vec4(gl_TessCoord, 1.0);
+       }
+  )";
+  EXPECT_TRUE(CompilationSuccess(compiler.get_compiler_handle(), kTESShader,
+                                 shaderc_glsl_tess_evaluation_shader));
+}
+
 }  // anonymous namespace


### PR DESCRIPTION
Currently only vertex and fragment shader types are exposed; this adds
mappings for the remainder