### PR TITLE
Enabled caching of glsl state.

### DIFF
--- a/libshaderc/src/shaderc_private.h
+++ b/libshaderc/src/shaderc_private.h
@@ -36,9 +36,12 @@ struct shaderc_spv_module {
       shaderc_compilation_status_null_result_module;
 };
 
+namespace shaderc_util {
+class GlslInitializer;
+}
+
 struct shaderc_compiler {
-  // Whether or not this compiler is in an initialized state.
-  bool initialized = true;
+  shaderc_util::GlslInitializer* initializer;
 };
 
 #endif  // LIBSHADERC_SRC_SHADERC_PRIVATE_H_

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -32,10 +32,10 @@
 namespace shaderc_util {
 
 // Initializes glslang on creation, and destroys it on completion.
-// There is expected to be precisely one of these objects active within
-// the current process at a time.
+// This object is expected to be a singleton, so that internal
+// glslang state can be correctly handled.
 // TODO(awoloszyn): Once glslang no longer has static global mutable state
-//                  remove this object.
+//                  remove this class.
 class GlslInitializer {
  public:
   GlslInitializer() : last_messages_(EShMsgDefault) {
@@ -71,8 +71,8 @@ class GlslInitializer {
 
   // Obtains exclusive access to the glslang state. The state remains
   // exclusive until the Initialization Token has been destroyed.
-  // Re-initializes glsl state iff the previous rules and the current rules
-  // are incompatible.
+  // Re-initializes glsl state iff the previous messages and the current
+  // messages are incompatible.
   InitializationToken Acquire(EShMessages new_messages) {
     state_lock_.lock();
 
@@ -160,8 +160,8 @@ class Compiler {
   // includer.
   //
   // The initializer parameter must be a valid GlslInitializer object.
-  // Acquire will be called on the initializer, and cleaned up
-  // as necessary.
+  // Acquire will be called on the initializer and the result will be
+  // destoryed before the function ends.
   //
   // Any error messages are written as if the file name were error_tag.
   // Any errors are written to the error_stream parameter.

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -17,6 +17,7 @@
 #define LIBSHADERC_UTIL_INC_COMPILER_H
 
 #include <functional>
+#include <mutex>
 #include <ostream>
 #include <string>
 #include <unordered_map>
@@ -31,10 +32,68 @@
 namespace shaderc_util {
 
 // Initializes glslang on creation, and destroys it on completion.
+// There is expected to be precisely one of these objects active within
+// the current process at a time.
+// TODO(awoloszyn): Once glslang no longer has static global mutable state
+//                  remove this object.
 class GlslInitializer {
  public:
-  GlslInitializer() { glslang::InitializeProcess(); }
+  GlslInitializer() : last_messages_(EShMsgDefault) {
+    glslang::InitializeProcess();
+  }
+
   ~GlslInitializer() { glslang::FinalizeProcess(); }
+
+  // Calls release on GlslangInitializer used to intialize this object
+  // when it is destroyed.
+  class InitializationToken {
+   public:
+    ~InitializationToken() {
+      if (initializer_) {
+        initializer_->Release();
+      }
+    }
+
+    InitializationToken(InitializationToken&& other):
+      initializer_(other.initializer_) {
+        other.initializer_ = nullptr;
+    }
+
+    InitializationToken(const InitializationToken&) = delete;
+
+   private:
+    InitializationToken(GlslInitializer* initializer)
+        : initializer_(initializer) {}
+
+    friend class GlslInitializer;
+    GlslInitializer* initializer_;
+  };
+
+  // Obtains exclusive access to the glslang state. The state remains
+  // exclusive until the Initialization Token has been destroyed.
+  // Re-initializes glsl state iff the previous rules and the current rules
+  // are incompatible.
+  InitializationToken Acquire(EShMessages new_messages) {
+    state_lock_.lock();
+
+    if ((last_messages_ ^ new_messages) &
+        (EShMsgVulkanRules | EShMsgSpvRules)) {
+      glslang::FinalizeProcess();
+      glslang::InitializeProcess();
+    }
+    last_messages_ = new_messages;
+    return InitializationToken(this);
+  }
+
+ private:
+  void Release() {
+    state_lock_.unlock();
+  }
+
+  friend class InitializationToken;
+
+  EShMessages last_messages_;
+  std::mutex state_lock_;
 };
 
 // Maps macro names to their definitions.  Stores string_pieces, so the
@@ -56,7 +115,7 @@ class Compiler {
         warnings_as_errors_(false),
         suppress_warnings_(false),
         generate_debug_info_(false),
-        message_rules_(static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules)) {}
+        message_rules_(GetDefaultRules()) {}
 
   // Instead of outputting object files, output the disassembled textual output.
   virtual void SetDisassemblyMode();
@@ -82,6 +141,9 @@ class Compiler {
   // Sets message rules to be used when generating compiler warnings/errors
   void SetMessageRules(EShMessages rules);
 
+  // Gets the message rules when generating compiler warnings/error.
+  EShMessages GetMessageRules() const;
+
   // Forces (without any verification) the default version and profile for
   // subsequent CompileShader() calls.
   void SetForcedVersionProfile(int version, EProfile profile);
@@ -97,6 +159,10 @@ class Compiler {
   // from the shader text. Any #include directives are parsed with the given
   // includer.
   //
+  // The initializer parameter must be a valid GlslInitializer object.
+  // Acquire will be called on the initializer, and cleaned up
+  // as necessary.
+  //
   // Any error messages are written as if the file name were error_tag.
   // Any errors are written to the error_stream parameter.
   // total_warnings and total_errors are incremented once for every
@@ -110,7 +176,13 @@ class Compiler {
                                                    error_tag)>& stage_callback,
                const CountingIncluder& includer, std::ostream* output_stream,
                std::ostream* error_stream, size_t* total_warnings,
-               size_t* total_errors) const;
+               size_t* total_errors,
+               GlslInitializer* initializer) const;
+
+  static EShMessages GetDefaultRules() {
+    return static_cast<EShMessages>(EShMsgSpvRules |
+                                                EShMsgVulkanRules);
+  }
 
  protected:
   // Preprocesses a shader whose filename is filename and content is

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -107,14 +107,16 @@ spv_result_t DisassembleBinary(const std::vector<uint32_t>& binary,
 namespace shaderc_util {
 
 bool Compiler::Compile(
-    const string_piece& input_source_string, EShLanguage forced_shader_stage,
-    const std::string& error_tag,
+    const string_piece& input_source_string, 
+    EShLanguage forced_shader_stage, const std::string& error_tag,
     const std::function<EShLanguage(std::ostream* error_stream,
                                     const string_piece& error_tag)>&
         stage_callback,
     const CountingIncluder& includer, std::ostream* output_stream,
     std::ostream* error_stream, size_t* total_warnings,
-    size_t* total_errors) const {
+    size_t* total_errors, GlslInitializer* initializer) const {
+
+  auto token = initializer->Acquire(GetMessageRules());
   EShLanguage used_shader_stage = forced_shader_stage;
   const std::string macro_definitions =
       shaderc_util::format(predefined_macros_, "#define ", " ", "\n");
@@ -133,6 +135,8 @@ bool Compiler::Compile(
     std::tie(success, preprocessed_shader, glslang_errors) =
         PreprocessShader(error_tag, input_source_string, preamble, includer);
 
+    // Make sure we do not create/destroy the entire glslang process data
+    // between here and compile_shader.
     success &= PrintFilteredErrors(error_tag, error_stream, warnings_as_errors_,
                                    /* suppress_warnings = */ true,
                                    glslang_errors.c_str(), total_warnings,
@@ -171,7 +175,6 @@ bool Compiler::Compile(
   }
 
   // Parsing requires its own Glslang symbol tables.
-  GlslInitializer initializer;
   glslang::TShader shader(used_shader_stage);
   const char* shader_strings = input_source_string.data();
   const int shader_lengths = static_cast<int>(input_source_string.size());
@@ -226,6 +229,8 @@ void Compiler::AddMacroDefinition(const string_piece& macro,
 
 void Compiler::SetMessageRules(EShMessages rules) { message_rules_ = rules; }
 
+EShMessages Compiler::GetMessageRules() const { return message_rules_; }
+
 void Compiler::SetForcedVersionProfile(int version, EProfile profile) {
   default_version_ = version;
   default_profile_ = profile;
@@ -251,7 +256,7 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
   // or Vulkan is turned on.  Since preprocessing uses different
   // message rules from parsing, to be safe the preprocessor step must
   // build its own symbol tables and tear them down.
-  GlslInitializer initializer;
+
   // The stage does not matter for preprocessing.
   glslang::TShader shader(EShLangVertex);
   const char* shader_strings = shader_source.data();

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -135,8 +135,6 @@ bool Compiler::Compile(
     std::tie(success, preprocessed_shader, glslang_errors) =
         PreprocessShader(error_tag, input_source_string, preamble, includer);
 
-    // Make sure we do not create/destroy the entire glslang process data
-    // between here and compile_shader.
     success &= PrintFilteredErrors(error_tag, error_stream, warnings_as_errors_,
                                    /* suppress_warnings = */ true,
                                    glslang_errors.c_str(), total_warnings,
@@ -251,11 +249,6 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
     const std::string& error_tag, const string_piece& shader_source,
     const string_piece& shader_preamble,
     const CountingIncluder& includer) const {
-  // Glslang's symbol tables of builtins are lazily initialized, but
-  // the already-initialized check is insensitive to whether SPIR-V
-  // or Vulkan is turned on.  Since preprocessing uses different
-  // message rules from parsing, to be safe the preprocessor step must
-  // build its own symbol tables and tear them down.
 
   // The stage does not matter for preprocessing.
   glslang::TShader shader(EShLangVertex);

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -94,10 +94,11 @@ class CompilerTest : public testing::Test {
     std::stringstream errors;
     size_t total_warnings = 0;
     size_t total_errors = 0;
-
+    shaderc_util::GlslInitializer initializer;
     const bool result = compiler_.Compile(
-        source, stage, "shader", stage_callback, DummyCountingIncluder(), &out,
-        &errors, &total_warnings, &total_errors);
+        source, stage,
+        "shader", stage_callback, DummyCountingIncluder(), &out, &errors,
+        &total_warnings, &total_errors, &initializer);
     errors_ = errors.str();
     return result;
   }


### PR DESCRIPTION
We only Initialize/Finalize process every compile because there
is a subset of options that interfere with internal glslang
state. Until this is remedied in glslang, allow re-use of
state except in the cases where we know state will get broken.