### PR TITLE
Add shaderc_compile_options_set_message_rules API

### DIFF
--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -21,6 +21,7 @@ extern "C" {
 
 #include <stddef.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef enum {
   shaderc_glsl_vertex_shader,
@@ -30,6 +31,13 @@ typedef enum {
   shaderc_glsl_tess_control_shader,
   shaderc_glsl_tess_evaluation_shader
 } shaderc_shader_kind;
+
+typedef enum {
+  shaderc_target_env_vulkan,      // create SPIR-V under Vulkan semantics
+  shaderc_target_env_glsl,        // create SPIR-V under OpenGL semantics
+  shaderc_target_env_glsl_compat, // create SPIR-V under OpenGL semantics, including compatibility profile functions
+  shaderc_target_env_default = shaderc_target_env_vulkan
+} shaderc_target_env;
 
 // Usage examples:
 //
@@ -104,6 +112,12 @@ void shaderc_compile_options_release(shaderc_compile_options_t options);
 // deleted after this function has returned.
 void shaderc_compile_options_add_macro_definition(
     shaderc_compile_options_t options, const char* name, const char* value);
+
+// Set the target shader environment, affecting which warnings or errors will be issued.
+// The version will be for distinguishing between different versions of the target environment.
+// "0" is the only supported version at this point
+void shaderc_compile_options_set_target_env(
+    shaderc_compile_options_t options, shaderc_target_env target, uint32_t version);
 
 // An opaque handle to the results of a call to shaderc_compile_into_spv().
 typedef struct shaderc_spv_module* shaderc_spv_module_t;

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -33,9 +33,9 @@ typedef enum {
 } shaderc_shader_kind;
 
 typedef enum {
-  shaderc_target_env_vulkan,      // create SPIR-V under Vulkan semantics
-  shaderc_target_env_glsl,        // create SPIR-V under OpenGL semantics
-  shaderc_target_env_glsl_compat, // create SPIR-V under OpenGL semantics, including compatibility profile functions
+  shaderc_target_env_vulkan,        // create SPIR-V under Vulkan semantics
+  shaderc_target_env_opengl,        // create SPIR-V under OpenGL semantics
+  shaderc_target_env_opengl_compat, // create SPIR-V under OpenGL semantics, including compatibility profile functions
   shaderc_target_env_default = shaderc_target_env_vulkan
 } shaderc_target_env;
 

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -104,6 +104,13 @@ class CompileOptions {
     AddMacroDefinition(name.c_str(), value.c_str());
   }
 
+  // Set the target shader environment, affecting which warnings or errors will be issued.
+  // The version will be for distinguishing between different versions of the target environment.
+  // "0" is the only supported version at this point
+  void SetTargetEnvironment(shaderc_target_env target, uint32_t version) {
+    shaderc_compile_options_set_target_env(options_, target, version);
+  }
+
  private:
   CompileOptions& operator=(const CompileOptions& other) = delete;
   shaderc_compile_options_t options_;

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -61,9 +61,9 @@ EShMessages GetMessageRules(shaderc_target_env target) {
   EShMessages msgs = EShMsgDefault;
 
   switch(target) {
-    case shaderc_target_env_glsl_compat:
+    case shaderc_target_env_opengl_compat:
       break;
-    case shaderc_target_env_glsl:
+    case shaderc_target_env_opengl:
       msgs = EShMsgSpvRules;
       break;
     case shaderc_target_env_vulkan:

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -56,6 +56,24 @@ EShLanguage GetStage(shaderc_shader_kind kind) {
   return EShLangVertex;
 }
 
+// Converts shaderc_target_env to EShMessages
+EShMessages GetMessageRules(shaderc_target_env target) {
+  EShMessages msgs = EShMsgDefault;
+
+  switch(target) {
+    case shaderc_target_env_glsl_compat:
+      break;
+    case shaderc_target_env_glsl:
+      msgs = EShMsgSpvRules;
+      break;
+    case shaderc_target_env_vulkan:
+      msgs = static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules);
+      break;
+  }
+
+  return msgs;
+}
+
 struct {
   // The number of currently initialized compilers.
   int compiler_initialization_count;
@@ -103,6 +121,13 @@ void shaderc_compile_options_release(shaderc_compile_options_t options) {
 void shaderc_compile_options_add_macro_definition(
     shaderc_compile_options_t options, const char* name, const char* value) {
   options->compiler.AddMacroDefinition(name, value);
+}
+
+void shaderc_compile_options_set_target_env(
+    shaderc_compile_options_t options, shaderc_target_env target, uint32_t version) {
+  // "version" reserved for future use, intended to distinguish between different
+  // versions of a target environment
+  options->compiler.SetMessageRules(GetMessageRules(target));
 }
 
 shaderc_compiler_t shaderc_compiler_initialize() {

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -253,8 +253,8 @@ TEST(CppInterface, TargetEnvCompileOptions) {
   shaderc::Compiler compiler;
   shaderc::CompileOptions options;
 
-  // Test shader compilation which requires glsl compatibility environment
-  options.SetTargetEnvironment(shaderc_target_env_glsl_compat, 0);
+  // Test shader compilation which requires opengl compatibility environment
+  options.SetTargetEnvironment(shaderc_target_env_opengl_compat, 0);
   const std::string kGlslShader =
     R"(#version 100
        uniform highp sampler2D tex;

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -249,4 +249,24 @@ TEST(CppInterface, MacroCompileOptions) {
                   .GetSuccess());
 }
 
+TEST(CppInterface, TargetEnvCompileOptions) {
+  shaderc::Compiler compiler;
+  shaderc::CompileOptions options;
+
+  // Test shader compilation which requires glsl compatibility environment
+  options.SetTargetEnvironment(shaderc_target_env_glsl_compat, 0);
+  const std::string kGlslShader =
+    R"(#version 100
+       uniform highp sampler2D tex;
+       void main() {
+         gl_FragColor = texture2D(tex, vec2(0.0,0.0));
+       }
+  )";
+
+  EXPECT_TRUE(compiler.CompileGlslToSpv(kGlslShader,
+                                        shaderc_glsl_fragment_shader,
+                                        options)
+                  .GetSuccess());
+}
+
 }  // anonymous namespace

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -232,6 +232,36 @@ TEST(CompileStringWithOptions, IfDefCompileOption) {
                                  shaderc_glsl_vertex_shader, options.get()));
 }
 
+TEST(CompileStringWithOptions, TargetEnv) {
+  Compiler compiler;
+  compile_options_ptr options(shaderc_compile_options_initialize());
+  ASSERT_NE(nullptr, compiler.get_compiler_handle());
+
+  // Confirm that this shader compiles with shaderc_target_env_glsl_compat;
+  // if targeting Vulkan, glslang will fail to compile it
+  const std::string kGlslShader =
+    R"(#version 100
+       uniform highp sampler2D tex;
+       void main() {
+         gl_FragColor = texture2D(tex, vec2(0.0,0.0));
+       }
+  )";
+
+  EXPECT_FALSE(CompilesToValidSpv(compiler.get_compiler_handle(),
+                                  kGlslShader,
+                                  shaderc_glsl_fragment_shader, options.get()));
+
+  shaderc_compile_options_set_target_env(options.get(), shaderc_target_env_glsl_compat, 0);
+  EXPECT_TRUE(CompilesToValidSpv(compiler.get_compiler_handle(),
+                                 kGlslShader,
+                                 shaderc_glsl_fragment_shader, options.get()));
+
+  shaderc_compile_options_set_target_env(options.get(), shaderc_target_env_vulkan, 0);
+  EXPECT_FALSE(CompilesToValidSpv(compiler.get_compiler_handle(),
+                                  kGlslShader,
+                                  shaderc_glsl_fragment_shader, options.get()));
+}
+
 TEST(CompileString, ShaderKindRespected) {
   Compiler compiler;
   ASSERT_NE(nullptr, compiler.get_compiler_handle());

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -237,7 +237,7 @@ TEST(CompileStringWithOptions, TargetEnv) {
   compile_options_ptr options(shaderc_compile_options_initialize());
   ASSERT_NE(nullptr, compiler.get_compiler_handle());
 
-  // Confirm that this shader compiles with shaderc_target_env_glsl_compat;
+  // Confirm that this shader compiles with shaderc_target_env_opengl_compat;
   // if targeting Vulkan, glslang will fail to compile it
   const std::string kGlslShader =
     R"(#version 100
@@ -251,7 +251,7 @@ TEST(CompileStringWithOptions, TargetEnv) {
                                   kGlslShader,
                                   shaderc_glsl_fragment_shader, options.get()));
 
-  shaderc_compile_options_set_target_env(options.get(), shaderc_target_env_glsl_compat, 0);
+  shaderc_compile_options_set_target_env(options.get(), shaderc_target_env_opengl_compat, 0);
   EXPECT_TRUE(CompilesToValidSpv(compiler.get_compiler_handle(),
                                  kGlslShader,
                                  shaderc_glsl_fragment_shader, options.get()));

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -206,7 +206,9 @@ class Compiler {
   // output.
   bool generate_debug_info_;
 
-  // Set of rules used to generate compiler warnings/errors
+  // Sets the glslang EshMessages bitmask for determining which dialect of GLSL
+  // and which SPIR-V codegen semantics are used. This impacts the warning & error
+  // messages as well as the set of available builtins
   EShMessages message_rules_;
 };
 

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -55,7 +55,8 @@ class Compiler {
         disassemble_(false),
         warnings_as_errors_(false),
         suppress_warnings_(false),
-        generate_debug_info_(false) {}
+        generate_debug_info_(false),
+        message_rules_(static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules)) {}
 
   // Instead of outputting object files, output the disassembled textual output.
   virtual void SetDisassemblyMode();
@@ -77,6 +78,9 @@ class Compiler {
   // calls.
   void AddMacroDefinition(const string_piece& macro,
                           const string_piece& definition);
+
+  // Sets message rules to be used when generating compiler warnings/errors
+  void SetMessageRules(EShMessages rules);
 
   // Forces (without any verification) the default version and profile for
   // subsequent CompileShader() calls.
@@ -201,6 +205,9 @@ class Compiler {
   // When true, compilation will generate debug info with the binary SPIR-V
   // output.
   bool generate_debug_info_;
+
+  // Set of rules used to generate compiler warnings/errors
+  EShMessages message_rules_;
 };
 
 }  // namespace shaderc_util

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -149,7 +149,7 @@ bool Compiler::Compile(
       shader.parse(&shaderc_util::kDefaultTBuiltInResource, default_version_,
                    default_profile_, force_version_profile_,
                    kNotForwardCompatible,
-                   static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules),
+                   message_rules_,
                    includer);
 
   success &= PrintFilteredErrors(error_tag, error_stream, warnings_as_errors_,
@@ -184,6 +184,10 @@ bool Compiler::Compile(
 void Compiler::AddMacroDefinition(const string_piece& macro,
                                   const string_piece& definition) {
   predefined_macros_[macro] = definition;
+}
+
+void Compiler::SetMessageRules(EShMessages rules) {
+  message_rules_ = rules;
 }
 
 void Compiler::SetForcedVersionProfile(int version, EProfile profile) {


### PR DESCRIPTION
This provides an API for specifying which set of rules should be used for warning/error generation. The default remains spirv/vulkan, but this allows using more relaxed rules for legacy or non-Vulkan shaders.

This was previously possible until commit 68b4a047 when the default rules used by shaderc were changed.