### PR TITLE
Add shaderc_get_spv_version() to retrieve SPIR-V version/revision

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,3 +14,4 @@ David Neto <dneto@google.com>
 Andrew Woloszyn <awoloszyn@google.com>
 Stefanus Du Toit <sdt@google.com>
 Dejan Mircevski <deki@google.com>
+Mark Adams <marka@nvidia.com>

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -143,6 +143,9 @@ const char* shaderc_module_get_bytes(const shaderc_spv_module_t module);
 // during the compilation.
 const char* shaderc_module_get_error_message(const shaderc_spv_module_t module);
 
+// Provides the version & revision of the SPIR-V which will be produced
+void shaderc_get_spv_version(unsigned int *version, unsigned int *revision);
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -21,6 +21,8 @@
 #include <sstream>
 #include <vector>
 
+#include "SPIRV/spirv.hpp"
+
 #include "libshaderc_util/compiler.h"
 #include "libshaderc_util/resources.h"
 
@@ -204,4 +206,9 @@ void shaderc_module_release(shaderc_spv_module_t module) { delete module; }
 const char* shaderc_module_get_error_message(
     const shaderc_spv_module_t module) {
   return module->messages.c_str();
+}
+
+void shaderc_get_spv_version(unsigned int *version, unsigned int *revision) {
+    *version = spv::Version;
+    *revision = spv::Revision;
 }

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -52,6 +52,14 @@ TEST(Init, MultipleThreadsCalling) {
   shaderc_compiler_release(compiler3);
 }
 
+TEST(Init, SPVVersion) {
+  unsigned int version = 0;
+  unsigned int revision = 0;
+  shaderc_get_spv_version(&version, &revision);
+  EXPECT_EQ(spv::Version, version);
+  EXPECT_EQ(spv::Revision, revision);
+}
+
 // RAII class for shaderc_spv_module.
 class Compilation {
  public:


### PR DESCRIPTION
This is useful for diagnostic purposes when embedded in test apps.
