### PR TITLE
Set Vulkan and SPIR-V rules bits when invoking glslang

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,3 +15,4 @@ Andrew Woloszyn <awoloszyn@google.com>
 Stefanus Du Toit <sdt@google.com>
 Dejan Mircevski <deki@google.com>
 Mark Adams <marka@nvidia.com>
+Jason Ekstrand <jason.ekstrand@intel.com>

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -148,7 +148,9 @@ bool Compiler::Compile(
   bool success =
       shader.parse(&shaderc_util::kDefaultTBuiltInResource, default_version_,
                    default_profile_, force_version_profile_,
-                   kNotForwardCompatible, EShMsgDefault, includer);
+                   kNotForwardCompatible,
+                   static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules),
+                   includer);
 
   success &= PrintFilteredErrors(error_tag, error_stream, warnings_as_errors_,
                                  suppress_warnings_, shader.getInfoLog(),


### PR DESCRIPTION
Without these, it assumes some GL-based set of rules and doesn't enable
everything.  Some day, it might be good if these came from command-line
flags or a #extension declaration or something.