### PR TITLE
Add const char* input_file_name to arg list of 'compile' interface.

### DIFF
--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -19,8 +19,8 @@
 extern "C" {
 #endif
 
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 typedef enum {
@@ -47,9 +47,11 @@ typedef enum {
 } shaderc_shader_kind;
 
 typedef enum {
-  shaderc_target_env_vulkan,        // create SPIR-V under Vulkan semantics
-  shaderc_target_env_opengl,        // create SPIR-V under OpenGL semantics
-  shaderc_target_env_opengl_compat, // create SPIR-V under OpenGL semantics, including compatibility profile functions
+  shaderc_target_env_vulkan,         // create SPIR-V under Vulkan semantics
+  shaderc_target_env_opengl,         // create SPIR-V under OpenGL semantics
+  shaderc_target_env_opengl_compat,  // create SPIR-V under OpenGL semantics,
+                                     // including compatibility profile
+                                     // functions
   shaderc_target_env_default = shaderc_target_env_vulkan
 } shaderc_target_env;
 
@@ -198,12 +200,9 @@ typedef void (*shaderc_includer_response_release_fn)(
 //  go to /path/to/include/b to find the file b.
 //  This needs context info from compiler to client includer, and may needs
 //  interface changes.
-
 void shaderc_compile_options_set_includer_callbacks(
-    shaderc_compile_options_t options,
-    shaderc_includer_response_get_fn getter,
-    shaderc_includer_response_release_fn releasor,
-    void* user_data);
+    shaderc_compile_options_t options, shaderc_includer_response_get_fn getter,
+    shaderc_includer_response_release_fn releasor, void* user_data);
 
 // Sets the compiler mode to do only preprocessing. The byte array result in the
 // module returned by the compilation is the text of the preprocessed shader.
@@ -222,8 +221,9 @@ void shaderc_compile_options_set_suppress_warnings(
 // Sets the target shader environment, affecting which warnings or errors will
 // be issued.  The version will be for distinguishing between different versions
 // of the target environment.  "0" is the only supported version at this point
-void shaderc_compile_options_set_target_env(
-    shaderc_compile_options_t options, shaderc_target_env target, uint32_t version);
+void shaderc_compile_options_set_target_env(shaderc_compile_options_t options,
+                                            shaderc_target_env target,
+                                            uint32_t version);
 
 // Sets the compiler mode to treat all warnings as errors. Note the
 // suppress-warnings mode overrides this option, i.e. if both
@@ -235,14 +235,17 @@ void shaderc_compile_options_set_warnings_as_errors(
 // An opaque handle to the results of a call to shaderc_compile_into_spv().
 typedef struct shaderc_spv_module* shaderc_spv_module_t;
 
-// Takes a GLSL source string and the associated shader kind, compiles it
-// according to the given additional_options. If the shader kind is not set
-// to a specified kind, but shaderc_glslc_infer_from_source, the compiler
-// will try to deduce the shader kind from the source string and a failure
-// in deducing will generate an error. Currently only #pragma annotation is
-// supported. If the shader kind is set to one of the default shader kinds,
-// the compiler will fall back to the default shader kind in case it failed to
-// deduce the shader kind from source string.
+// Takes a GLSL source string and the associated shader kind, input file
+// name, compiles it according to the given additional_options. If the shader
+// kind is not set to a specified kind, but shaderc_glslc_infer_from_source,
+// the compiler will try to deduce the shader kind from the source
+// string and a failure in deducing will generate an error. Currently only
+// #pragma annotation is supported. If the shader kind is set to one of the
+// default shader kinds, the compiler will fall back to the default shader
+// kind in case it failed to deduce the shader kind from source string.
+// The input_file_name is a null-termintated string. It is used as a tag to
+// identify the source string in cases like emitting error messages. It
+// doesn't have to be a 'file name'.
 // By default the source string will be compiled into SPIR-V binary
 // and a shaderc_spv_module will be returned to hold the results of the
 // compilation. When disassembly mode or preprocessing only mode is enabled
@@ -292,7 +295,7 @@ const char* shaderc_module_get_bytes(const shaderc_spv_module_t module);
 const char* shaderc_module_get_error_message(const shaderc_spv_module_t module);
 
 // Provides the version & revision of the SPIR-V which will be produced
-void shaderc_get_spv_version(unsigned int *version, unsigned int *revision);
+void shaderc_get_spv_version(unsigned int* version, unsigned int* revision);
 
 #ifdef __cplusplus
 }

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -256,7 +256,7 @@ typedef struct shaderc_spv_module* shaderc_spv_module_t;
 shaderc_spv_module_t shaderc_compile_into_spv(
     const shaderc_compiler_t compiler, const char* source_text,
     size_t source_text_size, shaderc_shader_kind shader_kind,
-    const char* entry_point_name,
+    const char* input_file_name, const char* entry_point_name,
     const shaderc_compile_options_t additional_options);
 
 // The following functions, operating on shaderc_spv_module_t objects, offer

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -299,7 +299,7 @@ class Compiler {
   }
 
   // Compiles the given source GLSL into a SPIR-V module by invoking
-  // CompileGlslToSpv(const char*, size_t, shaderc_shader_kind);
+  // CompileGlslToSpv(const char*, size_t, shaderc_shader_kind, const char*);
   SpvModule CompileGlslToSpv(const std::string& source_text,
                              shaderc_shader_kind shader_kind,
                              const char* input_file_name) const {
@@ -308,7 +308,8 @@ class Compiler {
   }
 
   // Compiles the given source GLSL into a SPIR-V module by invoking
-  // CompileGlslToSpv(const char*, size_t, shaderc_shader_kind, options);
+  // CompileGlslToSpv(const char*, size_t, shaderc_shader_kind, const char*,
+  // options);
   SpvModule CompileGlslToSpv(const std::string& source_text,
                              shaderc_shader_kind shader_kind,
                              const char* input_file_name,

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -255,9 +255,11 @@ class Compiler {
   // It is valid for the returned SpvModule object to outlive this compiler
   // object.
   SpvModule CompileGlslToSpv(const char* source_text, size_t source_text_size,
-                             shaderc_shader_kind shader_kind) const {
-    shaderc_spv_module_t module = shaderc_compile_into_spv(
-        compiler_, source_text, source_text_size, shader_kind, "main", nullptr);
+                             shaderc_shader_kind shader_kind,
+                             const char* input_file_name) const {
+    shaderc_spv_module_t module =
+        shaderc_compile_into_spv(compiler_, source_text, source_text_size,
+                                 shader_kind, input_file_name, "main", nullptr);
     return SpvModule(module);
   }
 
@@ -281,28 +283,31 @@ class Compiler {
   // binary generated with default options.
   SpvModule CompileGlslToSpv(const char* source_text, size_t source_text_size,
                              shaderc_shader_kind shader_kind,
+                             const char* input_file_name,
                              const CompileOptions& options) const {
-    shaderc_spv_module_t module =
-        shaderc_compile_into_spv(compiler_, source_text, source_text_size,
-                                 shader_kind, "main", options.options_);
+    shaderc_spv_module_t module = shaderc_compile_into_spv(
+        compiler_, source_text, source_text_size, shader_kind, input_file_name,
+        "main", options.options_);
     return SpvModule(module);
   }
 
   // Compiles the given source GLSL into a SPIR-V module by invoking
   // CompileGlslToSpv(const char*, size_t, shaderc_shader_kind);
   SpvModule CompileGlslToSpv(const std::string& source_text,
-                             shaderc_shader_kind shader_kind) const {
-    return CompileGlslToSpv(source_text.data(), source_text.size(),
-                            shader_kind);
+                             shaderc_shader_kind shader_kind,
+                             const char* input_file_name) const {
+    return CompileGlslToSpv(source_text.data(), source_text.size(), shader_kind,
+                            input_file_name);
   }
 
   // Compiles the given source GLSL into a SPIR-V module by invoking
   // CompileGlslToSpv(const char*, size_t, shaderc_shader_kind, options);
   SpvModule CompileGlslToSpv(const std::string& source_text,
                              shaderc_shader_kind shader_kind,
+                             const char* input_file_name,
                              const CompileOptions& options) const {
     return CompileGlslToSpv(source_text.data(), source_text.size(), shader_kind,
-                            options);
+                            input_file_name, options);
   }
 
  private:

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -15,9 +15,9 @@
 #ifndef SHADERC_HPP_
 #define SHADERC_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 #include "shaderc.h"
 
@@ -122,7 +122,7 @@ class CompileOptions {
   }
 
   // Sets the compiler mode to generate debug information in the output.
-  void SetGenerateDebugInfo(){
+  void SetGenerateDebugInfo() {
     shaderc_compile_options_set_generate_debug_info(options_);
   }
 
@@ -145,8 +145,7 @@ class CompileOptions {
 
   class IncluderInterface {
    public:
-    virtual shaderc_includer_response* GetInclude(
-        const char* filename) = 0;
+    virtual shaderc_includer_response* GetInclude(const char* filename) = 0;
     virtual void ReleaseInclude(shaderc_includer_response* data) = 0;
   };
 
@@ -174,7 +173,7 @@ class CompileOptions {
   // from shaderc_compile_into_spv() will consist of SPIR-V assembly text.
   // Note the preprocessing only mode overrides this option, and this option
   // overrides the default mode generating a SPIR-V binary.
-  void SetDisassemblyMode(){
+  void SetDisassemblyMode() {
     shaderc_compile_options_set_disassembly_mode(options_);
   }
 
@@ -204,8 +203,10 @@ class CompileOptions {
     shaderc_compile_options_set_suppress_warnings(options_);
   }
 
-  // Sets the target shader environment, affecting which warnings or errors will be issued.
-  // The version will be for distinguishing between different versions of the target environment.
+  // Sets the target shader environment, affecting which warnings or errors will
+  // be issued.
+  // The version will be for distinguishing between different versions of the
+  // target environment.
   // "0" is the only supported version at this point
   void SetTargetEnvironment(shaderc_target_env target, uint32_t version) {
     shaderc_compile_options_set_target_env(options_, target, version);
@@ -251,6 +252,9 @@ class Compiler {
   // annotation is supported. If the shader kind is set to one of the default
   // shader kinds, the compiler will fall back to the specified default shader
   // kind in case it failed to deduce the shader kind from the source string.
+  // The input_file_name is a null-termintated string. It is used as a tag to
+  // identify the source string in cases like emitting error messages. It
+  // doesn't have to be a 'file name'.
   // The compilation is done with default compile options.
   // It is valid for the returned SpvModule object to outlive this compiler
   // object.
@@ -274,6 +278,9 @@ class Compiler {
   // annotation is supported. If the shader kind is set to one of the default
   // shader kinds, the compiler will fall back to the specified default shader
   // kind in case it failed to deduce the shader kind from the source string.
+  // The input_file_name is a null-termintated string. It is used as a tag to
+  // identify the source string in cases like emitting error messages. It
+  // doesn't have to be a 'file name'.
   // The compilation is passed any options specified in the CompileOptions
   // parameter.
   // It is valid for the returned SpvModule object to outlive this compiler

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -71,7 +71,7 @@ EShLanguage GetForcedStage(shaderc_shader_kind kind) {
 EShMessages GetMessageRules(shaderc_target_env target) {
   EShMessages msgs = EShMsgDefault;
 
-  switch(target) {
+  switch (target) {
     case shaderc_target_env_opengl_compat:
       break;
     case shaderc_target_env_opengl:
@@ -247,7 +247,7 @@ void shaderc_compile_options_set_forced_version_profile(
   // Transfer the profile parameter from public enum type to glslang internal
   // enum type. No default case here so that compiler will complain if new enum
   // member is added later but not handled here.
-  switch(profile){
+  switch (profile) {
     case shaderc_profile_none:
       options->compiler.SetForcedVersionProfile(version, ENoProfile);
       break;
@@ -283,9 +283,11 @@ void shaderc_compile_options_set_suppress_warnings(
   options->compiler.SetSuppressWarnings();
 }
 
-void shaderc_compile_options_set_target_env(
-    shaderc_compile_options_t options, shaderc_target_env target, uint32_t version) {
-  // "version" reserved for future use, intended to distinguish between different
+void shaderc_compile_options_set_target_env(shaderc_compile_options_t options,
+                                            shaderc_target_env target,
+                                            uint32_t version) {
+  // "version" reserved for future use, intended to distinguish between
+  // different
   // versions of a target environment
   options->compiler.SetMessageRules(GetMessageRules(target));
 }
@@ -410,7 +412,7 @@ const char* shaderc_module_get_error_message(
   return module->messages.c_str();
 }
 
-void shaderc_get_spv_version(unsigned int *version, unsigned int *revision) {
-    *version = spv::Version;
-    *revision = spv::Revision;
+void shaderc_get_spv_version(unsigned int* version, unsigned int* revision) {
+  *version = spv::Version;
+  *revision = spv::Revision;
 }

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -54,8 +54,7 @@ bool CompilesToValidSpv(const shaderc::Compiler& compiler,
 bool CompilesToValidSpv(const shaderc::Compiler& compiler,
                         const std::string& shader, shaderc_shader_kind kind,
                         const CompileOptions& options) {
-  return IsValidSpv(
-      compiler.CompileGlslToSpv(shader, kind, "shader", options));
+  return IsValidSpv(compiler.CompileGlslToSpv(shader, kind, "shader", options));
 }
 
 class CppInterface : public testing::Test {
@@ -65,8 +64,7 @@ class CppInterface : public testing::Test {
   bool CompilationSuccess(const std::string& shader,
                           shaderc_shader_kind kind) const {
     return compiler_
-        .CompileGlslToSpv(shader.c_str(), shader.length(), kind,
-                          "shader" /*input_file_name*/)
+        .CompileGlslToSpv(shader.c_str(), shader.length(), kind, "shader")
         .GetSuccess();
   }
 
@@ -76,8 +74,8 @@ class CppInterface : public testing::Test {
   bool CompilationSuccess(const std::string& shader, shaderc_shader_kind kind,
                           const CompileOptions& options) const {
     return compiler_
-        .CompileGlslToSpv(shader.c_str(), shader.length(), kind,
-                          "shader" /*input_file_name*/, options)
+        .CompileGlslToSpv(shader.c_str(), shader.length(), kind, "shader",
+                          options)
         .GetSuccess();
   }
 
@@ -90,8 +88,8 @@ class CppInterface : public testing::Test {
       // be easily confused with a no-options-provided
       // case:
       const CompileOptions& options) {
-    const auto module = compiler_.CompileGlslToSpv(
-        shader, kind, "shader" /*input_file_name*/, options);
+    const auto module =
+        compiler_.CompileGlslToSpv(shader, kind, "shader", options);
     EXPECT_TRUE(module.GetSuccess()) << kind << '\n' << shader;
     return module.GetErrorMessage();
   }
@@ -104,8 +102,8 @@ class CppInterface : public testing::Test {
                                 // be easily confused with a no-options-provided
                                 // case:
                                 const CompileOptions& options) {
-    const auto module = compiler_.CompileGlslToSpv(
-        shader, kind, "shader" /*input_file_name*/, options);
+    const auto module =
+        compiler_.CompileGlslToSpv(shader, kind, "shader", options);
     EXPECT_FALSE(module.GetSuccess()) << kind << '\n' << shader;
     return module.GetErrorMessage();
   }
@@ -116,8 +114,8 @@ class CppInterface : public testing::Test {
   std::string CompilationOutput(const std::string& shader,
                                 shaderc_shader_kind kind,
                                 const CompileOptions& options) const {
-    const auto module = compiler_.CompileGlslToSpv(
-        shader, kind, "shader" /*input_file_name*/, options);
+    const auto module =
+        compiler_.CompileGlslToSpv(shader, kind, "shader", options);
     EXPECT_TRUE(module.GetSuccess()) << kind << '\n';
     // Use string(const char* s, size_t n) constructor instead of
     // string(const char* s) to make sure the string has complete binary data.
@@ -176,7 +174,7 @@ TEST_F(CppInterface, EmptyString) {
 
 TEST_F(CppInterface, ModuleMoves) {
   shaderc::SpvModule result = compiler_.CompileGlslToSpv(
-      kMinimalShader, shaderc_glsl_vertex_shader, "shader" /*input_file_name*/);
+      kMinimalShader, shaderc_glsl_vertex_shader, "shader");
   EXPECT_TRUE(result.GetSuccess());
   shaderc::SpvModule result2(std::move(result));
   EXPECT_FALSE(result.GetSuccess());
@@ -289,9 +287,8 @@ TEST_F(CppInterface, MacroCompileOptions) {
 
 TEST_F(CppInterface, DisassemblyOption) {
   options_.SetDisassemblyMode();
-  shaderc::SpvModule result =
-      compiler_.CompileGlslToSpv(kMinimalShader, shaderc_glsl_vertex_shader,
-                                 "shader" /*input_file_name*/, options_);
+  shaderc::SpvModule result = compiler_.CompileGlslToSpv(
+      kMinimalShader, shaderc_glsl_vertex_shader, "shader", options_);
   EXPECT_TRUE(result.GetSuccess());
   // This should work with both the glslang native disassembly format and the
   // SPIR-V Tools assembly format.
@@ -299,9 +296,8 @@ TEST_F(CppInterface, DisassemblyOption) {
   EXPECT_THAT(result.GetData(), HasSubstr("MemoryModel"));
 
   CompileOptions cloned_options(options_);
-  shaderc::SpvModule result_from_cloned_options =
-      compiler_.CompileGlslToSpv(kMinimalShader, shaderc_glsl_vertex_shader,
-                                 "shader" /*input_file_name*/, cloned_options);
+  shaderc::SpvModule result_from_cloned_options = compiler_.CompileGlslToSpv(
+      kMinimalShader, shaderc_glsl_vertex_shader, "shader", cloned_options);
   EXPECT_TRUE(result_from_cloned_options.GetSuccess());
   // The mode should be carried into any clone of the original option object.
   EXPECT_THAT(result_from_cloned_options.GetData(),
@@ -415,27 +411,27 @@ TEST_F(CppInterface, GenerateDebugInfoDisassemblyClonedOptions) {
 
 TEST_F(CppInterface, GetNumErrors) {
   std::string shader(kTwoErrorsShader);
-  const shaderc::SpvModule module = compiler_.CompileGlslToSpv(
-      kTwoErrorsShader, strlen(kTwoErrorsShader), shaderc_glsl_vertex_shader,
-      "shader" /*input_file_name*/);
+  const shaderc::SpvModule module =
+      compiler_.CompileGlslToSpv(kTwoErrorsShader, strlen(kTwoErrorsShader),
+                                 shaderc_glsl_vertex_shader, "shader");
   EXPECT_FALSE(module.GetSuccess());
   EXPECT_EQ(2u, module.GetNumErrors());
   EXPECT_EQ(0u, module.GetNumWarnings());
 }
 
 TEST_F(CppInterface, GetNumWarnings) {
-  const shaderc::SpvModule module = compiler_.CompileGlslToSpv(
-      kTwoWarningsShader, strlen(kTwoWarningsShader),
-      shaderc_glsl_vertex_shader, "shader" /*input_file_name*/);
+  const shaderc::SpvModule module =
+      compiler_.CompileGlslToSpv(kTwoWarningsShader, strlen(kTwoWarningsShader),
+                                 shaderc_glsl_vertex_shader, "shader");
   EXPECT_TRUE(module.GetSuccess());
   EXPECT_EQ(2u, module.GetNumWarnings());
   EXPECT_EQ(0u, module.GetNumErrors());
 }
 
 TEST_F(CppInterface, ZeroErrorsZeroWarnings) {
-  const shaderc::SpvModule module = compiler_.CompileGlslToSpv(
-      kMinimalShader, strlen(kMinimalShader), shaderc_glsl_vertex_shader,
-      "shader" /*input_file_name*/);
+  const shaderc::SpvModule module =
+      compiler_.CompileGlslToSpv(kMinimalShader, strlen(kMinimalShader),
+                                 shaderc_glsl_vertex_shader, "shader");
   EXPECT_TRUE(module.GetSuccess());
   EXPECT_EQ(0u, module.GetNumErrors());
   EXPECT_EQ(0u, module.GetNumWarnings());
@@ -443,11 +439,11 @@ TEST_F(CppInterface, ZeroErrorsZeroWarnings) {
 
 TEST_F(CppInterface, ErrorTagIsInputFileName) {
   std::string shader(kTwoErrorsShader);
-  const shaderc::SpvModule module = compiler_.CompileGlslToSpv(
-      kTwoErrorsShader, strlen(kTwoErrorsShader), shaderc_glsl_vertex_shader,
-      "SampleInputFile" /*input_file_name*/);
-  // Expects compilation failure with two errors. The error tag should be
-  // 'SampleInputFile' used when calling CompileGlslToSpv().
+  const shaderc::SpvModule module =
+      compiler_.CompileGlslToSpv(kTwoErrorsShader, strlen(kTwoErrorsShader),
+                                 shaderc_glsl_vertex_shader, "SampleInputFile");
+  // Expects compilation failure errors. The error tag should be
+  // 'SampleInputFile'
   EXPECT_FALSE(module.GetSuccess());
   EXPECT_THAT(module.GetErrorMessage(), HasSubstr("SampleInputFile:2: error:"));
 }
@@ -455,8 +451,7 @@ TEST_F(CppInterface, ErrorTagIsInputFileName) {
 TEST_F(CppInterface, PreprocessingOnlyOption) {
   options_.SetPreprocessingOnlyMode();
   shaderc::SpvModule result = compiler_.CompileGlslToSpv(
-      kMinimalShaderWithMacro, shaderc_glsl_vertex_shader,
-      "shader" /*input_file_name*/, options_);
+      kMinimalShaderWithMacro, shaderc_glsl_vertex_shader, "shader", options_);
   EXPECT_TRUE(result.GetSuccess());
   EXPECT_THAT(result.GetData(), HasSubstr("void main(){ }"));
 
@@ -465,8 +460,8 @@ TEST_F(CppInterface, PreprocessingOnlyOption) {
       "void E_CLONE_OPTION(){}\n";
   CompileOptions cloned_options(options_);
   shaderc::SpvModule result_from_cloned_options = compiler_.CompileGlslToSpv(
-      kMinimalShaderCloneOption, shaderc_glsl_vertex_shader,
-      "shader" /*input_file_name*/, cloned_options);
+      kMinimalShaderCloneOption, shaderc_glsl_vertex_shader, "shader",
+      cloned_options);
   EXPECT_TRUE(result_from_cloned_options.GetSuccess());
   EXPECT_THAT(result_from_cloned_options.GetData(),
               HasSubstr("void main(){ }"));
@@ -479,8 +474,8 @@ TEST_F(CppInterface, PreprocessingOnlyModeFirstOverridesDisassemblyMode) {
   options_.SetDisassemblyMode();
   shaderc::SpvModule result_preprocessing_mode_first =
       compiler_.CompileGlslToSpv(kMinimalShaderWithMacro,
-                                 shaderc_glsl_vertex_shader,
-                                 "shader" /*input_file_name*/, options_);
+                                 shaderc_glsl_vertex_shader, "shader",
+                                 options_);
   EXPECT_TRUE(result_preprocessing_mode_first.GetSuccess());
   EXPECT_THAT(result_preprocessing_mode_first.GetData(),
               HasSubstr("void main(){ }"));
@@ -492,8 +487,7 @@ TEST_F(CppInterface, PreprocessingOnlyModeSecondOverridesDisassemblyMode) {
   options_.SetDisassemblyMode();
   options_.SetPreprocessingOnlyMode();
   shaderc::SpvModule result_disassembly_mode_first = compiler_.CompileGlslToSpv(
-      kMinimalShaderWithMacro, shaderc_glsl_vertex_shader,
-      "shader" /*input_file_name*/, options_);
+      kMinimalShaderWithMacro, shaderc_glsl_vertex_shader, "shader", options_);
   EXPECT_TRUE(result_disassembly_mode_first.GetSuccess());
   EXPECT_THAT(result_disassembly_mode_first.GetData(),
               HasSubstr("void main(){ }"));
@@ -521,8 +515,8 @@ using ValidShaderKind = testing::TestWithParam<ShaderKindTestCase>;
 TEST_P(ValidShaderKind, ValidSpvCode) {
   const ShaderKindTestCase& test_case = GetParam();
   shaderc::Compiler compiler;
-  EXPECT_TRUE(CompilesToValidSpv(compiler, test_case.shader_,
-                                 test_case.shader_kind_));
+  EXPECT_TRUE(
+      CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_kind_));
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -558,8 +552,8 @@ using InvalidShaderKind = testing::TestWithParam<ShaderKindTestCase>;
 TEST_P(InvalidShaderKind, CompilationShouldFail) {
   const ShaderKindTestCase& test_case = GetParam();
   shaderc::Compiler compiler;
-  EXPECT_FALSE(CompilesToValidSpv(compiler, test_case.shader_,
-                                  test_case.shader_kind_));
+  EXPECT_FALSE(
+      CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_kind_));
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -635,9 +629,8 @@ TEST_P(IncluderTests, SetIncluder) {
   CompileOptions options;
   options.SetIncluder(std::unique_ptr<TestIncluder>(new TestIncluder(fs)));
   options.SetPreprocessingOnlyMode();
-  const shaderc::SpvModule module =
-      compiler.CompileGlslToSpv(shader.c_str(), shaderc_glsl_vertex_shader,
-                                "shader" /*input_file_name*/, options);
+  const shaderc::SpvModule module = compiler.CompileGlslToSpv(
+      shader.c_str(), shaderc_glsl_vertex_shader, "shader", options);
   // Checks the existence of the expected string.
   EXPECT_THAT(module.GetData(), HasSubstr(test_case.expected_substring()));
 }
@@ -653,9 +646,8 @@ TEST_P(IncluderTests, SetIncluderClonedOptions) {
 
   // Cloned options should have all the settings.
   CompileOptions cloned_options(options);
-  const shaderc::SpvModule module =
-      compiler.CompileGlslToSpv(shader.c_str(), shaderc_glsl_vertex_shader,
-                                "shader" /*input_file_name*/, cloned_options);
+  const shaderc::SpvModule module = compiler.CompileGlslToSpv(
+      shader.c_str(), shaderc_glsl_vertex_shader, "shader", cloned_options);
   // Checks the existence of the expected string.
   EXPECT_THAT(module.GetData(), HasSubstr(test_case.expected_substring()));
 }

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -128,7 +128,7 @@ class CompileStringTest : public testing::Test {
                           shaderc_compile_options_t options = nullptr) {
     return shaderc_module_get_success(
         Compilation(compiler_.get_compiler_handle(), shader, kind,
-                    "shader" /*input_file_name*/, options)
+                    "shader", options)
             .result());
   }
 
@@ -138,7 +138,7 @@ class CompileStringTest : public testing::Test {
       const std::string& shader, shaderc_shader_kind kind,
       const shaderc_compile_options_t options = nullptr) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           "shader" /*input_file_name*/, options);
+                           "shader", options);
     EXPECT_TRUE(shaderc_module_get_success(comp.result())) << kind << '\n'
                                                            << shader;
     return shaderc_module_get_error_message(comp.result());
@@ -150,7 +150,7 @@ class CompileStringTest : public testing::Test {
       const std::string& shader, shaderc_shader_kind kind,
       const shaderc_compile_options_t options = nullptr) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           "shader" /*input_file_name*/, options);
+                           "shader", options);
     EXPECT_FALSE(shaderc_module_get_success(comp.result())) << kind << '\n'
                                                             << shader;
     return shaderc_module_get_error_message(comp.result());
@@ -162,7 +162,7 @@ class CompileStringTest : public testing::Test {
       const std::string& shader, shaderc_shader_kind kind,
       const shaderc_compile_options_t options = nullptr) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           "shader" /*input_file_name*/, options);
+                           "shader", options);
     EXPECT_TRUE(shaderc_module_get_success(comp.result())) << kind << '\n'
                                                            << shader;
     // Use string(const char* s, size_t n) constructor instead of

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -67,10 +67,11 @@ class Compilation {
  public:
   // Compiles shader, keeping the result.
   Compilation(const shaderc_compiler_t compiler, const std::string& shader,
-              shaderc_shader_kind kind,
+              shaderc_shader_kind kind, const char* input_file_name,
               const shaderc_compile_options_t options = nullptr)
-      : compiled_result_(shaderc_compile_into_spv(
-            compiler, shader.c_str(), shader.size(), kind, "", options)) {}
+      : compiled_result_(
+            shaderc_compile_into_spv(compiler, shader.c_str(), shader.size(),
+                                     kind, input_file_name, "", options)) {}
 
   ~Compilation() { shaderc_module_release(compiled_result_); }
 
@@ -104,7 +105,8 @@ class Compiler {
 bool CompilesToValidSpv(Compiler& compiler, const std::string& shader,
                         shaderc_shader_kind kind,
                         const shaderc_compile_options_t options = nullptr) {
-  const Compilation comp(compiler.get_compiler_handle(), shader, kind, options);
+  const Compilation comp(compiler.get_compiler_handle(), shader, kind, "shader",
+                         options);
   auto result = comp.result();
   if (!shaderc_module_get_success(result)) return false;
   size_t length = shaderc_module_get_length(result);
@@ -117,14 +119,16 @@ bool CompilesToValidSpv(Compiler& compiler, const std::string& shader,
 // A testing class to test the compilation of a string with or without options.
 // This class wraps the initailization of compiler and compiler options and
 // groups the result checking methods. Subclass tests can access the compiler
-// object and compiler option object to set their properties.
+// object and compiler option object to set their properties. All the Input file
+// names are set to "shader".
 class CompileStringTest : public testing::Test {
  protected:
   // Compiles a shader and returns true on success, false on failure.
   bool CompilationSuccess(const std::string& shader, shaderc_shader_kind kind,
                           shaderc_compile_options_t options = nullptr) {
     return shaderc_module_get_success(
-        Compilation(compiler_.get_compiler_handle(), shader, kind, options)
+        Compilation(compiler_.get_compiler_handle(), shader, kind,
+                    "shader" /*input_file_name*/, options)
             .result());
   }
 
@@ -134,7 +138,7 @@ class CompileStringTest : public testing::Test {
       const std::string& shader, shaderc_shader_kind kind,
       const shaderc_compile_options_t options = nullptr) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           options);
+                           "shader" /*input_file_name*/, options);
     EXPECT_TRUE(shaderc_module_get_success(comp.result())) << kind << '\n'
                                                            << shader;
     return shaderc_module_get_error_message(comp.result());
@@ -146,7 +150,7 @@ class CompileStringTest : public testing::Test {
       const std::string& shader, shaderc_shader_kind kind,
       const shaderc_compile_options_t options = nullptr) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           options);
+                           "shader" /*input_file_name*/, options);
     EXPECT_FALSE(shaderc_module_get_success(comp.result())) << kind << '\n'
                                                             << shader;
     return shaderc_module_get_error_message(comp.result());
@@ -158,7 +162,7 @@ class CompileStringTest : public testing::Test {
       const std::string& shader, shaderc_shader_kind kind,
       const shaderc_compile_options_t options = nullptr) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           options);
+                           "shader" /*input_file_name*/, options);
     EXPECT_TRUE(shaderc_module_get_success(comp.result())) << kind << '\n'
                                                            << shader;
     // Use string(const char* s, size_t n) constructor instead of
@@ -398,7 +402,8 @@ TEST_F(CompileStringWithOptionsTest, GenerateDebugInfoDisassembly) {
 
 TEST_F(CompileStringWithOptionsTest, GetNumErrors) {
   Compilation comp(compiler_.get_compiler_handle(), kTwoErrorsShader,
-                   shaderc_glsl_vertex_shader, options_.get());
+                   shaderc_glsl_vertex_shader, "shader" /*input_file_name*/,
+                   options_.get());
   // Expects compilation failure and two errors.
   EXPECT_FALSE(shaderc_module_get_success(comp.result()));
   EXPECT_EQ(2u, shaderc_module_get_num_errors(comp.result()));
@@ -408,7 +413,8 @@ TEST_F(CompileStringWithOptionsTest, GetNumErrors) {
 
 TEST_F(CompileStringWithOptionsTest, GetNumWarnings) {
   Compilation comp(compiler_.get_compiler_handle(), kTwoWarningsShader,
-                   shaderc_glsl_vertex_shader, options_.get());
+                   shaderc_glsl_vertex_shader, "shader" /*input_file_name*/,
+                   options_.get());
   // Expects compilation success with two warnings.
   EXPECT_TRUE(shaderc_module_get_success(comp.result()));
   EXPECT_EQ(2u, shaderc_module_get_num_warnings(comp.result()));
@@ -418,7 +424,7 @@ TEST_F(CompileStringWithOptionsTest, GetNumWarnings) {
 
 TEST_F(CompileStringWithOptionsTest, ZeroErrorsZeroWarnings) {
   Compilation comp(compiler_.get_compiler_handle(), kMinimalShader,
-                   shaderc_glsl_vertex_shader);
+                   shaderc_glsl_vertex_shader, "shader" /*input_file_name*/);
   // Expects compilation success with zero warnings.
   EXPECT_TRUE(shaderc_module_get_success(comp.result()));
   EXPECT_EQ(0u, shaderc_module_get_num_warnings(comp.result()));
@@ -602,7 +608,8 @@ TEST_P(IncluderTests, SetIncluderCallbacks) {
       TestIncluder::ReleaseIncluderResponseWrapper, &includer);
 
   const Compilation comp(compiler.get_compiler_handle(), shader,
-                         shaderc_glsl_vertex_shader, options.get());
+                         shaderc_glsl_vertex_shader,
+                         "shader" /*input_file_name*/, options.get());
   // Checks the existence of the expected string.
   EXPECT_THAT(shaderc_module_get_bytes(comp.result()),
               HasSubstr(test_case.expected_substring()));
@@ -625,7 +632,8 @@ TEST_P(IncluderTests, SetIncluderCallbacksClonedOptions) {
       shaderc_compile_options_clone(options.get()));
 
   const Compilation comp(compiler.get_compiler_handle(), shader,
-                         shaderc_glsl_vertex_shader, cloned_options.get());
+                         shaderc_glsl_vertex_shader,
+                         "shader" /*input_file_name*/, cloned_options.get());
   // Checks the existence of the expected string.
   EXPECT_THAT(shaderc_module_get_bytes(comp.result()),
               HasSubstr(test_case.expected_substring()));

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -119,8 +119,8 @@ bool CompilesToValidSpv(Compiler& compiler, const std::string& shader,
 // A testing class to test the compilation of a string with or without options.
 // This class wraps the initailization of compiler and compiler options and
 // groups the result checking methods. Subclass tests can access the compiler
-// object and compiler option object to set their properties. All the Input file
-// names are set to "shader".
+// object and compiler option object to set their properties. Input file names
+// are set to "shader".
 class CompileStringTest : public testing::Test {
  protected:
   // Compiles a shader and returns true on success, false on failure.
@@ -402,7 +402,7 @@ TEST_F(CompileStringWithOptionsTest, GenerateDebugInfoDisassembly) {
 
 TEST_F(CompileStringWithOptionsTest, GetNumErrors) {
   Compilation comp(compiler_.get_compiler_handle(), kTwoErrorsShader,
-                   shaderc_glsl_vertex_shader, "shader" /*input_file_name*/,
+                   shaderc_glsl_vertex_shader, "shader",
                    options_.get());
   // Expects compilation failure and two errors.
   EXPECT_FALSE(shaderc_module_get_success(comp.result()));
@@ -413,7 +413,7 @@ TEST_F(CompileStringWithOptionsTest, GetNumErrors) {
 
 TEST_F(CompileStringWithOptionsTest, GetNumWarnings) {
   Compilation comp(compiler_.get_compiler_handle(), kTwoWarningsShader,
-                   shaderc_glsl_vertex_shader, "shader" /*input_file_name*/,
+                   shaderc_glsl_vertex_shader, "shader",
                    options_.get());
   // Expects compilation success with two warnings.
   EXPECT_TRUE(shaderc_module_get_success(comp.result()));
@@ -424,7 +424,7 @@ TEST_F(CompileStringWithOptionsTest, GetNumWarnings) {
 
 TEST_F(CompileStringWithOptionsTest, ZeroErrorsZeroWarnings) {
   Compilation comp(compiler_.get_compiler_handle(), kMinimalShader,
-                   shaderc_glsl_vertex_shader, "shader" /*input_file_name*/);
+                   shaderc_glsl_vertex_shader, "shader");
   // Expects compilation success with zero warnings.
   EXPECT_TRUE(shaderc_module_get_success(comp.result()));
   EXPECT_EQ(0u, shaderc_module_get_num_warnings(comp.result()));
@@ -609,7 +609,7 @@ TEST_P(IncluderTests, SetIncluderCallbacks) {
 
   const Compilation comp(compiler.get_compiler_handle(), shader,
                          shaderc_glsl_vertex_shader,
-                         "shader" /*input_file_name*/, options.get());
+                         "shader", options.get());
   // Checks the existence of the expected string.
   EXPECT_THAT(shaderc_module_get_bytes(comp.result()),
               HasSubstr(test_case.expected_substring()));
@@ -633,7 +633,7 @@ TEST_P(IncluderTests, SetIncluderCallbacksClonedOptions) {
 
   const Compilation comp(compiler.get_compiler_handle(), shader,
                          shaderc_glsl_vertex_shader,
-                         "shader" /*input_file_name*/, cloned_options.get());
+                         "shader", cloned_options.get());
   // Checks the existence of the expected string.
   EXPECT_THAT(shaderc_module_get_bytes(comp.result()),
               HasSubstr(test_case.expected_substring()));


### PR DESCRIPTION
So that we have the 'error_tag' in libshaderc_util work properly, instead of always using "shader" as its error_tag.