### PR TITLE
Add error type field result module

### DIFF
--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -63,12 +63,11 @@ typedef enum {
   shaderc_profile_es,
 } shaderc_profile;
 
-// Used in result module (shaderc_spv_module) to tell the type of errors
+// Used in the result module (shaderc_spv_module) to tell the type of errors
 // generated during compilation.
 typedef enum {
   shaderc_none_error,
-  shaderc_shader_kind_error,  // errors due to failure in shader stage
-                              // deduction.
+  shaderc_shader_kind_error,  // error in the deduction of shader stage
   shaderc_compilation_error,
 } shaderc_error_type;
 
@@ -292,8 +291,8 @@ size_t shaderc_module_get_num_warnings(const shaderc_spv_module_t module);
 // Returns the number of errors generated during the compilation.
 size_t shaderc_module_get_num_errors(const shaderc_spv_module_t module);
 
-// Returns the type of the generated compilation errors. Returns
-// shaderc_none_error if there isn't error or result module doesn't exist.
+// Returns the type of the errors of one compilation. Returns shaderc_none_error
+// if there isn't any error.
 shaderc_error_type shaderc_module_get_error_type(const shaderc_spv_module_t);
 
 // Returns a pointer to the start of the SPIR-V bytes, either SPIR-V binary or

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -66,10 +66,11 @@ typedef enum {
 // Used in the result module (shaderc_spv_module) to tell the type of errors
 // generated during compilation.
 typedef enum {
-  shaderc_none_error,
-  shaderc_shader_kind_error,  // error in the deduction of shader stage
-  shaderc_compilation_error,
-} shaderc_error_type;
+  shaderc_compilation_result_success,
+  shaderc_compilation_result_failed_invalid_stage,  // error in the deduction of shader stage
+  shaderc_compilation_result_compilation_failed,
+  shaderc_compilation_result_null_result_module,
+} shaderc_compilation_result;
 
 // Usage examples:
 //
@@ -291,9 +292,11 @@ size_t shaderc_module_get_num_warnings(const shaderc_spv_module_t module);
 // Returns the number of errors generated during the compilation.
 size_t shaderc_module_get_num_errors(const shaderc_spv_module_t module);
 
-// Returns the type of the errors of one compilation. Returns shaderc_none_error
-// if there isn't any error.
-shaderc_error_type shaderc_module_get_error_type(const shaderc_spv_module_t);
+// Returns the compilation result, indicating whether the compilation succeeded,
+// or failed due to some reasons, like invalid shader stage or compilation
+// errors.
+shaderc_compilation_result shaderc_module_get_compilation_result(
+    const shaderc_spv_module_t);
 
 // Returns a pointer to the start of the SPIR-V bytes, either SPIR-V binary or
 // char string. When the source string is compiled into SPIR-V binary, this is

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -63,6 +63,15 @@ typedef enum {
   shaderc_profile_es,
 } shaderc_profile;
 
+// Used in result module (shaderc_spv_module) to tell the type of errors
+// generated during compilation.
+typedef enum {
+  shaderc_none_error,
+  shaderc_shader_kind_error,  // errors due to failure in shader stage
+                              // deduction.
+  shaderc_compilation_error,
+} shaderc_error_type;
+
 // Usage examples:
 //
 // Aggressively release compiler resources, but spend time in initialization

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -292,6 +292,10 @@ size_t shaderc_module_get_num_warnings(const shaderc_spv_module_t module);
 // Returns the number of errors generated during the compilation.
 size_t shaderc_module_get_num_errors(const shaderc_spv_module_t module);
 
