### PR TITLE
Qualify CMake function names with "shaderc" to avoid conflictions.

### DIFF
--- a/cmake/setup_build.cmake
+++ b/cmake/setup_build.cmake
@@ -1,11 +1,11 @@
-# Find nosetests; see add_nosetests() from utils.cmake for opting in to
+# Find nosetests; see shaderc_add_nosetests() from utils.cmake for opting in to
 # nosetests in a specific directory.
 find_program(NOSETESTS_EXE NAMES nosetests PATHS $ENV{PYTHON_PACKAGE_PATH})
 if (NOT NOSETESTS_EXE)
   message(STATUS "nosetests was not found - python code will not be tested")
 endif()
 
-# Find asciidoctor; see add_asciidoc() from utils.cmake for
+# Find asciidoctor; see shaderc_add_asciidoc() from utils.cmake for
 # adding documents.
 find_program(ASCIIDOCTOR_EXE NAMES asciidoctor)
 if (NOT ASCIIDOCTOR_EXE)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,13 +1,13 @@
 # utility functions
 
-function (use_gmock TARGET)
+function (shaderc_use_gmock TARGET)
   target_include_directories(${TARGET} PRIVATE
     ${gmock_SOURCE_DIR}/include
     ${gtest_SOURCE_DIR}/include)
   target_link_libraries(${TARGET} PRIVATE gmock gtest_main)
-endfunction(use_gmock)
+endfunction(shaderc_use_gmock)
 
-function(default_compile_options TARGET)
+function(shaderc_default_compile_options TARGET)
   if (NOT "${MSVC}")
     target_compile_options(${TARGET} PRIVATE -std=c++11 -fPIC -Wall -Werror)
     if (ENABLE_CODE_COVERAGE)
@@ -24,11 +24,11 @@ function(default_compile_options TARGET)
     # (performance warning)
     target_compile_options(${TARGET} PRIVATE /wd4800)
   endif()
-endfunction(default_compile_options)
+endfunction(shaderc_default_compile_options)
 
 # Build an asciidoc file; additional arguments past the base filename specify
 # additional dependencies for the file.
