### PR TITLE
Add set_forced_version_profile to libshaderc.

### DIFF
--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -127,8 +127,10 @@ void shaderc_compile_options_add_macro_definition(
 void shaderc_compile_options_set_disassembly_mode(
     shaderc_compile_options_t options);
 
-// Sets the compiler mode to force (without any verification) the default
-// version and profile for compilation.
+// Forces the GLSL language version and profile to a given pair. The version
+// number is the same as would appear in the #version annotation in the source.
+// Version and profile specified here overrides the #version annotation in the
+// source.
 void shaderc_compile_options_set_forced_version_profile(
     shaderc_compile_options_t options, int version, shaderc_profile profile);
 

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -40,6 +40,8 @@ typedef enum {
 } shaderc_target_env;
 
 typedef enum {
+  shaderc_profile_none,  // Used if and only if GLSL version did not specify
+                         // profiles.
   shaderc_profile_core,
   shaderc_profile_compatibility,
   shaderc_profile_es,
@@ -130,7 +132,10 @@ void shaderc_compile_options_set_disassembly_mode(
 // Forces the GLSL language version and profile to a given pair. The version
 // number is the same as would appear in the #version annotation in the source.
 // Version and profile specified here overrides the #version annotation in the
-// source.
+// source. Versions before 150 do not allow a profile token, in that case
+// shaderc_profile_none should be passed down as the profile parameter, and
+// shaderc_profile_none should only be used when none profile is specified along
+// with version.
 void shaderc_compile_options_set_forced_version_profile(
     shaderc_compile_options_t options, int version, shaderc_profile profile);
 

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -39,6 +39,12 @@ typedef enum {
   shaderc_target_env_default = shaderc_target_env_vulkan
 } shaderc_target_env;
 
+typedef enum {
+  shaderc_profile_core,
+  shaderc_profile_compatibility,
+  shaderc_profile_es,
+} shaderc_profile;
+
 // Usage examples:
 //
 // Aggressively release compiler resources, but spend time in initialization
@@ -120,6 +126,11 @@ void shaderc_compile_options_add_macro_definition(
 // overrides the default mode generating a SPIR-V binary.
 void shaderc_compile_options_set_disassembly_mode(
     shaderc_compile_options_t options);
+
+// Sets the compiler mode to force (without any verification) the default
+// version and profile for compilation.
+void shaderc_compile_options_set_forced_version_profile(
+    shaderc_compile_options_t options, int version, shaderc_profile profile);
 
 // Sets the compiler mode to do only preprocessing. The byte array result in the
 // module returned by the compilation is the text of the preprocessed shader.

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -132,10 +132,8 @@ void shaderc_compile_options_set_disassembly_mode(
 // Forces the GLSL language version and profile to a given pair. The version
 // number is the same as would appear in the #version annotation in the source.
 // Version and profile specified here overrides the #version annotation in the
-// source. Versions before 150 do not allow a profile token, in that case
-// shaderc_profile_none should be passed down as the profile parameter, and
-// shaderc_profile_none should only be used when none profile is specified along
-// with version.
+// source. Use profile: 'shaderc_profile_none' for GLSL versions that do not
+// define profiles, e.g. versions below 150.
 void shaderc_compile_options_set_forced_version_profile(
     shaderc_compile_options_t options, int version, shaderc_profile profile);
 

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -113,8 +113,10 @@ class CompileOptions {
     shaderc_compile_options_set_disassembly_mode(options_);
   }
 
-  // Sets the compiler mode to force (without any verification) the default
-  // version and profile for compilation.
+  // Forces the GLSL language version and profile to a given pair. The version
+  // number is the same as would appear in the #version annotation in the
+  // source. Version and profile specified here overrides the #version
+  // annotation in the source.
   void SetForcedVersionProfile(int version, shaderc_profile profile) {
     shaderc_compile_options_set_forced_version_profile(options_, version,
                                                        profile);

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -113,6 +113,13 @@ class CompileOptions {
     shaderc_compile_options_set_disassembly_mode(options_);
   }
 
+  // Sets the compiler mode to force (without any verification) the default
+  // version and profile for compilation.
+  void SetForcedVersionProfile(int version, shaderc_profile profile) {
+    shaderc_compile_options_set_forced_version_profile(options_, version,
+                                                       profile);
+  }
+
   // Sets the compiler to do only preprocessing. The byte array result in the
   // module returned by the compilation is the text of the preprocessed shader.
   // This option overrides all other compilation modes, such as disassembly mode

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -116,7 +116,10 @@ class CompileOptions {
   // Forces the GLSL language version and profile to a given pair. The version
   // number is the same as would appear in the #version annotation in the
   // source. Version and profile specified here overrides the #version
-  // annotation in the source.
+  // annotation in the source. Versions before 150 do not allow a profile token,
+  // in that case shaderc_profile_none should be passed down as the profile
+  // parameter, and shaderc_profile_none should only be used when none profile
+  // is specified along with version.
   void SetForcedVersionProfile(int version, shaderc_profile profile) {
     shaderc_compile_options_set_forced_version_profile(options_, version,
                                                        profile);

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -116,10 +116,8 @@ class CompileOptions {
   // Forces the GLSL language version and profile to a given pair. The version
   // number is the same as would appear in the #version annotation in the
   // source. Version and profile specified here overrides the #version
-  // annotation in the source. Versions before 150 do not allow a profile token,
-  // in that case shaderc_profile_none should be passed down as the profile
-  // parameter, and shaderc_profile_none should only be used when none profile
-  // is specified along with version.
+  // annotation in the source. Use profile: 'shaderc_profile_none' for GLSL
+  // versions that do not define profiles, e.g. versions below 150.
   void SetForcedVersionProfile(int version, shaderc_profile profile) {
     shaderc_compile_options_set_forced_version_profile(options_, version,
                                                        profile);

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -128,6 +128,24 @@ void shaderc_compile_options_set_disassembly_mode(
   options->compiler.SetDisassemblyMode();
 }
 
+void shaderc_compile_options_set_forced_version_profile(
+    shaderc_compile_options_t options, int version, shaderc_profile profile) {
+  // Transfer the profile parameter from public enum type to glslang internal
+  // enum type. No default case here so that compiler will complain if new enum
+  // member is added later but not handled here.
+  switch(profile){
+    case shaderc_profile_core:
+      options->compiler.SetForcedVersionProfile(version, ECoreProfile);
+      break;
+    case shaderc_profile_compatibility:
+      options->compiler.SetForcedVersionProfile(version, ECompatibilityProfile);
+      break;
+    case shaderc_profile_es:
+      options->compiler.SetForcedVersionProfile(version, EEsProfile);
+      break;
+  }
+}
+
 void shaderc_compile_options_set_preprocessing_only_mode(
     shaderc_compile_options_t options) {
   options->compiler.SetPreprocessingOnlyMode();

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -134,6 +134,9 @@ void shaderc_compile_options_set_forced_version_profile(
   // enum type. No default case here so that compiler will complain if new enum
   // member is added later but not handled here.
   switch(profile){
+    case shaderc_profile_none:
+      options->compiler.SetForcedVersionProfile(version, ENoProfile);
+      break;
     case shaderc_profile_core:
       options->compiler.SetForcedVersionProfile(version, ECoreProfile);
       break;

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -313,8 +313,9 @@ TEST_F(CppInterface, ForcedVersionProfileCorrectStdClonedOptions) {
                                  shaderc_glsl_vertex_shader, cloned_options));
 }
 
-TEST_F(CppInterface, ForcedVersionProfileWrongStd) {
-  // Forces the version and profile to 310es, which is a wrong pair.
+TEST_F(CppInterface, ForcedVersionProfileInvalidModule) {
+  // Forces the version and profile to 310es, while the source module is invalid
+  // for this version of GLSL. Compilation should fail.
   options_.SetForcedVersionProfile(310, shaderc_profile_es);
   EXPECT_THAT(CompilationErrors(kCoreVertShaderWithoutVersion,
                                 shaderc_glsl_vertex_shader, options_),
@@ -340,6 +341,14 @@ TEST_F(CppInterface, ForcedVersionProfileUnknownVersionStd) {
   EXPECT_THAT(
       CompilationWarnings(kMinimalShader, shaderc_glsl_vertex_shader, options_),
       HasSubstr("warning: version 4242 is unknown.\n"));
+}
+
+TEST_F(CppInterface, ForcedVersionProfileVersionsBefore150) {
+  // Versions before 150 do not allow a profile token, shaderc_profile_none
+  // should be passed down as the profile parameter.
+  options_.SetForcedVersionProfile(100, shaderc_profile_none);
+  EXPECT_TRUE(
+      CompilationSuccess(kMinimalShader, shaderc_glsl_vertex_shader, options_));
 }
 
 TEST_F(CppInterface, ForcedVersionProfileRedundantProfileStd) {

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -310,7 +310,7 @@ TEST_F(CppInterface, ForcedVersionProfileCorrectStdClonedOptions) {
   options_.SetForcedVersionProfile(450, shaderc_profile_core);
   CompileOptions cloned_options(options_);
   EXPECT_TRUE(CompilesToValidSpv(kCoreVertShaderWithoutVersion,
-                                 shaderc_glsl_vertex_shader, options_));
+                                 shaderc_glsl_vertex_shader, cloned_options));
 }
 
 TEST_F(CppInterface, ForcedVersionProfileWrongStd) {

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -45,6 +45,12 @@ const std::string kMinimalUnknownVersionShader =
     "#version 550\n"
     "void main() {}\n";
 
+// gl_ClipDistance doesn't exist in es profile (at least until 3.10).
+const std::string kCoreVertShaderWithoutVersion =
+    "void main() {\n"
+    "gl_ClipDistance[0] = 5.;\n"
+    "}\n";
+
 class CppInterface : public testing::Test {
  protected:
   // Compiles a shader and returns true on success, false on failure.
@@ -288,6 +294,62 @@ TEST_F(CppInterface, DisassemblyOption) {
   EXPECT_THAT(result_from_cloned_options.GetData(),
               HasSubstr("Capability Shader"));
   EXPECT_THAT(result_from_cloned_options.GetData(), HasSubstr("MemoryModel"));
+}
+
+TEST_F(CppInterface, ForcedVersionProfileCorrectStd) {
+  // Forces the version and profile to 450core, which fixes the missing
+  // #version.
+  options_.SetForcedVersionProfile(450, shaderc_profile_core);
+  EXPECT_TRUE(CompilesToValidSpv(kCoreVertShaderWithoutVersion,
+                                 shaderc_glsl_vertex_shader, options_));
+}
+
+TEST_F(CppInterface, ForcedVersionProfileCorrectStdClonedOptions) {
+  // Forces the version and profile to 450core, which fixes the missing
+  // #version.
+  options_.SetForcedVersionProfile(450, shaderc_profile_core);
+  CompileOptions cloned_options(options_);
+  EXPECT_TRUE(CompilesToValidSpv(kCoreVertShaderWithoutVersion,
+                                 shaderc_glsl_vertex_shader, options_));
+}
+
+TEST_F(CppInterface, ForcedVersionProfileWrongStd) {
+  // Forces the version and profile to 310es, which is a wrong pair.
+  options_.SetForcedVersionProfile(310, shaderc_profile_es);
+  EXPECT_THAT(CompilationErrors(kCoreVertShaderWithoutVersion,
+                                shaderc_glsl_vertex_shader, options_),
+              HasSubstr("error: 'gl_ClipDistance' : undeclared identifier\n"));
+}
+
+TEST_F(CppInterface, ForcedVersionProfileConflictingStd) {
+  // Forces the version and profile to 450core, which is in conflict with the
+  // #version in shader.
+  const std::string kVertexShader =
+      std::string("#version 310 es\n") + kCoreVertShaderWithoutVersion;
+  options_.SetForcedVersionProfile(450, shaderc_profile_core);
+  EXPECT_THAT(
+      CompilationWarnings(kVertexShader, shaderc_glsl_vertex_shader, options_),
+      HasSubstr("warning: (version, profile) forced to be (450, core), "
+                "while in source code it is (310, es)\n"));
+}
+
+TEST_F(CppInterface, ForcedVersionProfileUnknownVersionStd) {
+  // Forces the version and profile to 4242core, which is an unknown version.
+  options_.SetForcedVersionProfile(4242 /*unknown version*/,
+                                   shaderc_profile_core);
+  EXPECT_THAT(
+      CompilationWarnings(kMinimalShader, shaderc_glsl_vertex_shader, options_),
+      HasSubstr("warning: version 4242 is unknown.\n"));
+}
+
+TEST_F(CppInterface, ForcedVersionProfileRedundantProfileStd) {
+  // Forces the version and profile to 100core. But versions before 150 do not
+  // allow a profile token, compilation should fail.
+  options_.SetForcedVersionProfile(100, shaderc_profile_core);
+  EXPECT_THAT(
+      CompilationErrors(kMinimalShader, shaderc_glsl_vertex_shader, options_),
+      HasSubstr("error: #version: versions before 150 do not allow a profile "
+                "token\n"));
 }
 
 TEST_F(CppInterface, PreprocessingOnlyOption) {

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -314,8 +314,9 @@ TEST_F(CompileStringWithOptionsTest,
                                  cloned_options.get()));
 }
 
-TEST_F(CompileStringWithOptionsTest, ForcedVersionProfileWrongStd) {
-  // Forces the version and profile to 310es, which is a wrong pair.
+TEST_F(CompileStringWithOptionsTest, ForcedVersionProfileInvalidModule) {
+  // Forces the version and profile to 310es, while the source module is invalid
+  // for this version of GLSL. Compilation should fail.
   shaderc_compile_options_set_forced_version_profile(options_.get(), 310,
                                                      shaderc_profile_es);
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
@@ -347,6 +348,15 @@ TEST_F(CompileStringWithOptionsTest, ForcedVersionProfileUnknownVersionStd) {
   EXPECT_THAT(CompilationWarnings(kMinimalShader, shaderc_glsl_vertex_shader,
                                   options_.get()),
               HasSubstr("warning: version 4242 is unknown.\n"));
+}
+
+TEST_F(CompileStringWithOptionsTest, ForcedVersionProfileVersionsBefore150) {
+  // Versions before 150 do not allow a profile token, shaderc_profile_none
+  // should be passed down as the profile parameter.
+  shaderc_compile_options_set_forced_version_profile(options_.get(), 100,
+                                                     shaderc_profile_none);
+  ASSERT_NE(nullptr, compiler_.get_compiler_handle());
+  EXPECT_TRUE(CompilationSuccess(kMinimalShader, shaderc_glsl_vertex_shader, options_.get()));
 }
 
 TEST_F(CompileStringWithOptionsTest, ForcedVersionProfileRedundantProfileStd) {


### PR DESCRIPTION
This code doesn't parse the version-profile pair from string, it only pass the int/enum value down to libshaderc_util. The parsing should be done before calling SetForcedVersionProfile().