### PR TITLE
Libshaderc rename kind to stage

### DIFF
--- a/glslc/src/file_compiler.cc
+++ b/glslc/src/file_compiler.cc
@@ -31,7 +31,7 @@ using shaderc_util::string_piece;
 
 namespace glslc {
 bool FileCompiler::CompileShaderFile(const std::string& input_file,
-                                     shaderc_shader_kind shader_stage) {
+                                     shaderc_shader_stage shader_stage) {
   std::vector<char> input_data;
   std::string path = input_file;
   if (!workdir_.empty() && !shaderc_util::IsAbsolutePath(path)) {
@@ -75,7 +75,7 @@ bool FileCompiler::CompileShaderFile(const std::string& input_file,
   bool compilation_success =
       result.GetCompilationStatus() == shaderc_compilation_status_success;
 
-  // Handle the error message for failing to deduce the shader kind.
+  // Handle the error message for failing to deduce the shader stage.
   if (result.GetCompilationStatus() ==
       shaderc_compilation_status_invalid_stage) {
     if (IsGlslFile(error_file_name)) {

--- a/glslc/src/file_compiler.h
+++ b/glslc/src/file_compiler.h
@@ -43,7 +43,7 @@ class FileCompiler {
   // Any errors/warnings found in the shader source will be output to std::cerr
   // and increment the counts reported by OutputMessages().
   bool CompileShaderFile(const std::string& input_file,
-                         shaderc_shader_kind shader_stage);
+                         shaderc_shader_stage shader_stage);
 
   // Sets the working directory for the compilation.
   void SetWorkingDirectory(const std::string& dir);

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -98,8 +98,8 @@ bool GetOptionArgument(int argc, char** argv, int* index,
 }  // anonymous namespace
 
 int main(int argc, char** argv) {
-  std::vector<std::pair<std::string, shaderc_shader_kind>> input_files;
-  shaderc_shader_kind current_fshader_stage = shaderc_glsl_infer_from_source;
+  std::vector<std::pair<std::string, shaderc_shader_stage>> input_files;
+  shaderc_shader_stage current_fshader_stage = shaderc_glsl_infer_from_source;
   glslc::FileCompiler compiler;
   bool success = true;
   bool has_stdin_input = false;
@@ -141,7 +141,7 @@ int main(int argc, char** argv) {
       compiler.SetWorkingDirectory(workdir.str());
     } else if (arg.starts_with("-fshader-stage=")) {
       const string_piece stage = arg.substr(std::strlen("-fshader-stage="));
-      current_fshader_stage = glslc::GetForcedShaderKindFromCmdLine(arg);
+      current_fshader_stage = glslc::GetForcedShaderStageFromCmdLine(arg);
       if (current_fshader_stage == shaderc_glsl_infer_from_source) {
         std::cerr << "glslc: error: stage not recognized: '" << stage << "'"
                   << std::endl;
@@ -255,13 +255,13 @@ int main(int argc, char** argv) {
       }
 
       // If current_fshader_stage is shaderc_glsl_infer_from_source, that means
-      // we didn't set forced shader kinds (otherwise an error should have
-      // already been emitted before). So we should deduce the shader kind
+      // we didn't set forced shader stages (otherwise an error should have
+      // already been emitted before). So we should deduce the shader stage
       // from the file name. If current_fshader_stage is specifed to one of
-      // the forced shader kinds, use that for the following compilation.
+      // the forced shader stages, use that for the following compilation.
       input_files.emplace_back(
           arg.str(), current_fshader_stage == shaderc_glsl_infer_from_source
-                         ? glslc::DeduceDefaultShaderKindFromFileName(arg)
+                         ? glslc::DeduceDefaultShaderStageFromFileName(arg)
                          : current_fshader_stage );
     }
   }
@@ -272,7 +272,7 @@ int main(int argc, char** argv) {
 
   for (const auto& input_file : input_files) {
     const std::string& name = input_file.first;
-    const shaderc_shader_kind stage = input_file.second;
+    const shaderc_shader_stage stage = input_file.second;
 
     success &= compiler.CompileShaderFile(name, stage);
   }

--- a/glslc/src/shader_stage.cc
+++ b/glslc/src/shader_stage.cc
@@ -25,35 +25,35 @@ namespace {
 // Maps an identifier to a shader stage.
 struct StageMapping {
   const char* id;
-  shaderc_shader_kind stage;
+  shaderc_shader_stage stage;
 };
 
 }  // anonymous namespace
 
 namespace glslc {
 
-shaderc_shader_kind MapStageNameToForcedKind(const string_piece& stage_name) {
-  const StageMapping string_to_kind[] = {
+shaderc_shader_stage MapStageNameToForcedShaderStage(const string_piece& stage_name) {
+  const StageMapping string_to_stage[] = {
       {"vertex", shaderc_glsl_vertex_shader},
       {"fragment", shaderc_glsl_fragment_shader},
       {"tesscontrol", shaderc_glsl_tess_control_shader},
       {"tesseval", shaderc_glsl_tess_evaluation_shader},
       {"geometry", shaderc_glsl_geometry_shader},
       {"compute", shaderc_glsl_compute_shader}};
-  for (const auto& entry : string_to_kind) {
+  for (const auto& entry : string_to_stage) {
     if (stage_name == entry.id) return entry.stage;
   }
   return shaderc_glsl_infer_from_source;
 }
 
-shaderc_shader_kind GetForcedShaderKindFromCmdLine(
+shaderc_shader_stage GetForcedShaderStageFromCmdLine(
     const shaderc_util::string_piece& f_shader_stage_str) {
   size_t equal_pos = f_shader_stage_str.find_first_of("=");
   if (equal_pos == std::string::npos) return shaderc_glsl_infer_from_source;
-  return MapStageNameToForcedKind(f_shader_stage_str.substr(equal_pos + 1));
+  return MapStageNameToForcedShaderStage(f_shader_stage_str.substr(equal_pos + 1));
 }
 
-shaderc_shader_kind DeduceDefaultShaderKindFromFileName(
+shaderc_shader_stage DeduceDefaultShaderStageFromFileName(
     const string_piece file_name) {
   // Add new stage types here.
   static const StageMapping kStringToStage[] = {
@@ -65,7 +65,7 @@ shaderc_shader_kind DeduceDefaultShaderKindFromFileName(
       {"comp", shaderc_glsl_default_compute_shader}};
 
   const string_piece extension = glslc::GetFileExtension(file_name);
-  shaderc_shader_kind stage = shaderc_glsl_infer_from_source;
+  shaderc_shader_stage stage = shaderc_glsl_infer_from_source;
 
   for (const auto& entry : kStringToStage) {
     if (extension == entry.id) stage = entry.stage;

--- a/glslc/src/shader_stage.h
+++ b/glslc/src/shader_stage.h
@@ -26,11 +26,11 @@ namespace glslc {
 // If the 'f_shader_stage_str' cannot be parsed to a valid force shader stage,
 // returns 'shaderc_glsl_infer_from_source' and an error should be emitted at
 // the caller site.
-shaderc_shader_kind GetForcedShaderKindFromCmdLine(
+shaderc_shader_stage GetForcedShaderStageFromCmdLine(
     const shaderc_util::string_piece& f_shader_stage_str);
 
 // Parse the file name extension to get the default shader kind.
-shaderc_shader_kind DeduceDefaultShaderKindFromFileName(
+shaderc_shader_stage DeduceDefaultShaderStageFromFileName(
     shaderc_util::string_piece file_name);
 }  // namespace glslc
 

--- a/glslc/src/stage_test.cc
+++ b/glslc/src/stage_test.cc
@@ -28,40 +28,40 @@ using shaderc_util::string_piece;
 
 namespace {
 
-TEST(DeduceDefaultShaderKindFromFileName, ValidStage) {
+TEST(DeduceDefaultShaderStageFromFileName, ValidStage) {
   std::stringstream error_stream;
   EXPECT_EQ(shaderc_glsl_default_vertex_shader,
-            glslc::DeduceDefaultShaderKindFromFileName("a.vert"));
+            glslc::DeduceDefaultShaderStageFromFileName("a.vert"));
 
   EXPECT_EQ(shaderc_glsl_default_fragment_shader,
-            glslc::DeduceDefaultShaderKindFromFileName("a.frag"));
+            glslc::DeduceDefaultShaderStageFromFileName("a.frag"));
 
   EXPECT_EQ(shaderc_glsl_default_geometry_shader,
-            glslc::DeduceDefaultShaderKindFromFileName("a.geom"));
+            glslc::DeduceDefaultShaderStageFromFileName("a.geom"));
 
   EXPECT_EQ(shaderc_glsl_default_tess_control_shader,
-            glslc::DeduceDefaultShaderKindFromFileName("a.tesc"));
+            glslc::DeduceDefaultShaderStageFromFileName("a.tesc"));
 
   EXPECT_EQ(shaderc_glsl_default_tess_evaluation_shader,
-            glslc::DeduceDefaultShaderKindFromFileName("a.tese"));
+            glslc::DeduceDefaultShaderStageFromFileName("a.tese"));
 
   EXPECT_EQ(shaderc_glsl_default_compute_shader,
-            glslc::DeduceDefaultShaderKindFromFileName("a.comp"));
+            glslc::DeduceDefaultShaderStageFromFileName("a.comp"));
 }
 
-TEST(DeduceDefaultShaderKindFromFileName, InvalidStage) {
+TEST(DeduceDefaultShaderStageFromFileName, InvalidStage) {
   std::stringstream error_stream;
   EXPECT_EQ(shaderc_glsl_infer_from_source,
-            glslc::DeduceDefaultShaderKindFromFileName("a.glsl"));
+            glslc::DeduceDefaultShaderStageFromFileName("a.glsl"));
 
   EXPECT_EQ(shaderc_glsl_infer_from_source,
-            glslc::DeduceDefaultShaderKindFromFileName("-"));
+            glslc::DeduceDefaultShaderStageFromFileName("-"));
 
   EXPECT_EQ(shaderc_glsl_infer_from_source,
-            glslc::DeduceDefaultShaderKindFromFileName("a.foo"));
+            glslc::DeduceDefaultShaderStageFromFileName("a.foo"));
 
   EXPECT_EQ(shaderc_glsl_infer_from_source,
-            glslc::DeduceDefaultShaderKindFromFileName("no-file-extension"));
+            glslc::DeduceDefaultShaderStageFromFileName("no-file-extension"));
 }
 
 }  // anonymous namespace

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -24,7 +24,7 @@ extern "C" {
 #include <stdint.h>
 
 typedef enum {
-  // Forced shader stages. These shader stagesforce the compiler to compile the
+  // Forced shader stages. These shader stages force the compiler to compile the
   // source code as the specified stage of shader.
   shaderc_glsl_vertex_shader,
   shaderc_glsl_fragment_shader,

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -44,7 +44,7 @@ typedef enum {
   shaderc_glsl_default_geometry_shader,
   shaderc_glsl_default_tess_control_shader,
   shaderc_glsl_default_tess_evaluation_shader,
-} shaderc_shader_kind;
+} shaderc_shader_stage;
 
 typedef enum {
   shaderc_target_env_vulkan,         // create SPIR-V under Vulkan semantics
@@ -260,7 +260,7 @@ typedef struct shaderc_spv_module* shaderc_spv_module_t;
 // was failure in allocating the compiler object NULL will be returned.
 shaderc_spv_module_t shaderc_compile_into_spv(
     const shaderc_compiler_t compiler, const char* source_text,
-    size_t source_text_size, shaderc_shader_kind shader_kind,
+    size_t source_text_size, shaderc_shader_stage shader_kind,
     const char* input_file_name, const char* entry_point_name,
     const shaderc_compile_options_t additional_options);
 

--- a/libshaderc/include/shaderc.h
+++ b/libshaderc/include/shaderc.h
@@ -24,20 +24,20 @@ extern "C" {
 #include <stdint.h>
 
 typedef enum {
-  // Forced shader kinds. These shader kinds force the compiler to compile the
-  // source code as the specified kind of shader.
+  // Forced shader stages. These shader stagesforce the compiler to compile the
+  // source code as the specified stage of shader.
   shaderc_glsl_vertex_shader,
   shaderc_glsl_fragment_shader,
   shaderc_glsl_compute_shader,
   shaderc_glsl_geometry_shader,
   shaderc_glsl_tess_control_shader,
   shaderc_glsl_tess_evaluation_shader,
-  // Deduce the shader kind from #pragma annotation in the source code. Compiler
-  // will emit error if #pragma annotation is not found.
+  // Deduce the shader stage from #pragma annotation in the source code.
+  // Compiler will emit error if #pragma annotation is not found.
   shaderc_glsl_infer_from_source,
-  // Default shader kinds. Compiler will fall back to compile the source code as
-  // the specified kind of shader when #pragma annotation is not found in the
-  // source code.
+  // Default shader stages. Compiler will fall back to compile the source code
+  // as the specified stage of shader when #pragma annotation is not found in
+  // the source code.
   shaderc_glsl_default_vertex_shader,
   shaderc_glsl_default_fragment_shader,
   shaderc_glsl_default_compute_shader,
@@ -154,7 +154,7 @@ void shaderc_compile_options_set_generate_debug_info(
 // Sets the compiler mode to emit a disassembly text instead of a binary. In
 // this mode, the byte array result in the shaderc_spv_module returned
 // from shaderc_compile_into_spv() will consist of SPIR-V assembly text.
-// Note the preprocessing only mode overrides this option, and this option
+// Note the preprocessing-only mode overrides this option, and this option
 // overrides the default mode generating a SPIR-V binary.
 void shaderc_compile_options_set_disassembly_mode(
     shaderc_compile_options_t options);
@@ -237,20 +237,20 @@ void shaderc_compile_options_set_warnings_as_errors(
 // An opaque handle to the results of a call to shaderc_compile_into_spv().
 typedef struct shaderc_spv_module* shaderc_spv_module_t;
 
-// Takes a GLSL source string and the associated shader kind, input file
+// Takes a GLSL source string and the associated shader stage, input file
 // name, compiles it according to the given additional_options. If the shader
-// kind is not set to a specified kind, but shaderc_glslc_infer_from_source,
-// the compiler will try to deduce the shader kind from the source
+// stage is not set to a specified stage, but shaderc_glslc_infer_from_source,
+// the compiler will try to deduce the shader stage from the source
 // string and a failure in deducing will generate an error. Currently only
-// #pragma annotation is supported. If the shader kind is set to one of the
-// default shader kinds, the compiler will fall back to the default shader
-// kind in case it failed to deduce the shader kind from source string.
+// #pragma annotation is supported. If the shader stage is set to one of the
+// default shader stages, the compiler will fall back to the default shader
+// stage in case it failed to deduce the shader stage from source string.
 // The input_file_name is a null-termintated string. It is used as a tag to
 // identify the source string in cases like emitting error messages. It
 // doesn't have to be a 'file name'.
 // By default the source string will be compiled into SPIR-V binary
 // and a shaderc_spv_module will be returned to hold the results of the
-// compilation. When disassembly mode or preprocessing only mode is enabled
+// compilation. When disassembly mode or preprocessing-only mode is enabled
 // in the additional_options, the source string will be compiled into char
 // strings and held by the returned shaderc_spv_module.  The entry_point_name
 // null-terminated string defines the name of the entry point to associate
@@ -260,7 +260,7 @@ typedef struct shaderc_spv_module* shaderc_spv_module_t;
 // was failure in allocating the compiler object NULL will be returned.
 shaderc_spv_module_t shaderc_compile_into_spv(
     const shaderc_compiler_t compiler, const char* source_text,
-    size_t source_text_size, shaderc_shader_stage shader_kind,
+    size_t source_text_size, shaderc_shader_stage shader_stage,
     const char* input_file_name, const char* entry_point_name,
     const shaderc_compile_options_t additional_options);
 
@@ -275,7 +275,7 @@ void shaderc_module_release(shaderc_spv_module_t module);
 bool shaderc_module_get_success(const shaderc_spv_module_t module);
 
 // Returns the number of bytes in a SPIR-V module result string. When the module
-// is compiled with disassembly mode or preprocessing only mode, the result
+// is compiled with disassembly mode or preprocessing-only mode, the result
 // string is a char string. Otherwise, the result string is binary string.
 size_t shaderc_module_get_length(const shaderc_spv_module_t module);
 
@@ -294,7 +294,7 @@ shaderc_compilation_status shaderc_module_get_compilation_status(
 // Returns a pointer to the start of the SPIR-V bytes, either SPIR-V binary or
 // char string. When the source string is compiled into SPIR-V binary, this is
 // guaranteed to be castable to a uint32_t*. If the source string is compiled in
-// disassembly mode or preprocessing only mode, the pointer will point to the
+// disassembly mode or preprocessing-only mode, the pointer will point to the
 // result char string.
 const char* shaderc_module_get_bytes(const shaderc_spv_module_t module);
 

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -162,7 +162,7 @@ class CompileOptions {
   // Sets the compiler to emit a disassembly text instead of a binary. In
   // this mode, the byte array result in the shaderc_spv_module returned
   // from shaderc_compile_into_spv() will consist of SPIR-V assembly text.
-  // Note the preprocessing only mode overrides this option, and this option
+  // Note the preprocessing-only mode overrides this option, and this option
   // overrides the default mode generating a SPIR-V binary.
   void SetDisassemblyMode() {
     shaderc_compile_options_set_disassembly_mode(options_);
@@ -235,14 +235,14 @@ class Compiler {
   // Compiles the given source GLSL into a SPIR-V module.
   // The source_text parameter must be a valid pointer.
   // The source_text_size parameter must be the length of the source text.
-  // The shader_kind parameter either forces the compilation to be done with a
-  // specified shader kind, or hint the compiler how to determine the exact
-  // shader kind. If the shader kind is set to shaderc_glslc_infer_from_source,
-  // the compiler will try to deduce the shader kind from the source string and
+  // The shader_stage parameter either forces the compilation to be done with a
+  // specified shader stage, or hint the compiler how to determine the exact
+  // shader stage. If the shader stage is set to shaderc_glslc_infer_from_source,
+  // the compiler will try to deduce the shader stage from the source string and
   // a failure in this proess will generate an error. Currently only #pragma
-  // annotation is supported. If the shader kind is set to one of the default
-  // shader kinds, the compiler will fall back to the specified default shader
-  // kind in case it failed to deduce the shader kind from the source string.
+  // annotation is supported. If the shader stage is set to one of the default
+  // shader stages, the compiler will fall back to the specified default shader
+  // stage in case it failed to deduce the shader stage from the source string.
   // The input_file_name is a null-termintated string. It is used as a tag to
   // identify the source string in cases like emitting error messages. It
   // doesn't have to be a 'file name'.
@@ -250,25 +250,25 @@ class Compiler {
   // It is valid for the returned SpvModule object to outlive this compiler
   // object.
   SpvModule CompileGlslToSpv(const char* source_text, size_t source_text_size,
-                             shaderc_shader_stage shader_kind,
+                             shaderc_shader_stage shader_stage,
                              const char* input_file_name) const {
     shaderc_spv_module_t module =
         shaderc_compile_into_spv(compiler_, source_text, source_text_size,
-                                 shader_kind, input_file_name, "main", nullptr);
+                                 shader_stage, input_file_name, "main", nullptr);
     return SpvModule(module);
   }
 
   // Compiles the given source GLSL into a SPIR-V module.
   // The source_text parameter must be a valid pointer.
   // The source_text_size parameter must be the length of the source text.
-  // The shader_kind parameter either forces the compilation to be done with a
-  // specified shader kind, or hint the compiler how to determine the exact
-  // shader kind. If the shader kind is set to shaderc_glslc_infer_from_source,
-  // the compiler will try to deduce the shader kind from the source string and
+  // The shader_stage parameter either forces the compilation to be done with a
+  // specified shader stage, or hint the compiler how to determine the exact
+  // shader stage. If the shader stage is set to shaderc_glslc_infer_from_source,
+  // the compiler will try to deduce the shader stage from the source string and
   // a failure in this proess will generate an error. Currently only #pragma
-  // annotation is supported. If the shader kind is set to one of the default
-  // shader kinds, the compiler will fall back to the specified default shader
-  // kind in case it failed to deduce the shader kind from the source string.
+  // annotation is supported. If the shader stage is set to one of the default
+  // shader stages, the compiler will fall back to the specified default shader
+  // stage in case it failed to deduce the shader stage from the source string.
   // The input_file_name is a null-termintated string. It is used as a tag to
   // identify the source string in cases like emitting error messages. It
   // doesn't have to be a 'file name'.
@@ -276,36 +276,36 @@ class Compiler {
   // parameter.
   // It is valid for the returned SpvModule object to outlive this compiler
   // object.
-  // Note when the options_ has disassembly mode or preprocessing only mode set
+  // Note when the options_ has disassembly mode or preprocessing-only mode set
   // on, the returned SpvModule will hold a text string, instead of a SPIR-V
   // binary generated with default options.
   SpvModule CompileGlslToSpv(const char* source_text, size_t source_text_size,
-                             shaderc_shader_stage shader_kind,
+                             shaderc_shader_stage shader_stage,
                              const char* input_file_name,
                              const CompileOptions& options) const {
     shaderc_spv_module_t module = shaderc_compile_into_spv(
-        compiler_, source_text, source_text_size, shader_kind, input_file_name,
+        compiler_, source_text, source_text_size, shader_stage, input_file_name,
         "main", options.options_);
     return SpvModule(module);
   }
 
   // Compiles the given source GLSL into a SPIR-V module by invoking
-  // CompileGlslToSpv(const char*, size_t, shaderc_shader_kind, const char*);
+  // CompileGlslToSpv(const char*, size_t, shaderc_shader_stage, const char*);
   SpvModule CompileGlslToSpv(const std::string& source_text,
-                             shaderc_shader_stage shader_kind,
+                             shaderc_shader_stage shader_stage,
                              const char* input_file_name) const {
-    return CompileGlslToSpv(source_text.data(), source_text.size(), shader_kind,
+    return CompileGlslToSpv(source_text.data(), source_text.size(), shader_stage,
                             input_file_name);
   }
 
   // Compiles the given source GLSL into a SPIR-V module by invoking
-  // CompileGlslToSpv(const char*, size_t, shaderc_shader_kind, const char*,
+  // CompileGlslToSpv(const char*, size_t, shaderc_shader_stage, const char*,
   // options);
   SpvModule CompileGlslToSpv(const std::string& source_text,
-                             shaderc_shader_stage shader_kind,
+                             shaderc_shader_stage shader_stage,
                              const char* input_file_name,
                              const CompileOptions& options) const {
-    return CompileGlslToSpv(source_text.data(), source_text.size(), shader_kind,
+    return CompileGlslToSpv(source_text.data(), source_text.size(), shader_stage,
                             input_file_name, options);
   }
 

--- a/libshaderc/include/shaderc.hpp
+++ b/libshaderc/include/shaderc.hpp
@@ -250,7 +250,7 @@ class Compiler {
   // It is valid for the returned SpvModule object to outlive this compiler
   // object.
   SpvModule CompileGlslToSpv(const char* source_text, size_t source_text_size,
-                             shaderc_shader_kind shader_kind,
+                             shaderc_shader_stage shader_kind,
                              const char* input_file_name) const {
     shaderc_spv_module_t module =
         shaderc_compile_into_spv(compiler_, source_text, source_text_size,
@@ -280,7 +280,7 @@ class Compiler {
   // on, the returned SpvModule will hold a text string, instead of a SPIR-V
   // binary generated with default options.
   SpvModule CompileGlslToSpv(const char* source_text, size_t source_text_size,
-                             shaderc_shader_kind shader_kind,
+                             shaderc_shader_stage shader_kind,
                              const char* input_file_name,
                              const CompileOptions& options) const {
     shaderc_spv_module_t module = shaderc_compile_into_spv(
@@ -292,7 +292,7 @@ class Compiler {
   // Compiles the given source GLSL into a SPIR-V module by invoking
   // CompileGlslToSpv(const char*, size_t, shaderc_shader_kind, const char*);
   SpvModule CompileGlslToSpv(const std::string& source_text,
-                             shaderc_shader_kind shader_kind,
+                             shaderc_shader_stage shader_kind,
                              const char* input_file_name) const {
     return CompileGlslToSpv(source_text.data(), source_text.size(), shader_kind,
                             input_file_name);
@@ -302,7 +302,7 @@ class Compiler {
   // CompileGlslToSpv(const char*, size_t, shaderc_shader_kind, const char*,
   // options);
   SpvModule CompileGlslToSpv(const std::string& source_text,
-                             shaderc_shader_kind shader_kind,
+                             shaderc_shader_stage shader_kind,
                              const char* input_file_name,
                              const CompileOptions& options) const {
     return CompileGlslToSpv(source_text.data(), source_text.size(), shader_kind,

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -78,7 +78,7 @@ const char kOpenGLVertexShader[] =
     R"(#version 150
        void main() { int t = gl_VertexID; })";
 
-// Empty 310 es shader. It is valid for vertex, fragment, compute shader kind.
+// Empty 310 es shader. It is valid for vertex, fragment, compute shader stage.
 const char kEmpty310ESShader[] =
     "#version 310 es\n"
     "void main() {}\n";

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -37,11 +37,11 @@
 
 namespace {
 
-// Returns shader stage (ie: vertex, fragment, etc.) in response to forced
-// shader stages. If the shader stage is not a forced stage, returns
-// EshLangCount to let #pragma annotation or shader stage deducer determine the
-// stage to use.
-EShLanguage GetForcedStage(shaderc_shader_stage stage) {
+// Returns glslang shader stage (ie: vertex, fragment, etc.) in response to
+// shaderc forced shader stages. If the shader stage is not a forced stage,
+// returns EshLangCount to let #pragma annotation or shader stage deducer
+// determine the stage to use.
+EShLanguage GetForcedGlslangStage(shaderc_shader_stage stage) {
   switch (stage) {
     case shaderc_glsl_vertex_shader:
       return EShLangVertex;
@@ -122,7 +122,7 @@ class StageDeducer {
   // call.
   EShLanguage operator()(std::ostream* /*error_stream*/,
                          const shaderc_util::string_piece& /*error_tag*/) {
-    EShLanguage stage = GetDefaultStage(stage_);
+    EShLanguage stage = GetDefaultGlslangStage(stage_);
     if (stage == EShLangCount) {
       error_ = true;
     } else {
@@ -135,9 +135,10 @@ class StageDeducer {
   bool error() const { return error_; }
 
  private:
-  // Gets the corresponding shader stage for a given 'default' shader stage. All
-  // other stages are mapped to EShLangCount which should not be used.
-  EShLanguage GetDefaultStage(shaderc_shader_stage stage) const {
+  // Gets the corresponding glslang shader stage for a given shaderc 'default'
+  // shader stage. All other shaderc stages are mapped to EShLangCount which
+  // should not be used.
+  EShLanguage GetDefaultGlslangStage(shaderc_shader_stage stage) const {
     switch (stage) {
       case shaderc_glsl_vertex_shader:
       case shaderc_glsl_fragment_shader:
@@ -368,7 +369,7 @@ shaderc_spv_module_t shaderc_compile_into_spv(
     size_t total_warnings = 0;
     size_t total_errors = 0;
     std::string input_file_name_str(input_file_name);
-    EShLanguage forced_stage = GetForcedStage(shader_stage);
+    EShLanguage forced_stage = GetForcedGlslangStage(shader_stage);
     shaderc_util::string_piece source_string =
         shaderc_util::string_piece(source_text, source_text + source_text_size);
     StageDeducer stage_deducer(shader_stage);

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -41,7 +41,7 @@ namespace {
 // shader kinds. If the shader kind is not a forced kind, returns EshLangCount
 // to let #pragma annotation or shader stage deducer determine the stage to
 // use.
-EShLanguage GetForcedStage(shaderc_shader_kind kind) {
+EShLanguage GetForcedStage(shaderc_shader_stage kind) {
   switch (kind) {
     case shaderc_glsl_vertex_shader:
       return EShLangVertex;
@@ -108,7 +108,7 @@ std::mutex compile_mutex;  // Guards shaderc_compile_*.
 // case.
 class StageDeducer {
  public:
-  StageDeducer(shaderc_shader_kind kind = shaderc_glsl_infer_from_source)
+  StageDeducer(shaderc_shader_stage kind = shaderc_glsl_infer_from_source)
       : kind_(kind), error_(false){};
   // The method that underlying glslang will call to determine the shader stage
   // to be used in current compilation. It is called only when there is neither
@@ -137,7 +137,7 @@ class StageDeducer {
  private:
   // Gets the corresponding shader stage for a given 'default' shader kind. All
   // other kinds are mapped to EShLangCount which should not be used.
-  EShLanguage GetDefaultStage(shaderc_shader_kind kind) const {
+  EShLanguage GetDefaultStage(shaderc_shader_stage kind) const {
     switch (kind) {
       case shaderc_glsl_vertex_shader:
       case shaderc_glsl_fragment_shader:
@@ -164,7 +164,7 @@ class StageDeducer {
     return EShLangCount;
   }
 
-  shaderc_shader_kind kind_;
+  shaderc_shader_stage kind_;
   bool error_;
 };
 
@@ -349,7 +349,7 @@ void shaderc_compiler_release(shaderc_compiler_t compiler) {
 
 shaderc_spv_module_t shaderc_compile_into_spv(
     const shaderc_compiler_t compiler, const char* source_text,
-    size_t source_text_size, shaderc_shader_kind shader_kind,
+    size_t source_text_size, shaderc_shader_stage shader_kind,
     const char* input_file_name, const char* entry_point_name,
     const shaderc_compile_options_t additional_options) {
   std::lock_guard<std::mutex> lock(compile_mutex);

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -535,7 +535,7 @@ TEST_F(CppInterface, PreprocessingOnlyModeSecondOverridesDisassemblyMode) {
 }
 
 // A shader stage test cases needs: 1) A shader text with or without #pragma
-// annotation, 2) shader_stage.
+// annotation, 2) shader stage.
 struct ShaderStageTestCase {
   const char* shader_;
   shaderc_shader_stage shader_stage_;

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -31,7 +31,7 @@ using testing::HasSubstr;
 
 // Helper function to check if the compilation result indicates a successful
 // compilation.
-bool CompilationResultIsSuccess(const shaderc::SpvModule& result_module) {
+bool CompilationStatusIsSuccess(const shaderc::SpvModule& result_module) {
   return result_module.GetCompilationStatus() ==
          shaderc_compilation_status_success;
 }
@@ -41,7 +41,7 @@ bool CompilationResultIsSuccess(const shaderc::SpvModule& result_module) {
 // true if the magic number is found at the correct postion, otherwise returns
 // false.
 bool IsValidSpv(const shaderc::SpvModule& result) {
-  if (!CompilationResultIsSuccess(result)) return false;
+  if (!CompilationStatusIsSuccess(result)) return false;
   size_t length = result.GetLength();
   if (length < 20) return false;
   const uint32_t* bytes =
@@ -52,16 +52,19 @@ bool IsValidSpv(const shaderc::SpvModule& result) {
 // Compiles a shader and returns true if the result is valid SPIR-V. The
 // input_file_name is set to "shader".
 bool CompilesToValidSpv(const shaderc::Compiler& compiler,
-                        const std::string& shader, shaderc_shader_stage kind) {
-  return IsValidSpv(compiler.CompileGlslToSpv(shader, kind, "shader"));
+                        const std::string& shader,
+                        shaderc_shader_stage shader_stage) {
+  return IsValidSpv(compiler.CompileGlslToSpv(shader, shader_stage, "shader"));
 }
 
 // Compiles a shader with options and returns true if the result is valid
 // SPIR-V. The input_file_name is set to "shader".
 bool CompilesToValidSpv(const shaderc::Compiler& compiler,
-                        const std::string& shader, shaderc_shader_stage kind,
+                        const std::string& shader,
+                        shaderc_shader_stage shader_stage,
                         const CompileOptions& options) {
-  return IsValidSpv(compiler.CompileGlslToSpv(shader, kind, "shader", options));
+  return IsValidSpv(
+      compiler.CompileGlslToSpv(shader, shader_stage, "shader", options));
 }
 
 class CppInterface : public testing::Test {
@@ -69,49 +72,53 @@ class CppInterface : public testing::Test {
   // Compiles a shader and returns true on success, false on failure.
   // The input file name is set to "shader" by default.
   bool CompilationSuccess(const std::string& shader,
-                          shaderc_shader_stage kind) const {
+                          shaderc_shader_stage shader_stage) const {
     return compiler_
-        .CompileGlslToSpv(shader.c_str(), shader.length(), kind, "shader")
-        .GetCompilationStatus() == shaderc_compilation_status_success;
+               .CompileGlslToSpv(shader.c_str(), shader.length(), shader_stage,
+                                 "shader")
+               .GetCompilationStatus() == shaderc_compilation_status_success;
   }
 
   // Compiles a shader with options and returns true on success, false on
   // failure.
   // The input file name is set to "shader" by default.
-  bool CompilationSuccess(const std::string& shader, shaderc_shader_stage kind,
+  bool CompilationSuccess(const std::string& shader,
+                          shaderc_shader_stage shader_stage,
                           const CompileOptions& options) const {
     return compiler_
-        .CompileGlslToSpv(shader.c_str(), shader.length(), kind, "shader",
-                          options)
-        .GetCompilationStatus() == shaderc_compilation_status_success;
+               .CompileGlslToSpv(shader.c_str(), shader.length(), shader_stage,
+                                 "shader", options)
+               .GetCompilationStatus() == shaderc_compilation_status_success;
   }
 
   // Compiles a shader, asserts compilation success, and returns the warning
   // messages.
   // The input file name is set to "shader" by default.
   std::string CompilationWarnings(
-      const std::string& shader, shaderc_shader_stage kind,
+      const std::string& shader, shaderc_shader_stage shader_stage,
       // This could default to options_, but that can
       // be easily confused with a no-options-provided
       // case:
       const CompileOptions& options) {
     const auto module =
-        compiler_.CompileGlslToSpv(shader, kind, "shader", options);
-    EXPECT_TRUE(CompilationResultIsSuccess(module)) << kind << '\n' << shader;
+        compiler_.CompileGlslToSpv(shader, shader_stage, "shader", options);
+    EXPECT_TRUE(CompilationStatusIsSuccess(module)) << shader_stage << '\n'
+                                                    << shader;
     return module.GetErrorMessage();
   }
 
   // Compiles a shader, asserts compilation fail, and returns the error
   // messages.
   std::string CompilationErrors(const std::string& shader,
-                                shaderc_shader_stage kind,
+                                shaderc_shader_stage shader_stage,
                                 // This could default to options_, but that can
                                 // be easily confused with a no-options-provided
                                 // case:
                                 const CompileOptions& options) {
     const auto module =
-        compiler_.CompileGlslToSpv(shader, kind, "shader", options);
-    EXPECT_FALSE(CompilationResultIsSuccess(module)) << kind << '\n' << shader;
+        compiler_.CompileGlslToSpv(shader, shader_stage, "shader", options);
+    EXPECT_FALSE(CompilationStatusIsSuccess(module)) << shader_stage << '\n'
+                                                     << shader;
     return module.GetErrorMessage();
   }
 
@@ -119,11 +126,11 @@ class CppInterface : public testing::Test {
   // bytes.
   // The input file name is set to "shader" by default.
   std::string CompilationOutput(const std::string& shader,
-                                shaderc_shader_stage kind,
+                                shaderc_shader_stage shader_stage,
                                 const CompileOptions& options) const {
     const auto module =
-        compiler_.CompileGlslToSpv(shader, kind, "shader", options);
-    EXPECT_TRUE(CompilationResultIsSuccess(module)) << kind << '\n';
+        compiler_.CompileGlslToSpv(shader, shader_stage, "shader", options);
+    EXPECT_TRUE(CompilationStatusIsSuccess(module)) << shader_stage << '\n';
     // Use string(const char* s, size_t n) constructor instead of
     // string(const char* s) to make sure the string has complete binary data.
     // string(const char* s) assumes a null-terminated C-string, which will cut
@@ -182,10 +189,10 @@ TEST_F(CppInterface, EmptyString) {
 TEST_F(CppInterface, ModuleMoves) {
   shaderc::SpvModule result = compiler_.CompileGlslToSpv(
       kMinimalShader, shaderc_glsl_vertex_shader, "shader");
-  EXPECT_TRUE(CompilationResultIsSuccess(result));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result));
   shaderc::SpvModule result2(std::move(result));
-  EXPECT_FALSE(CompilationResultIsSuccess(result));
-  EXPECT_TRUE(CompilationResultIsSuccess(result2));
+  EXPECT_FALSE(CompilationStatusIsSuccess(result));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result2));
 }
 
 TEST_F(CppInterface, GarbageString) {
@@ -229,8 +236,8 @@ TEST_F(CppInterface, StdAndCString) {
                                  shaderc_glsl_fragment_shader, "shader");
   shaderc::SpvModule result2 = compiler_.CompileGlslToSpv(
       std::string(kMinimalShader), shaderc_glsl_fragment_shader, "shader");
-  EXPECT_TRUE(CompilationResultIsSuccess(result1));
-  EXPECT_TRUE(CompilationResultIsSuccess(result2));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result1));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result2));
   EXPECT_EQ(result1.GetLength(), result2.GetLength());
   EXPECT_EQ(std::vector<char>(result1.GetData(),
                               result1.GetData() + result1.GetLength()),
@@ -241,7 +248,7 @@ TEST_F(CppInterface, StdAndCString) {
 TEST_F(CppInterface, ErrorsReported) {
   shaderc::SpvModule result = compiler_.CompileGlslToSpv(
       "int f(){return wrongname;}", shaderc_glsl_vertex_shader, "shader");
-  ASSERT_FALSE(CompilationResultIsSuccess(result));
+  ASSERT_FALSE(CompilationStatusIsSuccess(result));
   EXPECT_THAT(result.GetErrorMessage(), HasSubstr("wrongname"));
 }
 
@@ -261,7 +268,7 @@ TEST_F(CppInterface, MultipleThreadsCalling) {
 
 TEST_F(CppInterface, AccessorsOnNullModule) {
   shaderc::SpvModule result(nullptr);
-  EXPECT_FALSE(CompilationResultIsSuccess(result));
+  EXPECT_FALSE(CompilationStatusIsSuccess(result));
   EXPECT_EQ(std::string(), result.GetErrorMessage());
   EXPECT_EQ(std::string(), result.GetData());
   EXPECT_EQ(0u, result.GetLength());
@@ -296,7 +303,7 @@ TEST_F(CppInterface, DisassemblyOption) {
   options_.SetDisassemblyMode();
   shaderc::SpvModule result = compiler_.CompileGlslToSpv(
       kMinimalShader, shaderc_glsl_vertex_shader, "shader", options_);
-  EXPECT_TRUE(CompilationResultIsSuccess(result));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result));
   // This should work with both the glslang native disassembly format and the
   // SPIR-V Tools assembly format.
   EXPECT_THAT(result.GetData(), HasSubstr("Capability Shader"));
@@ -305,7 +312,7 @@ TEST_F(CppInterface, DisassemblyOption) {
   CompileOptions cloned_options(options_);
   shaderc::SpvModule result_from_cloned_options = compiler_.CompileGlslToSpv(
       kMinimalShader, shaderc_glsl_vertex_shader, "shader", cloned_options);
-  EXPECT_TRUE(CompilationResultIsSuccess(result_from_cloned_options));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result_from_cloned_options));
   // The mode should be carried into any clone of the original option object.
   EXPECT_THAT(result_from_cloned_options.GetData(),
               HasSubstr("Capability Shader"));
@@ -316,7 +323,7 @@ TEST_F(CppInterface, DisassembleMinimalShader) {
   options_.SetDisassemblyMode();
   shaderc::SpvModule result = compiler_.CompileGlslToSpv(
       kMinimalShader, shaderc_glsl_vertex_shader, "shader", options_);
-  EXPECT_TRUE(CompilationResultIsSuccess(result));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result));
   EXPECT_STREQ(kMinimalShaderDisassembly, result.GetData());
 }
 
@@ -429,7 +436,7 @@ TEST_F(CppInterface, GetNumErrors) {
   const shaderc::SpvModule module =
       compiler_.CompileGlslToSpv(kTwoErrorsShader, strlen(kTwoErrorsShader),
                                  shaderc_glsl_vertex_shader, "shader");
-  EXPECT_FALSE(CompilationResultIsSuccess(module));
+  EXPECT_FALSE(CompilationStatusIsSuccess(module));
   EXPECT_EQ(2u, module.GetNumErrors());
   EXPECT_EQ(0u, module.GetNumWarnings());
 }
@@ -438,7 +445,7 @@ TEST_F(CppInterface, GetNumWarnings) {
   const shaderc::SpvModule module =
       compiler_.CompileGlslToSpv(kTwoWarningsShader, strlen(kTwoWarningsShader),
                                  shaderc_glsl_vertex_shader, "shader");
-  EXPECT_TRUE(CompilationResultIsSuccess(module));
+  EXPECT_TRUE(CompilationStatusIsSuccess(module));
   EXPECT_EQ(2u, module.GetNumWarnings());
   EXPECT_EQ(0u, module.GetNumErrors());
 }
@@ -447,14 +454,14 @@ TEST_F(CppInterface, ZeroErrorsZeroWarnings) {
   const shaderc::SpvModule module =
       compiler_.CompileGlslToSpv(kMinimalShader, strlen(kMinimalShader),
                                  shaderc_glsl_vertex_shader, "shader");
-  EXPECT_TRUE(CompilationResultIsSuccess(module));
+  EXPECT_TRUE(CompilationStatusIsSuccess(module));
   EXPECT_EQ(0u, module.GetNumErrors());
   EXPECT_EQ(0u, module.GetNumWarnings());
 }
 
 TEST_F(CppInterface, ErrorTypeUnknownShaderStage) {
-  // The shader kind/stage can not be determined, the error type field should
-  // indicate the error type is shaderc_shader_kind_error.
+  // The shader stage can not be determined, the compilation status should
+  // indicate the failure is caused by invalid stage.
   const shaderc::SpvModule module =
       compiler_.CompileGlslToSpv(kMinimalShader, strlen(kMinimalShader),
                                  shaderc_glsl_infer_from_source, "shader");
@@ -463,8 +470,8 @@ TEST_F(CppInterface, ErrorTypeUnknownShaderStage) {
 }
 
 TEST_F(CppInterface, ErrorTypeCompilationError) {
-  // The shader kind is valid, the result module's error type field should
-  // indicate this compilaion fails due to compilation errors.
+  // The shader stage is valid, the compilation status should indicate this
+  // compilaion fails due to compilation errors.
   const shaderc::SpvModule module = compiler_.CompileGlslToSpv(
       kTwoErrorsShader, shaderc_glsl_vertex_shader, "shader");
   EXPECT_EQ(shaderc_compilation_status_compilation_error,
@@ -478,7 +485,7 @@ TEST_F(CppInterface, ErrorTagIsInputFileName) {
                                  shaderc_glsl_vertex_shader, "SampleInputFile");
   // Expects compilation failure errors. The error tag should be
   // 'SampleInputFile'
-  EXPECT_FALSE(CompilationResultIsSuccess(module));
+  EXPECT_FALSE(CompilationStatusIsSuccess(module));
   EXPECT_THAT(module.GetErrorMessage(), HasSubstr("SampleInputFile:2: error:"));
 }
 
@@ -486,7 +493,7 @@ TEST_F(CppInterface, PreprocessingOnlyOption) {
   options_.SetPreprocessingOnlyMode();
   shaderc::SpvModule result = compiler_.CompileGlslToSpv(
       kMinimalShaderWithMacro, shaderc_glsl_vertex_shader, "shader", options_);
-  EXPECT_TRUE(CompilationResultIsSuccess(result));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result));
   EXPECT_THAT(result.GetData(), HasSubstr("void main(){ }"));
 
   const std::string kMinimalShaderCloneOption =
@@ -496,7 +503,7 @@ TEST_F(CppInterface, PreprocessingOnlyOption) {
   shaderc::SpvModule result_from_cloned_options = compiler_.CompileGlslToSpv(
       kMinimalShaderCloneOption, shaderc_glsl_vertex_shader, "shader",
       cloned_options);
-  EXPECT_TRUE(CompilationResultIsSuccess(result_from_cloned_options));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result_from_cloned_options));
   EXPECT_THAT(result_from_cloned_options.GetData(),
               HasSubstr("void main(){ }"));
 }
@@ -510,7 +517,7 @@ TEST_F(CppInterface, PreprocessingOnlyModeFirstOverridesDisassemblyMode) {
       compiler_.CompileGlslToSpv(kMinimalShaderWithMacro,
                                  shaderc_glsl_vertex_shader, "shader",
                                  options_);
-  EXPECT_TRUE(CompilationResultIsSuccess(result_preprocessing_mode_first));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result_preprocessing_mode_first));
   EXPECT_THAT(result_preprocessing_mode_first.GetData(),
               HasSubstr("void main(){ }"));
 }
@@ -522,41 +529,41 @@ TEST_F(CppInterface, PreprocessingOnlyModeSecondOverridesDisassemblyMode) {
   options_.SetPreprocessingOnlyMode();
   shaderc::SpvModule result_disassembly_mode_first = compiler_.CompileGlslToSpv(
       kMinimalShaderWithMacro, shaderc_glsl_vertex_shader, "shader", options_);
-  EXPECT_TRUE(CompilationResultIsSuccess(result_disassembly_mode_first));
+  EXPECT_TRUE(CompilationStatusIsSuccess(result_disassembly_mode_first));
   EXPECT_THAT(result_disassembly_mode_first.GetData(),
               HasSubstr("void main(){ }"));
 }
 
-// A shader kind test cases needs: 1) A shader text with or without #pragma
-// annotation, 2) shader_kind.
-struct ShaderKindTestCase {
+// A shader stage test cases needs: 1) A shader text with or without #pragma
+// annotation, 2) shader_stage.
+struct ShaderStageTestCase {
   const char* shader_;
-  shaderc_shader_stage shader_kind_;
+  shaderc_shader_stage shader_stage_;
 };
 
-// Test the shader kind deduction process. If the shader kind is one
+// Test the shader stage deduction process. If the shader stage is one
 // of the non-default ones, the compiler will just try to compile the
-// source code in that specified shader kind. If the shader kind is
+// source code in that specified shader stage. If the shader stage is
 // shaderc_glsl_deduce_from_pragma, the compiler will determine the shader
-// kind from #pragma annotation in the source code and emit error if none
-// such annotation is found. When the shader kind is one of the default
-// ones, the compiler will fall back to use the specified shader kind if
+// stage from #pragma annotation in the source code and emit error if none
+// such annotation is found. When the shader stage is one of the default
+// ones, the compiler will fall back to use the specified shader stage if
 // and only if #pragma annoation is not found.
 
-// Valid shader kind settings should generate valid SPIR-V code.
-using ValidShaderKind = testing::TestWithParam<ShaderKindTestCase>;
+// Valid shader stage settings should generate valid SPIR-V code.
+using ValidShaderStage = testing::TestWithParam<ShaderStageTestCase>;
 
-TEST_P(ValidShaderKind, ValidSpvCode) {
-  const ShaderKindTestCase& test_case = GetParam();
+TEST_P(ValidShaderStage, ValidSpvCode) {
+  const ShaderStageTestCase& test_case = GetParam();
   shaderc::Compiler compiler;
   EXPECT_TRUE(
-      CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_kind_));
+      CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_stage_));
 }
 
 INSTANTIATE_TEST_CASE_P(
-    CompileStringTest, ValidShaderKind,
-    testing::ValuesIn(std::vector<ShaderKindTestCase>{
-        // Valid default shader kinds.
+    CompileStringTest, ValidShaderStage,
+    testing::ValuesIn(std::vector<ShaderStageTestCase>{
+        // Valid default shader stages.
         {kEmpty310ESShader, shaderc_glsl_default_vertex_shader},
         {kEmpty310ESShader, shaderc_glsl_default_fragment_shader},
         {kEmpty310ESShader, shaderc_glsl_default_compute_shader},
@@ -565,7 +572,7 @@ INSTANTIATE_TEST_CASE_P(
         {kTessEvaluationOnlyShader,
          shaderc_glsl_default_tess_evaluation_shader},
 
-        // #pragma annotation overrides default shader kinds.
+        // #pragma annotation overrides default shader stages.
         {kVertexOnlyShaderWithPragma, shaderc_glsl_default_compute_shader},
         {kFragmentOnlyShaderWithPragma, shaderc_glsl_default_vertex_shader},
         {kTessControlOnlyShaderWithPragma,
@@ -576,30 +583,30 @@ INSTANTIATE_TEST_CASE_P(
          shaderc_glsl_default_tess_evaluation_shader},
         {kComputeOnlyShaderWithPragma, shaderc_glsl_default_geometry_shader},
 
-        // Specified non-default shader kind overrides #pragma annotation.
+        // Specified non-default shader stage overrides #pragma annotation.
         {kVertexOnlyShaderWithInvalidPragma, shaderc_glsl_vertex_shader},
     }));
 
-// Invalid shader kind settings should generate errors.
-using InvalidShaderKind = testing::TestWithParam<ShaderKindTestCase>;
+// Invalid shader stage settings should generate errors.
+using InvalidShaderStage = testing::TestWithParam<ShaderStageTestCase>;
 
-TEST_P(InvalidShaderKind, CompilationShouldFail) {
-  const ShaderKindTestCase& test_case = GetParam();
+TEST_P(InvalidShaderStage, CompilationShouldFail) {
+  const ShaderStageTestCase& test_case = GetParam();
   shaderc::Compiler compiler;
   EXPECT_FALSE(
-      CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_kind_));
+      CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_stage_));
 }
 
 INSTANTIATE_TEST_CASE_P(
-    CompileStringTest, InvalidShaderKind,
-    testing::ValuesIn(std::vector<ShaderKindTestCase>{
-        // Invalid default shader kind.
+    CompileStringTest, InvalidShaderStage,
+    testing::ValuesIn(std::vector<ShaderStageTestCase>{
+        // Invalid default shader stage.
         {kVertexOnlyShader, shaderc_glsl_default_fragment_shader},
-        // Sets to deduce shader kind from #pragma, but #pragma is defined in
+        // Sets to deduce shader stage from #pragma, but #pragma is defined in
         // the source code.
         {kVertexOnlyShader, shaderc_glsl_infer_from_source},
-        // Invalid #pragma cause errors, even though default shader kind is set
-        // to valid shader kind.
+        // Invalid #pragma cause errors, even though default shader stage is set
+        // to valid shader stage.
         {kVertexOnlyShaderWithInvalidPragma,
          shaderc_glsl_default_vertex_shader},
     }));

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -52,14 +52,14 @@ bool IsValidSpv(const shaderc::SpvModule& result) {
 // Compiles a shader and returns true if the result is valid SPIR-V. The
 // input_file_name is set to "shader".
 bool CompilesToValidSpv(const shaderc::Compiler& compiler,
-                        const std::string& shader, shaderc_shader_kind kind) {
+                        const std::string& shader, shaderc_shader_stage kind) {
   return IsValidSpv(compiler.CompileGlslToSpv(shader, kind, "shader"));
 }
 
 // Compiles a shader with options and returns true if the result is valid
 // SPIR-V. The input_file_name is set to "shader".
 bool CompilesToValidSpv(const shaderc::Compiler& compiler,
-                        const std::string& shader, shaderc_shader_kind kind,
+                        const std::string& shader, shaderc_shader_stage kind,
                         const CompileOptions& options) {
   return IsValidSpv(compiler.CompileGlslToSpv(shader, kind, "shader", options));
 }
@@ -69,7 +69,7 @@ class CppInterface : public testing::Test {
   // Compiles a shader and returns true on success, false on failure.
   // The input file name is set to "shader" by default.
   bool CompilationSuccess(const std::string& shader,
-                          shaderc_shader_kind kind) const {
+                          shaderc_shader_stage kind) const {
     return compiler_
         .CompileGlslToSpv(shader.c_str(), shader.length(), kind, "shader")
         .GetCompilationStatus() == shaderc_compilation_status_success;
@@ -78,7 +78,7 @@ class CppInterface : public testing::Test {
   // Compiles a shader with options and returns true on success, false on
   // failure.
   // The input file name is set to "shader" by default.
-  bool CompilationSuccess(const std::string& shader, shaderc_shader_kind kind,
+  bool CompilationSuccess(const std::string& shader, shaderc_shader_stage kind,
                           const CompileOptions& options) const {
     return compiler_
         .CompileGlslToSpv(shader.c_str(), shader.length(), kind, "shader",
@@ -90,7 +90,7 @@ class CppInterface : public testing::Test {
   // messages.
   // The input file name is set to "shader" by default.
   std::string CompilationWarnings(
-      const std::string& shader, shaderc_shader_kind kind,
+      const std::string& shader, shaderc_shader_stage kind,
       // This could default to options_, but that can
       // be easily confused with a no-options-provided
       // case:
@@ -104,7 +104,7 @@ class CppInterface : public testing::Test {
   // Compiles a shader, asserts compilation fail, and returns the error
   // messages.
   std::string CompilationErrors(const std::string& shader,
-                                shaderc_shader_kind kind,
+                                shaderc_shader_stage kind,
                                 // This could default to options_, but that can
                                 // be easily confused with a no-options-provided
                                 // case:
@@ -119,7 +119,7 @@ class CppInterface : public testing::Test {
   // bytes.
   // The input file name is set to "shader" by default.
   std::string CompilationOutput(const std::string& shader,
-                                shaderc_shader_kind kind,
+                                shaderc_shader_stage kind,
                                 const CompileOptions& options) const {
     const auto module =
         compiler_.CompileGlslToSpv(shader, kind, "shader", options);
@@ -531,7 +531,7 @@ TEST_F(CppInterface, PreprocessingOnlyModeSecondOverridesDisassemblyMode) {
 // annotation, 2) shader_kind.
 struct ShaderKindTestCase {
   const char* shader_;
-  shaderc_shader_kind shader_kind_;
+  shaderc_shader_stage shader_kind_;
 };
 
 // Test the shader kind deduction process. If the shader kind is one

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -67,11 +67,11 @@ class Compilation {
  public:
   // Compiles shader, keeping the result.
   Compilation(const shaderc_compiler_t compiler, const std::string& shader,
-              shaderc_shader_stage kind, const char* input_file_name,
+              shaderc_shader_stage shader_stage, const char* input_file_name,
               const shaderc_compile_options_t options = nullptr)
-      : compiled_result_(
-            shaderc_compile_into_spv(compiler, shader.c_str(), shader.size(),
-                                     kind, input_file_name, "", options)) {}
+      : compiled_result_(shaderc_compile_into_spv(
+            compiler, shader.c_str(), shader.size(), shader_stage,
+            input_file_name, "", options)) {}
 
   ~Compilation() { shaderc_module_release(compiled_result_); }
 
@@ -110,10 +110,10 @@ bool CompilationResultIsSuccess(const shaderc_spv_module_t result_module) {
 
 // Compiles a shader and returns true if the result is valid SPIR-V.
 bool CompilesToValidSpv(Compiler& compiler, const std::string& shader,
-                        shaderc_shader_stage kind,
+                        shaderc_shader_stage shader_stage,
                         const shaderc_compile_options_t options = nullptr) {
-  const Compilation comp(compiler.get_compiler_handle(), shader, kind, "shader",
-                         options);
+  const Compilation comp(compiler.get_compiler_handle(), shader, shader_stage,
+                         "shader", options);
   auto result = comp.result();
   if (!CompilationResultIsSuccess(result)) return false;
   size_t length = shaderc_module_get_length(result);
@@ -131,10 +131,11 @@ bool CompilesToValidSpv(Compiler& compiler, const std::string& shader,
 class CompileStringTest : public testing::Test {
  protected:
   // Compiles a shader and returns true on success, false on failure.
-  bool CompilationSuccess(const std::string& shader, shaderc_shader_stage kind,
+  bool CompilationSuccess(const std::string& shader,
+                          shaderc_shader_stage shader_stage,
                           shaderc_compile_options_t options = nullptr) {
     return CompilationResultIsSuccess(
-        Compilation(compiler_.get_compiler_handle(), shader, kind,
+        Compilation(compiler_.get_compiler_handle(), shader, shader_stage,
                     "shader", options)
             .result());
   }
@@ -142,11 +143,12 @@ class CompileStringTest : public testing::Test {
   // Compiles a shader, expects compilation success, and returns the warning
   // messages.
   const std::string CompilationWarnings(
-      const std::string& shader, shaderc_shader_stage kind,
+      const std::string& shader, shaderc_shader_stage shader_stage,
       const shaderc_compile_options_t options = nullptr) {
-    const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           "shader", options);
-    EXPECT_TRUE(CompilationResultIsSuccess(comp.result())) << kind << '\n'
+    const Compilation comp(compiler_.get_compiler_handle(), shader,
+                           shader_stage, "shader", options);
+    EXPECT_TRUE(CompilationResultIsSuccess(comp.result())) << shader_stage
+                                                           << '\n'
                                                            << shader;
     return shaderc_module_get_error_message(comp.result());
   };
@@ -154,11 +156,12 @@ class CompileStringTest : public testing::Test {
   // Compiles a shader, expects compilation failure, and returns the warning
   // messages.
   const std::string CompilationErrors(
-      const std::string& shader, shaderc_shader_stage kind,
+      const std::string& shader, shaderc_shader_stage shader_stage,
       const shaderc_compile_options_t options = nullptr) {
-    const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           "shader", options);
-    EXPECT_FALSE(CompilationResultIsSuccess(comp.result())) << kind << '\n'
+    const Compilation comp(compiler_.get_compiler_handle(), shader,
+                           shader_stage, "shader", options);
+    EXPECT_FALSE(CompilationResultIsSuccess(comp.result())) << shader_stage
+                                                            << '\n'
                                                             << shader;
     return shaderc_module_get_error_message(comp.result());
   };
@@ -166,11 +169,12 @@ class CompileStringTest : public testing::Test {
   // Compiles a shader, expects compilation success, and returns the output
   // bytes.
   const std::string CompilationOutput(
-      const std::string& shader, shaderc_shader_stage kind,
+      const std::string& shader, shaderc_shader_stage shader_stage,
       const shaderc_compile_options_t options = nullptr) {
-    const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           "shader", options);
-    EXPECT_TRUE(CompilationResultIsSuccess(comp.result())) << kind << '\n'
+    const Compilation comp(compiler_.get_compiler_handle(), shader,
+                           shader_stage, "shader", options);
+    EXPECT_TRUE(CompilationResultIsSuccess(comp.result())) << shader_stage
+                                                           << '\n'
                                                            << shader;
     // Use string(const char* s, size_t n) constructor instead of
     // string(const char* s) to make sure the string has complete binary data.
@@ -190,7 +194,7 @@ class CompileStringTest : public testing::Test {
 // Name holders so that we have test cases being grouped with only one real
 // compilation class.
 using CompileStringWithOptionsTest = CompileStringTest;
-using CompileKindsTest = CompileStringTest;
+using CompileStagesTest = CompileStringTest;
 
 TEST_F(CompileStringTest, EmptyString) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
@@ -261,15 +265,15 @@ TEST_F(CompileStringTest, ZeroErrorsZeroWarnings) {
 }
 
 TEST_F(CompileStringTest, ErrorTypeUnknownShaderStage) {
-  // The shader kind/stage can not be determined, the error type field should
-  // indicate the error type is shaderc_shader_kind_error.
+  // The shader stage can not be determined, the compilation status should
+  // indicate the failure is caused by invalid stage.
   Compilation comp(compiler_.get_compiler_handle(), kMinimalShader,
                    shaderc_glsl_infer_from_source, "shader");
   EXPECT_EQ(shaderc_compilation_status_invalid_stage,
             shaderc_module_get_compilation_status(comp.result()));
 }
 TEST_F(CompileStringTest, ErrorTypeCompilationError) {
-  // The shader kind is valid, the result module's error type field should
+  // The shader stage is valid, the result module's error type field should
   // indicate this compilaion fails due to compilation errors.
   Compilation comp(compiler_.get_compiler_handle(), kTwoErrorsShader,
                    shaderc_glsl_vertex_shader, "shader");
@@ -484,35 +488,36 @@ TEST_F(CompileStringWithOptionsTest, PreprocessingOnlyOption) {
   EXPECT_THAT(preprocessed_text_cloned_options, HasSubstr("void main(){ }"));
 }
 
-// A shader kind test cases needs: 1) A shader text with or without #pragma
-// annotation, 2) shader_kind.
-struct ShaderKindTestCase {
+// A shader stage test cases needs: 1) A shader text with or without #pragma
+// annotation, 2) shader_stage.
+struct ShaderStageTestCase {
   const char* shader_;
-  shaderc_shader_stage shader_kind_;
+  shaderc_shader_stage shader_stage_;
 };
 
-// Test the shader kind deduction process. If the shader kind is one of the
+// Test the shader stage deduction process. If the shader stage is one of the
 // forced ones, the compiler will just try to compile the source code in that
-// specified shader kind. If the shader kind is shaderc_glsl_deduce_from_pragma,
-// the compiler will determine the shader kind from #pragma annotation in the
+// specified shader stage. If the shader stage is
+// shaderc_glsl_deduce_from_pragma,
+// the compiler will determine the shader stage from #pragma annotation in the
 // source code and emit error if none such annotation is found. When the shader
-// kind is one of the default ones, the compiler will fall back to use the
-// specified shader kind if and only if #pragma annoation is not found.
+// stage is one of the default ones, the compiler will fall back to use the
+// specified shader stage if and only if #pragma annoation is not found.
 
-// Valid shader kind settings should generate valid SPIR-V code.
-using ValidShaderKind = testing::TestWithParam<ShaderKindTestCase>;
+// Valid shader stage settings should generate valid SPIR-V code.
+using ValidShaderStage = testing::TestWithParam<ShaderStageTestCase>;
 
-TEST_P(ValidShaderKind, ValidSpvCode) {
-  const ShaderKindTestCase& test_case = GetParam();
+TEST_P(ValidShaderStage, ValidSpvCode) {
+  const ShaderStageTestCase& test_case = GetParam();
   Compiler compiler;
   EXPECT_TRUE(
-      CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_kind_));
+      CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_stage_));
 }
 
 INSTANTIATE_TEST_CASE_P(
-    CompileStringTest, ValidShaderKind,
-    testing::ValuesIn(std::vector<ShaderKindTestCase>{
-        // Valid default shader kinds.
+    CompileStringTest, ValidShaderStage,
+    testing::ValuesIn(std::vector<ShaderStageTestCase>{
+        // Valid default shader stage.
         {kEmpty310ESShader, shaderc_glsl_default_vertex_shader},
         {kEmpty310ESShader, shaderc_glsl_default_fragment_shader},
         {kEmpty310ESShader, shaderc_glsl_default_compute_shader},
@@ -521,7 +526,7 @@ INSTANTIATE_TEST_CASE_P(
         {kTessEvaluationOnlyShader,
          shaderc_glsl_default_tess_evaluation_shader},
 
-        // #pragma annotation overrides default shader kinds.
+        // #pragma annotation overrides default shader stage.
         {kVertexOnlyShaderWithPragma, shaderc_glsl_default_compute_shader},
         {kFragmentOnlyShaderWithPragma, shaderc_glsl_default_vertex_shader},
         {kTessControlOnlyShaderWithPragma,
@@ -532,30 +537,30 @@ INSTANTIATE_TEST_CASE_P(
          shaderc_glsl_default_tess_evaluation_shader},
         {kComputeOnlyShaderWithPragma, shaderc_glsl_default_geometry_shader},
 
-        // Specified non-default shader kind overrides #pragma annotation.
+        // Specified non-default shader stage overrides #pragma annotation.
         {kVertexOnlyShaderWithInvalidPragma, shaderc_glsl_vertex_shader},
     }));
 
-using InvalidShaderKind = testing::TestWithParam<ShaderKindTestCase>;
+using InvalidShaderStage = testing::TestWithParam<ShaderStageTestCase>;
 
-// Invalid shader kind settings should generate errors.
-TEST_P(InvalidShaderKind, CompilationShouldFail) {
-  const ShaderKindTestCase& test_case = GetParam();
+// Invalid shader stage settings should generate errors.
+TEST_P(InvalidShaderStage, CompilationShouldFail) {
+  const ShaderStageTestCase& test_case = GetParam();
   Compiler compiler;
   EXPECT_FALSE(
-      CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_kind_));
+      CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_stage_));
 }
 
 INSTANTIATE_TEST_CASE_P(
-    CompileStringTest, InvalidShaderKind,
-    testing::ValuesIn(std::vector<ShaderKindTestCase>{
-        // Invalid default shader kind.
+    CompileStringTest, InvalidShaderStage,
+    testing::ValuesIn(std::vector<ShaderStageTestCase>{
+        // Invalid default shader stage.
         {kVertexOnlyShader, shaderc_glsl_default_fragment_shader},
-        // Sets to deduce shader kind from #pragma, but #pragma is defined in
+        // Sets to deduce shader stage from #pragma, but #pragma is defined in
         // the source code.
         {kVertexOnlyShader, shaderc_glsl_infer_from_source},
-        // Invalid #pragma cause errors, even though default shader kind is set
-        // to valid shader kind.
+        // Invalid #pragma cause errors, even though default shader stage is set
+        // to valid shader stage.
         {kVertexOnlyShaderWithInvalidPragma,
          shaderc_glsl_default_vertex_shader},
     }));
@@ -639,8 +644,7 @@ TEST_P(IncluderTests, SetIncluderCallbacks) {
       TestIncluder::ReleaseIncluderResponseWrapper, &includer);
 
   const Compilation comp(compiler.get_compiler_handle(), shader,
-                         shaderc_glsl_vertex_shader,
-                         "shader", options.get());
+                         shaderc_glsl_vertex_shader, "shader", options.get());
   // Checks the existence of the expected string.
   EXPECT_THAT(shaderc_module_get_bytes(comp.result()),
               HasSubstr(test_case.expected_substring()));
@@ -663,8 +667,8 @@ TEST_P(IncluderTests, SetIncluderCallbacksClonedOptions) {
       shaderc_compile_options_clone(options.get()));
 
   const Compilation comp(compiler.get_compiler_handle(), shader,
-                         shaderc_glsl_vertex_shader,
-                         "shader", cloned_options.get());
+                         shaderc_glsl_vertex_shader, "shader",
+                         cloned_options.get());
   // Checks the existence of the expected string.
   EXPECT_THAT(shaderc_module_get_bytes(comp.result()),
               HasSubstr(test_case.expected_substring()));
@@ -872,7 +876,7 @@ TEST_F(CompileStringWithOptionsTest, TargetEnvIgnoredWhenPreprocessing) {
                                  shaderc_glsl_fragment_shader, options_.get()));
 }
 
-TEST_F(CompileStringTest, ShaderKindRespected) {
+TEST_F(CompileStringTest, ShaderStageRespected) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
   const std::string kVertexShader = "void main(){ gl_Position = vec4(0);}";
   EXPECT_TRUE(CompilationSuccess(kVertexShader, shaderc_glsl_vertex_shader));
@@ -901,19 +905,19 @@ TEST_F(CompileStringTest, MultipleThreadsCalling) {
   EXPECT_THAT(results, Each(true));
 }
 
-TEST_F(CompileKindsTest, Vertex) {
+TEST_F(CompileStagesTest, Vertex) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
   const std::string kVertexShader = "void main(){ gl_Position = vec4(0);}";
   EXPECT_TRUE(CompilationSuccess(kVertexShader, shaderc_glsl_vertex_shader));
 }
 
-TEST_F(CompileKindsTest, Fragment) {
+TEST_F(CompileStagesTest, Fragment) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
   const std::string kFragShader = "void main(){ gl_FragColor = vec4(0);}";
   EXPECT_TRUE(CompilationSuccess(kFragShader, shaderc_glsl_fragment_shader));
 }
 
-TEST_F(CompileKindsTest, Compute) {
+TEST_F(CompileStagesTest, Compute) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
   const std::string kCompShader =
       R"(#version 310 es
@@ -922,7 +926,7 @@ TEST_F(CompileKindsTest, Compute) {
   EXPECT_TRUE(CompilationSuccess(kCompShader, shaderc_glsl_compute_shader));
 }
 
-TEST_F(CompileKindsTest, Geometry) {
+TEST_F(CompileStagesTest, Geometry) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
   const std::string kGeoShader =
 
@@ -939,7 +943,7 @@ TEST_F(CompileKindsTest, Geometry) {
   EXPECT_TRUE(CompilationSuccess(kGeoShader, shaderc_glsl_geometry_shader));
 }
 
-TEST_F(CompileKindsTest, TessControl) {
+TEST_F(CompileStagesTest, TessControl) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
   const std::string kTessControlShader =
       R"(#version 310 es
@@ -951,7 +955,7 @@ TEST_F(CompileKindsTest, TessControl) {
       CompilationSuccess(kTessControlShader, shaderc_glsl_tess_control_shader));
 }
 
-TEST_F(CompileKindsTest, TessEvaluation) {
+TEST_F(CompileStagesTest, TessEvaluation) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
   const std::string kTessEvaluationShader =
       R"(#version 310 es
@@ -991,8 +995,8 @@ TEST_P(ParseVersionProfileTest, FromNullTerminatedString) {
   const ParseVersionProfileTestCase& test_case = GetParam();
   int version;
   shaderc_profile profile;
-  bool succeed =
-      shaderc_parse_version_profile(test_case.input_string_.c_str(), &version, &profile);
+  bool succeed = shaderc_parse_version_profile(test_case.input_string_.c_str(),
+                                               &version, &profile);
   EXPECT_EQ(test_case.expected_succeed_, succeed);
   // check the return version and profile only when the parsing succeeds.
   if (succeed) {

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -67,7 +67,7 @@ class Compilation {
  public:
   // Compiles shader, keeping the result.
   Compilation(const shaderc_compiler_t compiler, const std::string& shader,
-              shaderc_shader_kind kind, const char* input_file_name,
+              shaderc_shader_stage kind, const char* input_file_name,
               const shaderc_compile_options_t options = nullptr)
       : compiled_result_(
             shaderc_compile_into_spv(compiler, shader.c_str(), shader.size(),
@@ -110,7 +110,7 @@ bool CompilationResultIsSuccess(const shaderc_spv_module_t result_module) {
 
 // Compiles a shader and returns true if the result is valid SPIR-V.
 bool CompilesToValidSpv(Compiler& compiler, const std::string& shader,
-                        shaderc_shader_kind kind,
+                        shaderc_shader_stage kind,
                         const shaderc_compile_options_t options = nullptr) {
   const Compilation comp(compiler.get_compiler_handle(), shader, kind, "shader",
                          options);
@@ -131,7 +131,7 @@ bool CompilesToValidSpv(Compiler& compiler, const std::string& shader,
 class CompileStringTest : public testing::Test {
  protected:
   // Compiles a shader and returns true on success, false on failure.
-  bool CompilationSuccess(const std::string& shader, shaderc_shader_kind kind,
+  bool CompilationSuccess(const std::string& shader, shaderc_shader_stage kind,
                           shaderc_compile_options_t options = nullptr) {
     return CompilationResultIsSuccess(
         Compilation(compiler_.get_compiler_handle(), shader, kind,
@@ -142,7 +142,7 @@ class CompileStringTest : public testing::Test {
   // Compiles a shader, expects compilation success, and returns the warning
   // messages.
   const std::string CompilationWarnings(
-      const std::string& shader, shaderc_shader_kind kind,
+      const std::string& shader, shaderc_shader_stage kind,
       const shaderc_compile_options_t options = nullptr) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
                            "shader", options);
@@ -154,7 +154,7 @@ class CompileStringTest : public testing::Test {
   // Compiles a shader, expects compilation failure, and returns the warning
   // messages.
   const std::string CompilationErrors(
-      const std::string& shader, shaderc_shader_kind kind,
+      const std::string& shader, shaderc_shader_stage kind,
       const shaderc_compile_options_t options = nullptr) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
                            "shader", options);
@@ -166,7 +166,7 @@ class CompileStringTest : public testing::Test {
   // Compiles a shader, expects compilation success, and returns the output
   // bytes.
   const std::string CompilationOutput(
-      const std::string& shader, shaderc_shader_kind kind,
+      const std::string& shader, shaderc_shader_stage kind,
       const shaderc_compile_options_t options = nullptr) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
                            "shader", options);
@@ -488,7 +488,7 @@ TEST_F(CompileStringWithOptionsTest, PreprocessingOnlyOption) {
 // annotation, 2) shader_kind.
 struct ShaderKindTestCase {
   const char* shader_;
-  shaderc_shader_kind shader_kind_;
+  shaderc_shader_stage shader_kind_;
 };
 
 // Test the shader kind deduction process. If the shader kind is one of the

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -489,7 +489,7 @@ TEST_F(CompileStringWithOptionsTest, PreprocessingOnlyOption) {
 }
 
 // A shader stage test cases needs: 1) A shader text with or without #pragma
-// annotation, 2) shader_stage.
+// annotation, 2) shader stage.
 struct ShaderStageTestCase {
   const char* shader_;
   shaderc_shader_stage shader_stage_;


### PR DESCRIPTION
Rename 'kind' to 'stage'. Now we need to distinguish libhshaderc stage with glslang stage. 

Change 'preprocessing only mode' in the blurbs of libshaderc to 'preprocessing-only mode'

Add blurbs for the includer interface defined in shaderc.hpp. Hope this helps with #105.