### PR TITLE
Enhance integrating with other Android projects.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -4,3 +4,29 @@ include $(ROOT_SHADERC_PATH)/third_party/Android.mk
 include $(ROOT_SHADERC_PATH)/libshaderc_util/Android.mk
 include $(ROOT_SHADERC_PATH)/libshaderc/Android.mk
 
+ALL_LIBS:=libglslang.a \
+	libOGLCompiler.a \
+	libOSDependent.a \
+	libshaderc.a \
+	libshaderc_util.a \
+	libSPIRV.a \
+	libSPIRV-Tools.a
+
+define gen_libshaderc
+$(1)/combine.ar: $(addprefix $(1)/, $(ALL_LIBS))
+	@echo "create libshaderc_combined.a" > $(1)/combine.ar
+	$(foreach lib,$(ALL_LIBS),
+		@echo "addlib $(lib)" >> $(1)/combine.ar
+	)
+	@echo "save" >> $(1)/combine.ar
+	@echo "end" >> $(1)/combine.ar
+		
+$(1)/libshaderc_combined.a: $(addprefix $(1)/, $(ALL_LIBS)) $(1)/combine.ar
+	@echo "[$(TARGET_ARCH_ABI)] Combine: libshaderc_combined.a <= $(ALL_LIBS)"
+	@cd $(1) && $(2)ar -M < combine.ar && cd -
+	@$(2)objcopy --strip-debug $(1)/libshaderc_combined.a
+
+libshaderc_combined:$(1)/libshaderc_combined.a
+endef
+
+$(eval $(call gen_libshaderc,$(TARGET_OUT),$(TOOLCHAIN_PREFIX)))

--- a/android_test/jni/Application.mk
+++ b/android_test/jni/Application.mk
@@ -1,5 +1,4 @@
-#APP_MODULES:=shaderc_shared
-APP_ABI:=all
-APP_BUILD_SCRIPT:=Android.mk
-APP_STL := c++_shared
+APP_ABI := all
+APP_BUILD_SCRIPT := Android.mk
+APP_STL := gnustl_static
 APP_PLATFORM := android-9

--- a/libshaderc/Android.mk
+++ b/libshaderc/Android.mk
@@ -7,7 +7,7 @@ LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)/include
 LOCAL_SRC_FILES:=src/shaderc.cc
 LOCAL_C_INCLUDES:=$(LOCAL_PATH)/include
 LOCAL_STATIC_LIBRARIES=shaderc_util
-LOCAL_CXXFLAGS:=-std=c++11
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti
 LOCAL_EXPORT_CPPFLAGS:=-std=c++11
 LOCAL_EXPORT_LDFLAGS:=-latomic
 include $(BUILD_STATIC_LIBRARY)

--- a/libshaderc_util/Android.mk
+++ b/libshaderc_util/Android.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE:=shaderc_util
-LOCAL_CXXFLAGS:=-std=c++11
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti
 LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)/include
 LOCAL_SRC_FILES:=src/compiler.cc \
 		src/file_finder.cc \


### PR DESCRIPTION
This cleans up a number of warnings related to glslang_tab.cpp.
It also allows the generation of libshaderc_combined by calling
ndk-build libshaderc_combined.