### PR TITLE
Fix cmake on mac

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,3 +16,4 @@ Stefanus Du Toit <sdt@google.com>
 Dejan Mircevski <deki@google.com>
 Mark Adams <marka@nvidia.com>
 Jason Ekstrand <jason.ekstrand@intel.com>
+Damien Mabin <dmabin@google.com>

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -127,7 +127,6 @@ function(combine_static_lib new_target target)
   get_transitive_libs(${target} all_libs)
   
   if(APPLE)
-
     string(REPLACE ";" " " all_libs_string "${all_libs}")
 
     add_custom_command(OUTPUT lib${new_target}.a
@@ -136,7 +135,6 @@ function(combine_static_lib new_target target)
     add_custom_target(${new_target}_genfile ALL
       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lib${new_target}.a)
   else()
-
     string(REPLACE ";" "\\\\naddlib " all_libs_string "${all_libs}")
 
     set(ar_script

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -123,11 +123,11 @@ function(combine_static_lib new_target target)
     message(FATAL_ERROR "MSVC does not yet support merging static libraries")
   endif()
 
-  # Should remove the if and use libtool on MacOS and Linux
+  set(all_libs "")
+  get_transitive_libs(${target} all_libs)
+  
   if(APPLE)
 
-    set(all_libs "")
-    get_transitive_libs(${target} all_libs)
     string(REPLACE ";" " " all_libs_string "${all_libs}")
 
     add_custom_command(OUTPUT lib${new_target}.a
@@ -135,11 +135,8 @@ function(combine_static_lib new_target target)
       COMMAND libtool -static -o lib${new_target}.a ${all_libs})
     add_custom_target(${new_target}_genfile ALL
       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lib${new_target}.a)
-
   else()
 
-    set(all_libs "")
-    get_transitive_libs(${target} all_libs)
     string(REPLACE ";" "\\\\naddlib " all_libs_string "${all_libs}")
 
     set(ar_script

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -132,8 +132,6 @@ function(combine_static_lib new_target target)
     add_custom_command(OUTPUT lib${new_target}.a
       DEPENDS ${all_libs}
       COMMAND libtool -static -o lib${new_target}.a ${all_libs})
-    add_custom_target(${new_target}_genfile ALL
-      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lib${new_target}.a)
   else()
     string(REPLACE ";" "\\\\naddlib " all_libs_string "${all_libs}")
 
@@ -143,9 +141,9 @@ function(combine_static_lib new_target target)
     add_custom_command(OUTPUT lib${new_target}.a
       DEPENDS ${all_libs}
       COMMAND ${ECHO_EXE} -e ${ar_script} | ${CMAKE_AR} -M)
-    add_custom_target(${new_target}_genfile ALL
-      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lib${new_target}.a)
   endif()
+  add_custom_target(${new_target}_genfile ALL
+      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lib${new_target}.a)
 
   # CMake needs to be able to see this as another normal library,
   # so import the newly created library as an imported library,


### PR DESCRIPTION
Replace "ar -M" on mac to be able to merge static libraries.
It now use "libtool" which is also available on linux, maybe we could remove the if later once the libtool method is tested on linux, in the meantime I left the linux code untouched.