### PR TITLE
Don't run spirv-tools-testsuite.

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -65,7 +65,3 @@ else()
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test-glslang/
   )
 endif()
-
-add_test(NAME spirv-tools-testsuite
-  COMMAND UnitSPIRV
-  WORKING_DIRECTORY ${SPIRV-Tools_BINARY_DIR})


### PR DESCRIPTION
When spirv-tools is added outside the Shaderc project, let that outside
location decide how and if to run the spirv-tools tests.