### PR TITLE
Use googletest master branch.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,8 +27,7 @@ init:
 
 # scripts that run after cloning repository
 install:
-  - git clone -b release-1.7.0 https://github.com/google/googlemock.git third_party/gmock-1.7.0
-  - git clone -b release-1.7.0 https://github.com/google/googletest.git third_party/gmock-1.7.0/gtest
+  - git clone https://github.com/google/googletest.git third_party/googletest
   - git clone https://github.com/google/glslang third_party/glslang
 
 build:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,7 @@ install:
   - if [ "$CC" = "clang" ]; then export CC=clang-3.6 CXX=clang++-3.6; fi # Make sure that clang-3.6 is selected.
 
 before_script:
-  - git clone -b release-1.7.0 https://github.com/google/googlemock.git third_party/gmock-1.7.0
-  - git clone -b release-1.7.0 https://github.com/google/googletest.git third_party/gmock-1.7.0/gtest
+  - git clone https://github.com/google/googletest.git third_party/googletest
   - git clone https://github.com/google/glslang.git third_party/glslang
 
 script:

--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ Shaderc into.
 ```sh
 git clone https://github.com/google/shaderc $SOURCE_DIR
 cd $SOURCE_DIR/third_party
-git clone -b release-1.7.0 https://github.com/google/googlemock.git gmock-1.7.0
-git clone -b release-1.7.0 https://github.com/google/googletest.git \
-    gmock-1.7.0/gtest
+git clone https://github.com/google/googletest.git
 git clone https://github.com/google/glslang glslang
 cd $SOURCE_DIR/
 ```

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Suppress all warnings from third-party projects.
 set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS -w)
 
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/gmock-1.7.0)
-  add_subdirectory(gmock-1.7.0)
+if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
+  add_subdirectory(googletest)
 endif()
 if (NOT TARGET gmock)
   message(FATAL_ERROR "gmock was not found - required for tests")


### PR DESCRIPTION
We recommend something newer than googletest 1.7.0 because
we want to pick up a fix for an RTTI issue related to mocking
https://github.com/google/googletest/issues/610
That's fixed on the googletest master branch after 2015-11-10.