### PR TITLE
Fix mismatch of builtins in preprocess vs. compile

### DIFF
--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -71,7 +71,7 @@ const char kTwoWarningsShader[] =
 
 // A shader that compiles under OpenGL compatibility profile rules,
 // but not OpenGL core profile rules.
-const char kOpenGLCompatibilityShader[] =
+const char kOpenGLCompatibilityFragmentShader[] =
     R"(#version 100
      uniform highp sampler2D tex;
      void main() {
@@ -741,28 +741,28 @@ TEST_F(CompileStringWithOptionsTest, IfDefCompileOption) {
 
 TEST_F(CompileStringWithOptionsTest,
        TargetEnvRespectedWhenCompilingOpenGLCompatibilityShaderToBinary) {
-  // Confirm that kOpenGLCompatibilityShader compiles with
+  // Confirm that kOpenGLCompatibilityFragmentShader compiles with
   // shaderc_target_env_opengl_compat.  When targeting OpenGL core profile
   // or Vulkan, it should fail to compile.
 
-  EXPECT_FALSE(CompilesToValidSpv(kOpenGLCompatibilityShader,
+  EXPECT_FALSE(CompilesToValidSpv(kOpenGLCompatibilityFragmentShader,
                                   shaderc_glsl_fragment_shader,
                                   options_.get()));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_opengl_compat, 0);
-  EXPECT_TRUE(CompilesToValidSpv(kOpenGLCompatibilityShader,
+  EXPECT_TRUE(CompilesToValidSpv(kOpenGLCompatibilityFragmentShader,
                                  shaderc_glsl_fragment_shader, options_.get()));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_opengl, 0);
-  EXPECT_FALSE(CompilesToValidSpv(kOpenGLCompatibilityShader,
+  EXPECT_FALSE(CompilesToValidSpv(kOpenGLCompatibilityFragmentShader,
                                   shaderc_glsl_fragment_shader,
                                   options_.get()));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_vulkan, 0);
-  EXPECT_FALSE(CompilesToValidSpv(kOpenGLCompatibilityShader,
+  EXPECT_FALSE(CompilesToValidSpv(kOpenGLCompatibilityFragmentShader,
                                   shaderc_glsl_fragment_shader,
                                   options_.get()));
 }
@@ -788,22 +788,22 @@ TEST_F(CompileStringWithOptionsTest,
 TEST_F(CompileStringWithOptionsTest, TargetEnvIgnoredWhenPreprocessing) {
   shaderc_compile_options_set_preprocessing_only_mode(options_.get());
 
-  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityShader,
+  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityFragmentShader,
                                  shaderc_glsl_fragment_shader, options_.get()));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_opengl_compat, 0);
-  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityShader,
+  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityFragmentShader,
                                  shaderc_glsl_fragment_shader, options_.get()));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_opengl, 0);
-  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityShader,
+  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityFragmentShader,
                                  shaderc_glsl_fragment_shader, options_.get()));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_vulkan, 0);
-  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityShader,
+  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityFragmentShader,
                                  shaderc_glsl_fragment_shader, options_.get()));
 }
 

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -69,6 +69,20 @@ const char kTwoWarningsShader[] =
     "attribute float y;\n"
     "void main(){}\n";
 
+// A shader that compiles under OpenGL compatibility profile rules,
+// but not OpenGL core profile rules.
+const char kOpenGLCompatibilityShader[] =
+    R"(#version 100
+     uniform highp sampler2D tex;
+     void main() {
+       gl_FragColor = texture2D(tex, vec2(0.0,0.0));
+     })";
+
+// A shader that compiles under OpenGL core profile rules.
+const char kOpenGLVertexShader[] =
+    R"(#version 150
+       void main() { int t = gl_VertexID; })";
+
 TEST(Init, MultipleCalls) {
   shaderc_compiler_t compiler1, compiler2, compiler3;
   EXPECT_NE(nullptr, compiler1 = shaderc_compiler_initialize());
@@ -725,30 +739,72 @@ TEST_F(CompileStringWithOptionsTest, IfDefCompileOption) {
                                  shaderc_glsl_vertex_shader, options_.get()));
 }
 
