### PR TITLE
Return ICE instead of Compilation Failure if we catch and exception.

### DIFF
--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -67,8 +67,9 @@ typedef enum {
 // compilation.
 typedef enum {
   shaderc_compilation_status_success = 0,
-  shaderc_compilation_status_invalid_stage,  // error in the deduction of shader stage
+  shaderc_compilation_status_invalid_stage,  // error stage deduction
   shaderc_compilation_status_compilation_error,
+  shaderc_compilation_status_internal_error, //unexpected failure
   shaderc_compilation_status_null_result_module,
 } shaderc_compilation_status;
 

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -407,7 +407,7 @@ shaderc_spv_module_t shaderc_compile_into_spv(
     }
   }
   CATCH_IF_EXCEPTIONS_ENABLED(...) {
-    result->compilation_status = shaderc_compilation_status_compilation_error;
+    result->compilation_status = shaderc_compilation_status_internal_error;
   }
   return result;
 }


### PR DESCRIPTION
Be more transparent about the cause of failure when we
catch and internal exception in the compiler.