### PR TITLE
WIP: Fix output data alignment and avoid copy

### DIFF
--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -530,7 +530,7 @@ TEST_F(CppInterface, PreprocessingOnlyModeSecondOverridesDisassemblyMode) {
               HasSubstr("void main(){ }"));
 }
 
-// A shader kind test cases needs: 1) A shader text with or without #pragma
+// A shader kind test case needs: 1) A shader text with or without #pragma
 // annotation, 2) shader_kind.
 struct ShaderKindTestCase {
   const char* shader_;

--- a/libshaderc/src/shaderc_private.h
+++ b/libshaderc/src/shaderc_private.h
@@ -23,8 +23,14 @@
 
 // Described in shaderc.h.
 struct shaderc_spv_module {
-  // SPIR-V binary.
-  std::string spirv;
+  // Compilation output data. In normal compilation mode, it contains the
+  // compiled SPIR-V binary code. In disassembly and preprocessing-only mode, it
+  // contains a null-terminated string which is the text output. For text
+  // output, extra bytes with value 0x00 might be appended to complete the last
+  // uint32_t element.
+  std::vector<uint32_t> output_data;
+  // The size of the output data in term of bytes.
+  size_t output_data_size;
   // Compilation messages.
   std::string messages;
   // Number of errors.


### PR DESCRIPTION
Change the output data container of libshaderc compilation result from
std::string to std::vector<uint32_t> to guarantee the output data alignment.

Change the libshaderc_util::Compiler::Compile() signature and
implementation to avoid extra copies of SPIR-V binary. Also store the
string data of text output in vector<uint32_t>.