-TEST_F(CompileStringWithOptionsTest, TargetEnv) {
-  ASSERT_NE(nullptr, compiler_.get_compiler_handle());
-  // Confirm that this shader compiles with shaderc_target_env_opengl_compat;
-  // if targeting Vulkan, glslang will fail to compile it
-  const std::string kGlslShader =
-      R"(#version 100
-       uniform highp sampler2D tex;
-       void main() {
-         gl_FragColor = texture2D(tex, vec2(0.0,0.0));
-       }
-  )";
+TEST_F(CompileStringWithOptionsTest,
+       TargetEnvRespectedWhenCompilingOpenGLCompatibilityShaderToBinary) {
+  // Confirm that kOpenGLCompatibilityShader compiles with
+  // shaderc_target_env_opengl_compat.  When targeting OpenGL core profile
+  // or Vulkan, it should fail to compile.
 
-  EXPECT_FALSE(CompilesToValidSpv(kGlslShader, shaderc_glsl_fragment_shader,
+  EXPECT_FALSE(CompilesToValidSpv(kOpenGLCompatibilityShader,
+                                  shaderc_glsl_fragment_shader,
                                   options_.get()));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_opengl_compat, 0);
-  EXPECT_TRUE(CompilesToValidSpv(kGlslShader, shaderc_glsl_fragment_shader,
-                                 options_.get()));
+  EXPECT_TRUE(CompilesToValidSpv(kOpenGLCompatibilityShader,
+                                 shaderc_glsl_fragment_shader, options_.get()));
+
+  shaderc_compile_options_set_target_env(options_.get(),
+                                         shaderc_target_env_opengl, 0);
+  EXPECT_FALSE(CompilesToValidSpv(kOpenGLCompatibilityShader,
+                                  shaderc_glsl_fragment_shader,
+                                  options_.get()));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_vulkan, 0);
-  EXPECT_FALSE(CompilesToValidSpv(kGlslShader, shaderc_glsl_fragment_shader,
+  EXPECT_FALSE(CompilesToValidSpv(kOpenGLCompatibilityShader,
+                                  shaderc_glsl_fragment_shader,
                                   options_.get()));
+}
+
+TEST_F(CompileStringWithOptionsTest,
+       TargetEnvRespectedWhenCompilingOpenGLCoreShaderToBinary) {
+  // Confirm that kOpenGLVertexShader compiles when targeting OpenGL
+  // compatibility or core profiles.
+
+  shaderc_compile_options_set_target_env(options_.get(),
+                                         shaderc_target_env_opengl_compat, 0);
+  EXPECT_TRUE(CompilesToValidSpv(kOpenGLVertexShader,
+                                 shaderc_glsl_vertex_shader, options_.get()));
+
+  shaderc_compile_options_set_target_env(options_.get(),
+                                         shaderc_target_env_opengl, 0);
+  EXPECT_TRUE(CompilesToValidSpv(kOpenGLVertexShader,
+                                 shaderc_glsl_vertex_shader, options_.get()));
+
+  // TODO(dneto): Check what happens when targeting Vulkan.
+}
+
+TEST_F(CompileStringWithOptionsTest, TargetEnvIgnoredWhenPreprocessing) {
+  shaderc_compile_options_set_preprocessing_only_mode(options_.get());
+
+  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityShader,
+                                 shaderc_glsl_fragment_shader, options_.get()));
+
+  shaderc_compile_options_set_target_env(options_.get(),
+                                         shaderc_target_env_opengl_compat, 0);
+  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityShader,
+                                 shaderc_glsl_fragment_shader, options_.get()));
+
+  shaderc_compile_options_set_target_env(options_.get(),
+                                         shaderc_target_env_opengl, 0);
+  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityShader,
+                                 shaderc_glsl_fragment_shader, options_.get()));
+
+  shaderc_compile_options_set_target_env(options_.get(),
+                                         shaderc_target_env_vulkan, 0);
+  EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityShader,
+                                 shaderc_glsl_fragment_shader, options_.get()));
 }
 
 TEST_F(CompileStringTest, ShaderKindRespected) {

--- a/libshaderc_util/CMakeLists.txt
+++ b/libshaderc_util/CMakeLists.txt
@@ -23,7 +23,7 @@ default_compile_options(shaderc_util)
 target_include_directories(shaderc_util PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
 find_package(Threads)
 target_link_libraries(shaderc_util PRIVATE
-  glslang OSDependent OGLCompiler glslang ${CMAKE_THREAD_LIBS_INIT})
+  glslang OSDependent OGLCompiler glslang SPIRV ${CMAKE_THREAD_LIBS_INIT})
 
 add_shaderc_tests(
   TEST_PREFIX shaderc_util
@@ -40,7 +40,7 @@ target_include_directories(shaderc_util_counting_includer_test PRIVATE ${glslang
 
 add_shaderc_tests(
   TEST_PREFIX shaderc_util
-  LINK_LIBS shaderc_util glslang OSDependent OGLCompiler glslang SPIRV ${CMAKE_THREAD_LIBS_INIT}
+  LINK_LIBS shaderc_util
   INCLUDE_DIRS ${glslang_SOURCE_DIR}
   TEST_NAMES
     compiler)

--- a/libshaderc_util/CMakeLists.txt
+++ b/libshaderc_util/CMakeLists.txt
@@ -38,6 +38,13 @@ add_shaderc_tests(
 
 target_include_directories(shaderc_util_counting_includer_test PRIVATE ${glslang_SOURCE_DIR})
 
+add_shaderc_tests(
+  TEST_PREFIX shaderc_util
+  LINK_LIBS shaderc_util glslang OSDependent OGLCompiler glslang SPIRV ${CMAKE_THREAD_LIBS_INIT}
+  INCLUDE_DIRS ${glslang_SOURCE_DIR}
+  TEST_NAMES
+    compiler)
+
 # This target copies content of testdata into the build directory.
 add_custom_target(testdata COMMAND
   ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/testdata/copy-to-build.cmake)

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -1,0 +1,189 @@
+// Copyright 2015 The Shaderc Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "libshaderc_util/compiler.h"
+
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#include "death_test.h"
+#include "libshaderc_util/counting_includer.h"
+
+namespace {
+
+using shaderc_util::Compiler;
+
+// These are the flag combinations Glslang uses to set language
+// rules based on the target environment.
+const EShMessages kOpenGLCompatibilityRules = EShMsgDefault;
+const EShMessages kOpenGLRules = EShMsgSpvRules;
+const EShMessages kVulkanRules =
+    static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules);
+
+// A trivial vertex shader
+const char kVertexShader[] =
+    "#version 100\n"
+    "void main() {}";
+
+// A shader that compiles under OpenGL compatibility profile rules,
+// but not OpenGL core profile rules.
+const char kOpenGLCompatibilityFragShader[] =
+    R"(#version 100
+       uniform highp sampler2D tex;
+       void main() {
+         gl_FragColor = texture2D(tex, vec2(0.0,0.0));
+       })";
+
+// A shader that compiles under OpenGL compatibility profile rules,
+// but not OpenGL core profile rules, even when deducing the stage.
+const char kOpenGLCompatibilityFragShaderDeducibleStage[] =
+    R"(#version 100
+       #pragma shader_stage(fragment)
+       uniform highp sampler2D tex;
+       void main() {
+         gl_FragColor = texture2D(tex, vec2(0.0,0.0));
+       })";
+
+// A shader that compiles under OpenGL core profile rules.
+const char kOpenGLVertexShader[] =
+    R"(#version 150
+       void main() { int t = gl_VertexID; })";
+
+// A shader that compiles under OpenGL core profile rules, even when
+// deducing the stage.
+const char kOpenGLVertexShaderDeducibleStage[] =
+    R"(#version 150
+       #pragma shader_stage(vertex)
+       void main() { int t = gl_VertexID; })";
+
+// A CountingIncluder that never returns valid content for a requested
+// file inclusion.
+class DummyCountingIncluder : public shaderc_util::CountingIncluder {
+ private:
+  // Returns a pair of empty strings.
+  virtual std::pair<std::string, std::string> include_delegate(
+      const char*) const override {
+    return std::make_pair(std::string(), std::string());
+  }
+};
+
+// A test fixture for compiling GLSL shaders.
+class CompilerTest : public testing::Test {
+ public:
+  // Returns true if the given compiler successfully compiles the given shader
+  // source for the given shader stage.  No includes are permitted, and shader
+  // stage deduction falls back to an invalid shader stage.
+  bool SimpleCompilationSucceeds(std::string source, EShLanguage stage) {
+    std::function<EShLanguage(std::ostream*, const shaderc_util::string_piece&)>
+        stage_callback = [](std::ostream*, const shaderc_util::string_piece&) {
+          return EShLangCount;
+        };
+    std::stringstream out;
+    std::stringstream errors;
+    size_t total_warnings = 0;
+    size_t total_errors = 0;
+
+    const bool result = compiler_.Compile(
+        source, stage, "shader", stage_callback, DummyCountingIncluder(), &out,
+        &errors, &total_warnings, &total_errors);
+    errors_ = errors.str();
+    return result;
+  }
+
+ protected:
+  Compiler compiler_;
+  // The error string from the most recent compilation.
+  std::string errors_;
+};
+
+TEST_F(CompilerTest, SimpleVertexShaderCompilesSuccessfully) {
+  EXPECT_TRUE(SimpleCompilationSucceeds(kVertexShader, EShLangVertex));
+}
+
+TEST_F(CompilerTest, BadVertexShaderFailsCompilation) {
+  EXPECT_FALSE(SimpleCompilationSucceeds(" bogus ", EShLangVertex));
+}
+
+TEST_F(CompilerTest, RespectTargetEnvOnOpenGLCompatibilityShader) {
+  const EShLanguage stage = EShLangFragment;
+
+  compiler_.SetMessageRules(kOpenGLCompatibilityRules);
+  EXPECT_TRUE(SimpleCompilationSucceeds(kOpenGLCompatibilityFragShader, stage));
+  compiler_.SetMessageRules(kOpenGLRules);
+  EXPECT_FALSE(
+      SimpleCompilationSucceeds(kOpenGLCompatibilityFragShader, stage));
+  compiler_.SetMessageRules(kVulkanRules);
+  EXPECT_FALSE(
+      SimpleCompilationSucceeds(kOpenGLCompatibilityFragShader, stage));
+  // Default compiler.
+  compiler_ = Compiler();
+  EXPECT_FALSE(
+      SimpleCompilationSucceeds(kOpenGLCompatibilityFragShader, stage));
+}
+
+TEST_F(CompilerTest,
+       RespectTargetEnvOnOpenGLCompatibilityShaderWhenDeducingStage) {
+  const EShLanguage stage = EShLangCount;
+
+  compiler_.SetMessageRules(kOpenGLCompatibilityRules);
+  EXPECT_TRUE(SimpleCompilationSucceeds(
+      kOpenGLCompatibilityFragShaderDeducibleStage, stage))
+      << errors_;
+  compiler_.SetMessageRules(kOpenGLRules);
+  EXPECT_FALSE(SimpleCompilationSucceeds(
+      kOpenGLCompatibilityFragShaderDeducibleStage, stage))
+      << errors_;
+  compiler_.SetMessageRules(kVulkanRules);
+  EXPECT_FALSE(SimpleCompilationSucceeds(
+      kOpenGLCompatibilityFragShaderDeducibleStage, stage))
+      << errors_;
+  // Default compiler.
+  compiler_ = Compiler();
+  EXPECT_FALSE(SimpleCompilationSucceeds(
+      kOpenGLCompatibilityFragShaderDeducibleStage, stage))
+      << errors_;
+}
+
+TEST_F(CompilerTest, RespectTargetEnvOnOpenGLShader) {
+  const EShLanguage stage = EShLangVertex;
+
+  compiler_.SetMessageRules(kOpenGLCompatibilityRules);
+  EXPECT_TRUE(SimpleCompilationSucceeds(kOpenGLVertexShader, stage));
+
+  compiler_.SetMessageRules(kOpenGLRules);
+  EXPECT_TRUE(SimpleCompilationSucceeds(kOpenGLVertexShader, stage));
+
+  // TODO(dneto): Check Vulkan rules.
+}
+
+TEST_F(CompilerTest, RespectTargetEnvOnOpenGLShaderWhenDeducingStage) {
+  const EShLanguage stage = EShLangCount;
+
+  compiler_.SetMessageRules(kOpenGLCompatibilityRules);
+  EXPECT_TRUE(
+      SimpleCompilationSucceeds(kOpenGLVertexShaderDeducibleStage, stage));
+
+  compiler_.SetMessageRules(kOpenGLRules);
+  EXPECT_TRUE(
+      SimpleCompilationSucceeds(kOpenGLVertexShaderDeducibleStage, stage));
+
+  // TODO(dneto): Check Vulkan rules.
+}
+
+TEST_F(CompilerTest, DISABLED_RespectTargetEnvOnVulkanShader) {
+  // TODO(dneto): Add test for a shader that should only compile for Vulkan.
+}
+
+}  // anonymous namespace


### PR DESCRIPTION
The fix is to:
 - Reinitialize Glslang for the preprocessing step used to
   deduce the shader stage.
 - When doing that preprocessing, combine the "message rules"
   with the just-preprocess rule.

Test profile-specific shaders vs. specified target environment.