### PR TITLE
Add Error message substring comparison and use it for --target-env tests

### DIFF
--- a/glslc/test/option_target_env.py
+++ b/glslc/test/option_target_env.py
@@ -39,17 +39,15 @@ class TestTargetEnvEqOpenglCompatWithOpenGlCompatShader(expect.ValidObjectFile):
 
 
 @inside_glslc_testsuite('OptionTargetEnv')
-class TestTargetEnvEqOpenglWithOpenGlCompatShader(expect.ErrorMessage):
+class TestTargetEnvEqOpenglWithOpenGlCompatShader(expect.ErrorMessageSubstr):
     """Tests the error message of compiling OpenGL Compatibility Fragment shader
     with --target-env=opengl"""
     shader = FileShader(opengl_compat_fragment_shader(), '.frag')
     glslc_args = ['--target-env=opengl', shader]
-    expected_error = [shader, ":4: error: 'texture2D' : ",
-                      "no matching overloaded function found\n",
-                      shader, ":4: error: 'assign' :  ",
-                      "cannot convert from 'const float' to 'fragColor ",
-                      "mediump 4-component vector of float FragColor'\n",
-                      "2 errors generated.\n"]
+    expected_error_substr = [shader, ":4: error: 'assign' :  ",
+                             "cannot convert from 'const float' to ",
+                             "'fragColor mediump 4-component vector ",
+                             "of float FragColor'\n"]
 
 
 @inside_glslc_testsuite('OptionTargetEnv')


### PR DESCRIPTION
Only test that the error message has what we expected as a substring, doesn't require an exact match. This fix the --target-env test for glslc, which have different error messages with different glslang.