### PR TITLE
Skip scanning Python files for nose tests in glslc test framework.

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -40,15 +40,15 @@ function(add_asciidoc TARGET FILE)
   endif(ASCIIDOCTOR_EXE)
 endfunction()
 
-# Run nosetests in the current directory. Nosetests will look for python files
-# with "nosetest" in their name, as well as descending into directories with
-# "nosetest" in their name. The test name will be ${PREFIX}_nosetests.
+# Run nosetests on file ${PREFIX}_nosetest.py. Nosetests will look for classes
+# and functions whose names start with "nosetest". The test name will be
+# ${PREFIX}_nosetests.
 function(add_nosetests PREFIX)
   if(NOSETESTS_EXE)
     add_test(
       NAME ${PREFIX}_nosetests
-      COMMAND ${NOSETESTS_EXE}
-        -m "(?:^|[b_./-])[Nn]ose[Tt]est" -v ${CMAKE_CURRENT_SOURCE_DIR})
+      COMMAND ${NOSETESTS_EXE} -m "^[Nn]ose[Tt]est" -v
+        ${CMAKE_CURRENT_SOURCE_DIR}/${PREFIX}_nosetest.py)
   endif()
 endfunction()
 

--- a/glslc/test/CMakeLists.txt
+++ b/glslc/test/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_nosetests(expect)
 add_nosetests(glslc_test_framework)
 
 add_test(NAME glslc_tests

--- a/glslc/test/glslc_test_framework.py
+++ b/glslc/test/glslc_test_framework.py
@@ -321,6 +321,10 @@ def main():
         manager.leave_output = True
     for root, _, filenames in os.walk(root_dir):
         for filename in fnmatch.filter(filenames, '*.py'):
+            if filename.endswith('nosetest.py'):
+                # Skip nose tests, which are for testing functions of
+                # the test framework.
+                continue
             sys.path = default_path
             sys.path.append(root)
             mod = __import__(os.path.splitext(filename)[0])


### PR DESCRIPTION
Those files contain tests for the test framework; they should be
added separately.