### PR TITLE
Parse version profile libshaderc

### DIFF
--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -312,10 +312,10 @@ const char* shaderc_module_get_error_message(const shaderc_spv_module_t module);
 // Provides the version & revision of the SPIR-V which will be produced
 void shaderc_get_spv_version(unsigned int* version, unsigned int* revision);
 
-// Parse the version and profile from a given string containing both version and
-// profile, like: '450core'. Returns false if the string can not be parsed.
-// Returns true when parsing succeeded. The parsed version and profile are
-// returned through arguments.
+// Parses the version and profile from a given string containing both
+// version and profile, like: '450core'. Returns false if the string can
+// not be parsed. Returns true when the parsing succeeds. The parsed version
+// and profile are returned through arguments.
 bool shaderc_parse_version_profile(const char* str, int* version,
                                    shaderc_profile* profile);
 

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -312,6 +312,13 @@ const char* shaderc_module_get_error_message(const shaderc_spv_module_t module);
 // Provides the version & revision of the SPIR-V which will be produced
 void shaderc_get_spv_version(unsigned int* version, unsigned int* revision);
 
+// Parse the version and profile from a given string containing both version and
+// profile, like: '450core'. Returns false if the string can not be parsed.
+// Returns true when parsing succeeded. The parsed version and profile are
+// returned through arguments.
+bool shaderc_parse_version_profile(const char* str, int* version,
+                                   shaderc_profile* profile);
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -461,6 +461,7 @@ bool shaderc_parse_version_profile(const char* str, int* version,
       return true;
     case ECompatibilityProfile:
       *profile = shaderc_profile_compatibility;
+      return true;
     case ENoProfile:
       *profile = shaderc_profile_none;
       return true;

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -468,4 +468,8 @@ bool shaderc_parse_version_profile(const char* str, int* version,
     case EBadProfile:
       return false;
   }
+
+  // Shouldn't reach here, all profile enum should be handled above.
+  // Be strict to return false.
+  return false;
 }

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -25,6 +25,7 @@
 
 #include "libshaderc_util/compiler.h"
 #include "libshaderc_util/resources.h"
+#include "libshaderc_util/version_profile.h"
 
 #if (defined(_MSC_VER) && !defined(_CPPUNWIND)) || !defined(__EXCEPTIONS)
 #define TRY_IF_EXCEPTIONS_ENABLED
@@ -442,4 +443,15 @@ shaderc_compilation_status shaderc_module_get_compilation_status(
 void shaderc_get_spv_version(unsigned int* version, unsigned int* revision) {
   *version = spv::Version;
   *revision = spv::Revision;
+}
+
+bool shaderc_parse_version_profile(const char* str, int* version,
+                                   shaderc_profile* profile) {
+  EProfile glslang_profile;
+  bool success = shaderc_util::ParseVersionProfile(
+      std::string(str, strlen(str)), version, &glslang_profile);
+  if (!success) return false;
+
+
+
 }

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -452,6 +452,19 @@ bool shaderc_parse_version_profile(const char* str, int* version,
       std::string(str, strlen(str)), version, &glslang_profile);
   if (!success) return false;
 
-
-
+  switch (glslang_profile) {
+    case EEsProfile:
+      *profile = shaderc_profile_es;
+      return true;
+    case ECoreProfile:
+      *profile = shaderc_profile_core;
+      return true;
+    case ECompatibilityProfile:
+      *profile = shaderc_profile_compatibility;
+    case ENoProfile:
+      *profile = shaderc_profile_none;
+      return true;
+    case EBadProfile:
+      return false;
+  }
 }

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -956,4 +956,48 @@ TEST_F(CompileKindsTest, TessEvaluation) {
                                  shaderc_glsl_tess_evaluation_shader));
 }
 
+// A test case for ParseVersionProfileTest needs: 1) the input string, 2)
+// expected parsing results, including 'succeed' flag, version value, and
+// profile enum.
+struct ParseVersionProfileTestCase {
+  std::string str;
+  bool expected_succeed;
+  int expected_version;
+  shaderc_profile expected_profile;
+};
+
+// Test for a helper function to parse version and profile from string.
+using ParseVersionProfileTest =
+    testing::TestWithParam<ParseVersionProfileTestCase>;
+
+TEST_P(ParseVersionProfileTest, FromNullTerminatedString) {
+  const ParseVersionProfileTestCase& test_case = GetParam();
+  int version;
+  shaderc_profile profile;
+  bool succeed =
+      shaderc_parse_version_profile(test_case.str.c_str(), &version, &profile);
+  EXPECT_EQ(test_case.expected_succeed, succeed);
+  // check the return version and profile only when the parsing succeeds.
+  if (succeed) {
+    EXPECT_EQ(test_case.expected_version, version);
+    EXPECT_EQ(test_case.expected_profile, profile);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    HelperMethods, ParseVersionProfileTest,
+    testing::ValuesIn(std::vector<ParseVersionProfileTestCase>{
+        // Valid version profiles
+        {"450core", true, 450, shaderc_profile_core},
+        {"310es", true, 310, shaderc_profile_es},
+        {"100", true, 100, shaderc_profile_none},
+
+        // Invalid version profiles, the expected_version and expected_profile
+        // can be random value as they won't be checked if the tests pass
+        // correctly.
+        {"totally_wrong", false, 0, shaderc_profile_none},
+        {"111core", false, 0, shaderc_profile_none},
+        {"450wrongprofile", false, 0, shaderc_profile_none},
+    }));
+
 }  // anonymous namespace

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -1007,6 +1007,7 @@ INSTANTIATE_TEST_CASE_P(
         ParseVersionProfileTestCase("totally_wrong", false),
         ParseVersionProfileTestCase("111core", false),
         ParseVersionProfileTestCase("450wrongprofile", false),
+        ParseVersionProfileTestCase("", false),
     }));
 
 }  // anonymous namespace


### PR DESCRIPTION
Currently the test is not completed, I think we need more test cases.

Didn't add interface in CPP header, I think we don't need one for this method, do we?