### PR TITLE
Set debug info

### DIFF
--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -121,6 +121,10 @@ void shaderc_compile_options_release(shaderc_compile_options_t options);
 void shaderc_compile_options_add_macro_definition(
     shaderc_compile_options_t options, const char* name, const char* value);
 
+// Sets the compiler mode to generate debug information in the output.
+void shaderc_compile_options_set_generate_debug_info(
+    shaderc_compile_options_t options);
+
 // Sets the compiler mode to emit a disassembly text instead of a binary. In
 // this mode, the byte array result in the shaderc_spv_module returned
 // from shaderc_compile_into_spv() will consist of SPIR-V assembly text.

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -104,6 +104,11 @@ class CompileOptions {
     AddMacroDefinition(name.c_str(), value.c_str());
   }
 
+  // Sets the compiler mode to generate debug information in the output.
+  void SetGenerateDebugInfo(){
+    shaderc_compile_options_set_generate_debug_info(options_);
+  }
+
   // Sets the compiler to emit a disassembly text instead of a binary. In
   // this mode, the byte array result in the shaderc_spv_module returned
   // from shaderc_compile_into_spv() will consist of SPIR-V assembly text.

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -123,6 +123,11 @@ void shaderc_compile_options_add_macro_definition(
   options->compiler.AddMacroDefinition(name, value);
 }
 
+void shaderc_compile_options_set_generate_debug_info(
+    shaderc_compile_options_t options) {
+  options->compiler.SetGenerateDebugInfo();
+}
+
 void shaderc_compile_options_set_disassembly_mode(
     shaderc_compile_options_t options) {
   options->compiler.SetDisassemblyMode();

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -121,6 +121,10 @@ class CppInterface : public testing::Test {
                                 const CompileOptions& options) const {
     const auto module = compiler_.CompileGlslToSpv(shader, kind, options);
     EXPECT_TRUE(module.GetSuccess()) << kind << '\n';
+    // Use string(const char* s, size_t n) constructor instead of
+    // string(const char* s) to make sure the string has complete binary data.
+    // string(const char* s) assumes a null-terminated C-string, which will cut
+    // the binary data when it sees a '\0' byte.
     return std::string(module.GetData(), module.GetLength());
   }
 


### PR DESCRIPTION
Add set_generate_debug_info() to libshaderc api.

Update/add CompilationOutput() to construct output string from 'char*' and 'length',so that we can check the content of the complete output binary array.

Fix some format problems.