-function(add_asciidoc TARGET FILE)
+function(shaderc_add_asciidoc TARGET FILE)
   if (ASCIIDOCTOR_EXE)
     set(DEST ${CMAKE_CURRENT_BINARY_DIR}/${FILE}.html)
     add_custom_command(
@@ -43,7 +43,7 @@ endfunction()
 # Run nosetests on file ${PREFIX}_nosetest.py. Nosetests will look for classes
 # and functions whose names start with "nosetest". The test name will be
 # ${PREFIX}_nosetests.
-function(add_nosetests PREFIX)
+function(shaderc_add_nosetests PREFIX)
   if(NOSETESTS_EXE)
     add_test(
       NAME ${PREFIX}_nosetests
@@ -60,7 +60,7 @@ endfunction()
 # LINK_LIBS:    (optional) a list of libraries to be linked to the test target
 # INCLUDE_DIRS: (optional) a list of include directories to be searched
 #               for header files.
-function(add_shaderc_tests)
+function(shaderc_add_tests)
   cmake_parse_arguments(PARSED_ARGS
     ""
     "TEST_PREFIX"
@@ -75,7 +75,7 @@ function(add_shaderc_tests)
   foreach(TARGET ${PARSED_ARGS_TEST_NAMES})
     set(TEST_NAME ${PARSED_ARGS_TEST_PREFIX}_${TARGET}_test)
     add_executable(${TEST_NAME} src/${TARGET}_test.cc)
-    default_compile_options(${TEST_NAME})
+    shaderc_default_compile_options(${TEST_NAME})
     if (PARSED_ARGS_LINK_LIBS)
       target_link_libraries(${TEST_NAME} PRIVATE
         ${PARSED_ARGS_LINK_LIBS})
@@ -84,17 +84,17 @@ function(add_shaderc_tests)
       target_include_directories(${TEST_NAME} PRIVATE
         ${PARSED_ARGS_INCLUDE_DIRS})
     endif()
-    use_gmock(${TEST_NAME})
+    shaderc_use_gmock(${TEST_NAME})
     add_test(
       NAME ${PARSED_ARGS_TEST_PREFIX}_${TARGET}
       COMMAND ${TEST_NAME})
   endforeach()
-endfunction(add_shaderc_tests)
+endfunction(shaderc_add_tests)
 
 # Finds all transitive static library dependencies of a given target.
 # This will skip libraries that were statically linked that were not
 # built by CMake, for example -lpthread.
-macro(get_transitive_libs target out_list)
+macro(shaderc_get_transitive_libs target out_list)
   if (TARGET ${target})
     get_target_property(libtype ${target} TYPE)
     # If this target is a static library, get anything it depends on.
@@ -102,7 +102,7 @@ macro(get_transitive_libs target out_list)
       get_target_property(libs ${target} LINK_LIBRARIES)
       if (libs)
         foreach(lib ${libs})
-          get_transitive_libs(${lib} ${out_list})
+          shaderc_get_transitive_libs(${lib} ${out_list})
         endforeach()
       endif()
     endif()
@@ -118,13 +118,13 @@ endmacro()
 
 # Combines the static library "target" with all of its transitive static library
 # dependencies into a single static library "new_target".
-function(combine_static_lib new_target target)
+function(shaderc_combine_static_lib new_target target)
   if ("${MSVC}")
     message(FATAL_ERROR "MSVC does not yet support merging static libraries")
   endif()
 
   set(all_libs "")
-  get_transitive_libs(${target} all_libs)
+  shaderc_get_transitive_libs(${target} all_libs)
 
   if(APPLE)
     string(REPLACE ";" " " all_libs_string "${all_libs}")

--- a/glslc/CMakeLists.txt
+++ b/glslc/CMakeLists.txt
@@ -11,24 +11,24 @@ add_library(glslc STATIC
   src/shader_stage.h
 )
 
-default_compile_options(glslc)
+shaderc_default_compile_options(glslc)
 target_include_directories(glslc PUBLIC ${glslang_SOURCE_DIR})
 target_link_libraries(glslc PRIVATE glslang OSDependent OGLCompiler
   glslang SPIRV ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(glslc PRIVATE shaderc_util)
 
 add_executable(glslc_exe src/main.cc)
-default_compile_options(glslc_exe)
+shaderc_default_compile_options(glslc_exe)
 set_target_properties(glslc_exe PROPERTIES OUTPUT_NAME glslc)
 target_link_libraries(glslc_exe PRIVATE glslc shaderc_util)
 
-add_shaderc_tests(
+shaderc_add_tests(
   TEST_PREFIX glslc
   LINK_LIBS glslc shaderc_util
   TEST_NAMES
     file
     stage)
 
-add_asciidoc(glslc_doc_README README)
+shaderc_add_asciidoc(glslc_doc_README README)
 
 add_subdirectory(test)

--- a/glslc/test/CMakeLists.txt
+++ b/glslc/test/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_nosetests(expect)
-add_nosetests(glslc_test_framework)
+shaderc_add_nosetests(expect)
+shaderc_add_nosetests(glslc_test_framework)
 
 add_test(NAME glslc_tests
   COMMAND ${PYTHON_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/glslc_test_framework.py

--- a/libshaderc/CMakeLists.txt
+++ b/libshaderc/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(shaderc STATIC
   src/shaderc_private.h
 )
 
-default_compile_options(shaderc)
+shaderc_default_compile_options(shaderc)
 target_include_directories(shaderc PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
 find_package(Threads)
 target_link_libraries(shaderc PRIVATE
@@ -15,7 +15,7 @@ target_link_libraries(shaderc PRIVATE shaderc_util)
 target_link_libraries(shaderc PRIVATE SPIRV)
 
 
-add_shaderc_tests(
+shaderc_add_tests(
   TEST_PREFIX shaderc
   LINK_LIBS shaderc
   INCLUDE_DIRS include ${glslang_SOURCE_DIR}
@@ -27,8 +27,8 @@ add_shaderc_tests(
 if (NOT "${MSVC}")
   # If we are not on windows, then create a single static library
   # that contains everything needed to use shaderc.
-  combine_static_lib(shaderc_combined shaderc)
-  add_shaderc_tests(
+  shaderc_combine_static_lib(shaderc_combined shaderc)
+  shaderc_add_tests(
     TEST_PREFIX shaderc_combined
     LINK_LIBS shaderc_combined ${CMAKE_THREAD_LIBS_INIT}
     INCLUDE_DIRS include ${glslang_SOURCE_DIR}

--- a/libshaderc_util/CMakeLists.txt
+++ b/libshaderc_util/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(shaderc_util STATIC
   src/version_profile.cc
 )
 
-default_compile_options(shaderc_util)
+shaderc_default_compile_options(shaderc_util)
 target_include_directories(shaderc_util
   PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
 find_package(Threads)
@@ -27,7 +27,7 @@ target_link_libraries(shaderc_util PRIVATE
   glslang OSDependent OGLCompiler glslang SPIRV
   SPIRV-Tools ${CMAKE_THREAD_LIBS_INIT})
 
-add_shaderc_tests(
+shaderc_add_tests(
   TEST_PREFIX shaderc_util
   LINK_LIBS shaderc_util
   TEST_NAMES
@@ -41,7 +41,7 @@ add_shaderc_tests(
 target_include_directories(shaderc_util_counting_includer_test
   PRIVATE ${glslang_SOURCE_DIR})
 
-add_shaderc_tests(
+shaderc_add_tests(
   TEST_PREFIX shaderc_util
   LINK_LIBS shaderc_util
   INCLUDE_DIRS ${glslang_SOURCE_DIR}


### PR DESCRIPTION
If a third-party project defines a CMake function with the same
name, by importing that project's CMake configuration, we may end
up overwriting our own copy. Qualify all defined functions to
reduce that probability.

Counterpart for https://github.com/KhronosGroup/SPIRV-Tools/pull/85