### PR TITLE
Add set_preprocessing_only_mode() to libshaderc.h API

### DIFF
--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -165,7 +165,7 @@ size_t shaderc_module_get_length(const shaderc_spv_module_t module);
 // Returns a pointer to the start of the SPIR-V bytes, either SPIR-V binary or
 // char string. When the source string is compiled into SPIR-V binary, this is
 // guaranteed to be castable to a uint32_t*. If the source string is compiled in
-// disassembly mode or preprocessing only mode, the pointer will points to the
+// disassembly mode or preprocessing only mode, the pointer will point to the
 // result char string.
 const char* shaderc_module_get_bytes(const shaderc_spv_module_t module);
 

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -115,7 +115,7 @@ void shaderc_compile_options_add_macro_definition(
 
 // Set the compiler to do only preprocessing. The byte array result in the
 // module returned by the compilation is the text of the preprocessed shader.
-// This option override all other compilation modes, such as disassembly mode
+// This option overrides all other compilation modes, such as disassembly mode
 // and the default mode of compilation to SPIR-V binary.
 void shaderc_compile_options_set_preprocessing_only_mode(
     shaderc_compile_options_t options);
@@ -165,8 +165,8 @@ size_t shaderc_module_get_length(const shaderc_spv_module_t module);
 // Returns a pointer to the start of the SPIR-V bytes, either SPIR-V binary or
 // char string. When the source string is compiled into SPIR-V binary, this is
 // guaranteed to be castable to a uint32_t*. If the source string is compiled in
-// disassembly mode or preprocessing only mode, the pointer points to the result
-// char string, and it will not castable to a uint32_t*.
+// disassembly mode or preprocessing only mode, the pointer will points to the
+// result char string.
 const char* shaderc_module_get_bytes(const shaderc_spv_module_t module);
 
 // Returns a null-terminated string that contains any error messages generated

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -123,6 +123,11 @@ void shaderc_compile_options_add_macro_definition(
   options->compiler.AddMacroDefinition(name, value);
 }
 
+void shaderc_compile_options_set_preprocessing_only_mode(
+    shaderc_compile_options_t options) {
+  options->compiler.SetPreprocessingOnlyMode();
+}
+
 void shaderc_compile_options_set_target_env(
     shaderc_compile_options_t options, shaderc_target_env target, uint32_t version) {
   // "version" reserved for future use, intended to distinguish between different

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -216,6 +216,33 @@ TEST(CompileStringWithOptions, MacroCompileOptions) {
       shaderc_glsl_vertex_shader, cloned_options.get()));
 }
 
+TEST(CompileStringWithOptions, PreprocessingOnlyOption) {
+  Compiler compiler;
+  compile_options_ptr options(shaderc_compile_options_initialize());
+  shaderc_compile_options_set_preprocessing_only_mode(options.get());
+  ASSERT_NE(nullptr, compiler.get_compiler_handle());
+  const std::string kMinimalShader =
+      "#define E main\n"
+      "void E(){}\n";
+  Compilation comp(compiler.get_compiler_handle(), kMinimalShader,
+                   shaderc_glsl_vertex_shader, options.get());
+  EXPECT_TRUE(shaderc_module_get_success(comp.result()));
+  EXPECT_THAT(shaderc_module_get_bytes(comp.result()),
+              HasSubstr("void main(){ }"));
+
+  const std::string kMinimalShaderCloneOption =
+      "#define E_CLONE_OPTION main\n"
+      "void E_CLONE_OPTION(){}\n";
+  compile_options_ptr cloned_options(
+      shaderc_compile_options_clone(options.get()));
+  Compilation comp_clone(compiler.get_compiler_handle(),
+                         kMinimalShaderCloneOption, shaderc_glsl_vertex_shader,
+                         cloned_options.get());
+  EXPECT_TRUE(shaderc_module_get_success(comp_clone.result()));
+  EXPECT_THAT(shaderc_module_get_bytes(comp_clone.result()),
+              HasSubstr("void main(){ }"));
+}
+
 TEST(CompileStringWithOptions, IfDefCompileOption) {
   Compiler compiler;
   compile_options_ptr options(shaderc_compile_options_initialize());


### PR DESCRIPTION
Add set_preprocessing_only_mode() to libshaderc C API (shaderc.h, shaderc.cc).

Add test for set_preprocessing_only_mode() in shaderc_test.cc