+// Returns the type of the generated compilation errors. Returns
+// shaderc_none_error if there isn't error or result module doesn't exist.
+shaderc_error_type shaderc_module_get_error_type(const shaderc_spv_module_t);
+
 // Returns a pointer to the start of the SPIR-V bytes, either SPIR-V binary or
 // char string. When the source string is compiled into SPIR-V binary, this is
 // guaranteed to be castable to a uint32_t*. If the source string is compiled in

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -66,7 +66,7 @@ typedef enum {
 // Used in the result module (shaderc_spv_module) to tell the type of errors
 // generated during compilation.
 typedef enum {
-  shaderc_compilation_result_success,
+  shaderc_compilation_result_success = 0,
   shaderc_compilation_result_failed_invalid_stage,  // error in the deduction of shader stage
   shaderc_compilation_result_compilation_failed,
   shaderc_compilation_result_null_result_module,

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -63,14 +63,14 @@ typedef enum {
   shaderc_profile_es,
 } shaderc_profile;
 
-// Used in the result module (shaderc_spv_module) to tell the type of errors
-// generated during compilation.
+// Used in the result module (shaderc_spv_module) to indicate the status of an
+// compilation.
 typedef enum {
-  shaderc_compilation_result_success = 0,
-  shaderc_compilation_result_failed_invalid_stage,  // error in the deduction of shader stage
-  shaderc_compilation_result_compilation_failed,
-  shaderc_compilation_result_null_result_module,
-} shaderc_compilation_result;
+  shaderc_compilation_status_success = 0,
+  shaderc_compilation_status_invalid_stage,  // error in the deduction of shader stage
+  shaderc_compilation_status_compilation_error,
+  shaderc_compilation_status_null_result_module,
+} shaderc_compilation_status;
 
 // Usage examples:
 //
@@ -292,10 +292,10 @@ size_t shaderc_module_get_num_warnings(const shaderc_spv_module_t module);
 // Returns the number of errors generated during the compilation.
 size_t shaderc_module_get_num_errors(const shaderc_spv_module_t module);
 
-// Returns the compilation result, indicating whether the compilation succeeded,
+// Returns the compilation status, indicating whether the compilation succeeded,
 // or failed due to some reasons, like invalid shader stage or compilation
 // errors.
-shaderc_compilation_result shaderc_module_get_compilation_result(
+shaderc_compilation_status shaderc_module_get_compilation_status(
     const shaderc_spv_module_t);
 
 // Returns a pointer to the start of the SPIR-V bytes, either SPIR-V binary or

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -36,11 +36,6 @@ class SpvModule {
     other.module_ = nullptr;
   }
 
-  // Returns true if the module was successfully compiled.
-  bool GetSuccess() const {
-    return module_ && shaderc_module_get_success(module_);
-  }
-
   // Returns any error message found during compilation.
   std::string GetErrorMessage() const {
     if (!module_) {
@@ -49,13 +44,14 @@ class SpvModule {
     return shaderc_module_get_error_message(module_);
   }
 
-  // Returns the type of the errors of one compilation. Returns
-  // shaderc_none_error if there isn't any error or result module doesn't exist.
-  shaderc_error_type GetErrorType() const {
+  // Returns the compilation result, indicating whether the compilation
+  // succeeded, or failed due to some reasons, like invalid shader stage or
+  // compilation errors.
+  shaderc_compilation_result GetCompilationResult() const {
     if (!module_) {
-      return shaderc_none_error;
+      return shaderc_compilation_result_null_result_module;
     }
-    return shaderc_module_get_error_type(module_);
+    return shaderc_module_get_compilation_result(module_);
   }
 
   // Returns a pointer to the start of the compiled SPIR-V.

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -49,6 +49,15 @@ class SpvModule {
     return shaderc_module_get_error_message(module_);
   }
 
+  // Returns the type of the generated compilation errors. Returns
+  // shaderc_none_error if there isn't error or result module doesn't exist.
+  shaderc_error_type GetErrorType() const {
+    if (!module_) {
+      return shaderc_none_error;
+    }
+    return shaderc_module_get_error_type(module_);
+  }
+
   // Returns a pointer to the start of the compiled SPIR-V.
   // It is guaranteed that static_cast<uint32_t> is valid to call on this
   // pointer.

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -44,14 +44,14 @@ class SpvModule {
     return shaderc_module_get_error_message(module_);
   }
 
-  // Returns the compilation result, indicating whether the compilation
+  // Returns the compilation status, indicating whether the compilation
   // succeeded, or failed due to some reasons, like invalid shader stage or
   // compilation errors.
-  shaderc_compilation_result GetCompilationResult() const {
+  shaderc_compilation_status GetCompilationStatus() const {
     if (!module_) {
-      return shaderc_compilation_result_null_result_module;
+      return shaderc_compilation_status_null_result_module;
     }
-    return shaderc_module_get_compilation_result(module_);
+    return shaderc_module_get_compilation_status(module_);
   }
 
   // Returns a pointer to the start of the compiled SPIR-V.

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -49,8 +49,8 @@ class SpvModule {
     return shaderc_module_get_error_message(module_);
   }
 
-  // Returns the type of the generated compilation errors. Returns
-  // shaderc_none_error if there isn't error or result module doesn't exist.
+  // Returns the type of the errors of one compilation. Returns
+  // shaderc_none_error if there isn't any error or result module doesn't exist.
   shaderc_error_type GetErrorType() const {
     if (!module_) {
       return shaderc_none_error;

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -391,16 +391,15 @@ shaderc_spv_module_t shaderc_compile_into_spv(
       // Check whether the error is caused by failing to deduce the shader
       // stage. If it is the case, set the error type to shader kind error.
       // Otherwise, set it to compilation error.
-      result->error_type = stage_deducer.error() ? shaderc_shader_kind_error
-                                                 : shaderc_compilation_error;
+      result->compilation_result = stage_deducer.error()
+                               ? shaderc_compilation_result_failed_invalid_stage
+                               : shaderc_compilation_result_compilation_failed;
+    } else {
+      result->compilation_result = shaderc_compilation_result_success;
     }
   }
   CATCH_IF_EXCEPTIONS_ENABLED(...) { result->compilation_succeeded = false; }
   return result;
-}
-
-bool shaderc_module_get_success(const shaderc_spv_module_t module) {
-  return module->compilation_succeeded;
 }
 
 size_t shaderc_module_get_length(const shaderc_spv_module_t module) {
@@ -426,9 +425,9 @@ const char* shaderc_module_get_error_message(
   return module->messages.c_str();
 }
 
-shaderc_error_type shaderc_module_get_error_type(
+shaderc_compilation_result shaderc_module_get_compilation_result(
     const shaderc_spv_module_t module) {
-  return module->error_type;
+  return module->compilation_result;
 }
 
 void shaderc_get_spv_version(unsigned int* version, unsigned int* revision) {

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -107,20 +107,25 @@ std::mutex compile_mutex;  // Guards shaderc_compile_*.
 // case.
 class StageDeducer {
  public:
-  StageDeducer() : kind_(shaderc_glsl_infer_from_source), error_(false){};
-  StageDeducer(shaderc_shader_kind kind) : kind_(kind), error_(false){};
+  StageDeducer(shaderc_shader_kind kind = shaderc_glsl_infer_from_source)
+      : kind_(kind), error_(false){};
   // The method that underlying glslang will call to determine the shader stage
   // to be used in current compilation. It is called only when there is neither
   // forced shader kind (or say stage, in the view of glslang), nor #pragma
   // annotation in the source code. This method transforms an user defined
   // 'default' shader kind to the corresponding shader stage. As this is the
   // last trial to determine the shader stage, failing to find the corresponding
-  // shader stage will cause an error.
+  // shader stage will record an error.
+  // Note that calling this method more than once during one compilation will
+  // have the error recorded for the previous call been overwriten by the next
+  // call.
   EShLanguage operator()(std::ostream* /*error_stream*/,
                          const shaderc_util::string_piece& /*error_tag*/) {
     EShLanguage stage = GetDefaultStage(kind_);
     if (stage == EShLangCount) {
       error_ = true;
+    } else {
+      error_ = false;
     }
     return stage;
   };
@@ -353,7 +358,9 @@ shaderc_spv_module_t shaderc_compile_into_spv(
     return nullptr;
   }
 
-  result->compilation_succeeded = false;  // In case we exit early.
+  result->compilation_status =
+      shaderc_compilation_status_invalid_stage;
+  bool compilation_succeeded = false; // In case we exit early.
   if (!compiler->initialized) return result;
   TRY_IF_EXCEPTIONS_ENABLED {
     std::stringstream output;
@@ -366,7 +373,7 @@ shaderc_spv_module_t shaderc_compile_into_spv(
         shaderc_util::string_piece(source_text, source_text + source_text_size);
     StageDeducer stage_deducer(shader_kind);
     if (additional_options) {
-      result->compilation_succeeded = additional_options->compiler.Compile(
+      compilation_succeeded = additional_options->compiler.Compile(
           source_string, forced_stage, input_file_name_str,
           // stage_deducer has a flag: error_, which we need to check later.
           // We need to make this a reference wrapper, so that std::function
@@ -378,7 +385,7 @@ shaderc_spv_module_t shaderc_compile_into_spv(
           &output, &errors, &total_warnings, &total_errors);
     } else {
       // Compile with default options.
-      result->compilation_succeeded = shaderc_util::Compiler().Compile(
+      compilation_succeeded = shaderc_util::Compiler().Compile(
           source_string, forced_stage, input_file_name_str,
           std::ref(stage_deducer), InternalFileIncluder(), &output, &errors,
           &total_warnings, &total_errors);
@@ -387,18 +394,20 @@ shaderc_spv_module_t shaderc_compile_into_spv(
     result->spirv = output.str();
     result->num_warnings = total_warnings;
     result->num_errors = total_errors;
-    if (!result->compilation_succeeded) {
+    if (compilation_succeeded) {
+      result->compilation_status = shaderc_compilation_status_success;
+    } else {
       // Check whether the error is caused by failing to deduce the shader
       // stage. If it is the case, set the error type to shader kind error.
       // Otherwise, set it to compilation error.
-      result->compilation_result = stage_deducer.error()
-                               ? shaderc_compilation_result_failed_invalid_stage
-                               : shaderc_compilation_result_compilation_failed;
-    } else {
-      result->compilation_result = shaderc_compilation_result_success;
+      result->compilation_status =
+          stage_deducer.error() ? shaderc_compilation_status_invalid_stage
+                                : shaderc_compilation_status_compilation_error;
     }
   }
-  CATCH_IF_EXCEPTIONS_ENABLED(...) { result->compilation_succeeded = false; }
+  CATCH_IF_EXCEPTIONS_ENABLED(...) {
+    result->compilation_status = shaderc_compilation_status_compilation_error;
+  }
   return result;
 }
 
@@ -425,9 +434,9 @@ const char* shaderc_module_get_error_message(
   return module->messages.c_str();
 }
 
-shaderc_compilation_result shaderc_module_get_compilation_result(
+shaderc_compilation_status shaderc_module_get_compilation_status(
     const shaderc_spv_module_t module) {
-  return module->compilation_result;
+  return module->compilation_status;
 }
 
 void shaderc_get_spv_version(unsigned int* version, unsigned int* revision) {

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -437,6 +437,23 @@ TEST_F(CppInterface, ZeroErrorsZeroWarnings) {
   EXPECT_EQ(0u, module.GetNumWarnings());
 }
 
+TEST_F(CppInterface, ErrorTypeShaderStageDeductionError) {
+  // The shader kind/stage can not be determined, the error type field should
+  // indicate the error type is shaderc_shader_kind_error.
+  const shaderc::SpvModule module =
+      compiler_.CompileGlslToSpv(kMinimalShader, strlen(kMinimalShader),
+                                 shaderc_glsl_infer_from_source, "shader");
+  EXPECT_EQ(shaderc_shader_kind_error, module.GetErrorType());
+}
+
+TEST_F(CppInterface, ErrorTypeCompilationError) {
+  // The shader kind is valid, the result module's error type field should
+  // indicate this compilaion fails due to compilation errors.
+  const shaderc::SpvModule module = compiler_.CompileGlslToSpv(
+      kTwoErrorsShader, shaderc_glsl_vertex_shader, "shader");
+  EXPECT_EQ(shaderc_compilation_error, module.GetErrorType());
+}
+
 TEST_F(CppInterface, ErrorTagIsInputFileName) {
   std::string shader(kTwoErrorsShader);
   const shaderc::SpvModule module =

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -32,8 +32,8 @@ using testing::HasSubstr;
 // Helper function to check if the compilation result indicates a successful
 // compilation.
 bool CompilationResultIsSuccess(const shaderc::SpvModule& result_module) {
-  return result_module.GetCompilationResult() ==
-         shaderc_compilation_result_success;
+  return result_module.GetCompilationStatus() ==
+         shaderc_compilation_status_success;
 }
 
 // Examine whether a SPIR-V result module has valid SPIR-V code, by checking the
@@ -72,7 +72,7 @@ class CppInterface : public testing::Test {
                           shaderc_shader_kind kind) const {
     return compiler_
         .CompileGlslToSpv(shader.c_str(), shader.length(), kind, "shader")
-        .GetCompilationResult() == shaderc_compilation_result_success;
+        .GetCompilationStatus() == shaderc_compilation_status_success;
   }
 
   // Compiles a shader with options and returns true on success, false on
@@ -83,7 +83,7 @@ class CppInterface : public testing::Test {
     return compiler_
         .CompileGlslToSpv(shader.c_str(), shader.length(), kind, "shader",
                           options)
-        .GetCompilationResult() == shaderc_compilation_result_success;
+        .GetCompilationStatus() == shaderc_compilation_status_success;
   }
 
   // Compiles a shader, asserts compilation success, and returns the warning
@@ -450,8 +450,8 @@ TEST_F(CppInterface, ErrorTypeUnknownShaderStage) {
   const shaderc::SpvModule module =
       compiler_.CompileGlslToSpv(kMinimalShader, strlen(kMinimalShader),
                                  shaderc_glsl_infer_from_source, "shader");
-  EXPECT_EQ(shaderc_compilation_result_failed_invalid_stage,
-            module.GetCompilationResult());
+  EXPECT_EQ(shaderc_compilation_status_invalid_stage,
+            module.GetCompilationStatus());
 }
 
 TEST_F(CppInterface, ErrorTypeCompilationError) {
@@ -459,8 +459,8 @@ TEST_F(CppInterface, ErrorTypeCompilationError) {
   // indicate this compilaion fails due to compilation errors.
   const shaderc::SpvModule module = compiler_.CompileGlslToSpv(
       kTwoErrorsShader, shaderc_glsl_vertex_shader, "shader");
-  EXPECT_EQ(shaderc_compilation_result_compilation_failed,
-            module.GetCompilationResult());
+  EXPECT_EQ(shaderc_compilation_status_compilation_error,
+            module.GetCompilationStatus());
 }
 
 TEST_F(CppInterface, ErrorTagIsInputFileName) {

--- a/libshaderc/src/shaderc_private.h
+++ b/libshaderc/src/shaderc_private.h
@@ -33,8 +33,8 @@ struct shaderc_spv_module {
   size_t num_errors = 0;
   // Number of warnings.
   size_t num_warnings = 0;
-  // Error type.
-  shaderc_error_type error_type = shaderc_none_error;
+  // Compilation result.
+  shaderc_compilation_result compilation_result;
 };
 
 struct shaderc_compiler {

--- a/libshaderc/src/shaderc_private.h
+++ b/libshaderc/src/shaderc_private.h
@@ -23,8 +23,6 @@
 
 // Described in shaderc.h.
 struct shaderc_spv_module {
-  // Whether compilation succeeded.
-  bool compilation_succeeded;
   // SPIR-V binary.
   std::string spirv;
   // Compilation messages.
@@ -33,8 +31,9 @@ struct shaderc_spv_module {
   size_t num_errors = 0;
   // Number of warnings.
   size_t num_warnings = 0;
-  // Compilation result.
-  shaderc_compilation_result compilation_result;
+  // Compilation status.
+  shaderc_compilation_status compilation_status =
+      shaderc_compilation_status_null_result_module;
 };
 
 struct shaderc_compiler {

--- a/libshaderc/src/shaderc_private.h
+++ b/libshaderc/src/shaderc_private.h
@@ -33,6 +33,8 @@ struct shaderc_spv_module {
   size_t num_errors = 0;
   // Number of warnings.
   size_t num_warnings = 0;
+  // Error type.
+  shaderc_error_type error_type = shaderc_none_error;
 };
 
 struct shaderc_compiler {

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -104,8 +104,8 @@ class Compiler {
 // Helper function to check if the compilation result indicates a successful
 // compilation.
 bool CompilationResultIsSuccess(const shaderc_spv_module_t result_module) {
-  return shaderc_module_get_compilation_result(result_module) ==
-         shaderc_compilation_result_success;
+  return shaderc_module_get_compilation_status(result_module) ==
+         shaderc_compilation_status_success;
 }
 
 // Compiles a shader and returns true if the result is valid SPIR-V.
@@ -265,16 +265,16 @@ TEST_F(CompileStringTest, ErrorTypeUnknownShaderStage) {
   // indicate the error type is shaderc_shader_kind_error.
   Compilation comp(compiler_.get_compiler_handle(), kMinimalShader,
                    shaderc_glsl_infer_from_source, "shader");
-  EXPECT_EQ(shaderc_compilation_result_failed_invalid_stage,
-            shaderc_module_get_compilation_result(comp.result()));
+  EXPECT_EQ(shaderc_compilation_status_invalid_stage,
+            shaderc_module_get_compilation_status(comp.result()));
 }
 TEST_F(CompileStringTest, ErrorTypeCompilationError) {
   // The shader kind is valid, the result module's error type field should
   // indicate this compilaion fails due to compilation errors.
   Compilation comp(compiler_.get_compiler_handle(), kTwoErrorsShader,
                    shaderc_glsl_vertex_shader, "shader");
-  EXPECT_EQ(shaderc_compilation_result_compilation_failed,
-            shaderc_module_get_compilation_result(comp.result()));
+  EXPECT_EQ(shaderc_compilation_status_compilation_error,
+            shaderc_module_get_compilation_status(comp.result()));
 }
 
 TEST_F(CompileStringWithOptionsTest, CloneCompilerOptions) {


### PR DESCRIPTION
The StageDeducer in libshaderc now keeps a flag, set to true when it is called to deduce a shader stage but failed (the last chance to get the stage). We then check the flag after compilation, to determine the error type, and store it in the result module

Replace get_success() with get_compilation_result(). Instead of returning a boolean, it returns an enum type: shaderc_compilation_result. The enum value can indicate whether the compilation succeeded or failed due to some reasons. 