### PR TITLE
Use statically typed compilation results in C++ API

### DIFF
--- a/glslc/src/file_compiler.cc
+++ b/glslc/src/file_compiler.cc
@@ -180,16 +180,15 @@ void FileCompiler::AddIncludeDirectory(const std::string& path) {
 }
 
 void FileCompiler::SetIndividualCompilationFlag() {
-  if (!disassemble_) {
+  if (output_type_ != OutputType::SpirvAssemblyText) {
     needs_linking_ = false;
     file_extension_ = ".spv";
   }
 }
 
 void FileCompiler::SetDisassemblyFlag() {
-  if (!preprocess_only_) {
+  if (!PreprocessingOnly()) {
     output_type_ = OutputType::SpirvAssemblyText;
-    disassemble_ = true;
     needs_linking_ = false;
     file_extension_ = ".spvasm";
   }
@@ -197,7 +196,6 @@ void FileCompiler::SetDisassemblyFlag() {
 
 void FileCompiler::SetPreprocessingOnlyFlag() {
   output_type_ = OutputType::PreprocessedText;
-  preprocess_only_ = true;
   needs_linking_ = false;
   if (output_file_name_.empty()) {
     output_file_name_ = "-";
@@ -220,8 +218,8 @@ bool FileCompiler::ValidateOptions(size_t num_files) {
   // If we are outputting many object files, we cannot specify -o. Also
   // if we are preprocessing multiple files they must be to stdout.
   if (num_files > 1 &&
-      ((!preprocess_only_ && !needs_linking_ && !output_file_name_.empty()) ||
-       (preprocess_only_ && output_file_name_ != "-"))) {
+      ((!PreprocessingOnly() && !needs_linking_ && !output_file_name_.empty()) ||
+       (PreprocessingOnly() && output_file_name_ != "-"))) {
     std::cerr << "glslc: error: cannot specify -o when generating multiple"
                  " output files"
               << std::endl;
@@ -258,12 +256,12 @@ std::string FileCompiler::GetOutputFileName(std::string input_filename) {
 
 std::string FileCompiler::GetCandidateOutputFileName(
     std::string input_filename) {
-  if (!output_file_name_.empty() && !preprocess_only_) {
+  if (!output_file_name_.empty() && !PreprocessingOnly()) {
     return output_file_name_.str();
   }
 
   std::string extension = file_extension_;
-  if (preprocess_only_ || needs_linking_) {
+  if (PreprocessingOnly() || needs_linking_) {
     extension = ".spv";
   }
 

--- a/glslc/src/file_compiler.cc
+++ b/glslc/src/file_compiler.cc
@@ -64,12 +64,41 @@ bool FileCompiler::CompileShaderFile(const std::string& input_file,
       new FileIncluder(&include_file_finder_));
   // Get a reference to the dependency trace before we pass the ownership to
   // shaderc::CompileOptions.
-  const auto& included_files = includer->file_path_trace();
+  const auto& used_source_files = includer->file_path_trace();
   options_.SetIncluder(std::move(includer));
 
-  shaderc::CompilationResult result = compiler_.CompileGlslToSpv(
-      source_string.data(), source_string.size(), shader_stage,
-      error_file_name.data(), options_);
+  switch (output_type_) {
+    case OutputType::SpirvBinary: {
+      const auto result = compiler_.CompileGlslToSpv(
+          source_string.data(), source_string.size(), shader_stage,
+          error_file_name.data(), options_);
+      return EmitCompiledResult(result, input_file, error_file_name,
+                                used_source_files, output_stream);
+    }
+    case OutputType::SpirvAssemblyText: {
+      const auto result = compiler_.CompileGlslToSpvAssembly(
+          source_string.data(), source_string.size(), shader_stage,
+          error_file_name.data(), options_);
+      return EmitCompiledResult(result, input_file, error_file_name,
+                                used_source_files, output_stream);
+    }
+    case OutputType::PreprocessedText: {
+      const auto result = compiler_.PreprocessGlsl(
+          source_string.data(), source_string.size(), shader_stage,
+          error_file_name.data(), options_);
+      return EmitCompiledResult(result, input_file, error_file_name,
+                                used_source_files, output_stream);
+    }
+  }
+  return false;
+}
+
+template <typename CompilationResultType>
+bool FileCompiler::EmitCompiledResult(
+    const CompilationResultType& result, const std::string& input_file,
+    string_piece error_file_name,
+    const std::unordered_set<std::string>& used_source_files,
+    std::ostream* out) {
   total_errors_ += result.GetNumErrors();
   total_warnings_ += result.GetNumWarnings();
 
@@ -104,8 +133,9 @@ bool FileCompiler::CompileShaderFile(const std::string& input_file,
   // later, if the handler is instantiated to dump as normal compilation output,
   // and the original compilation output should be blocked. Otherwise it won't
   // be touched. The main output stream dumps this string_piece later.
-  string_piece compilation_output(result.GetData(),
-                                  result.GetData() + result.GetLength());
+  string_piece compilation_output(
+      reinterpret_cast<const char*>(result.cbegin()),
+      reinterpret_cast<const char*>(result.cend()));
 
   // If we have dependency info dumping handler instantiated, we should dump
   // dependency info first. This may redirect the compilation output
@@ -114,7 +144,7 @@ bool FileCompiler::CompileShaderFile(const std::string& input_file,
   if (dependency_info_dumping_handler_) {
     if (!dependency_info_dumping_handler_->DumpDependencyInfo(
             GetCandidateOutputFileName(input_file), error_file_name.data(),
-            &potential_dependency_info_output, included_files)) {
+            &potential_dependency_info_output, used_source_files)) {
       return false;
     }
     if (!potential_dependency_info_output.empty()) {
@@ -127,12 +157,12 @@ bool FileCompiler::CompileShaderFile(const std::string& input_file,
   }
 
   // Write compilation output to output file.
-  output_stream->write(compilation_output.data(), compilation_output.size());
+  out->write(compilation_output.data(), compilation_output.size());
   // Write error message to std::cerr.
   std::cerr << result.GetErrorMessage();
-  if (output_stream->fail()) {
+  if (out->fail()) {
     // Something wrong happened on output.
-    if (output_stream == &std::cout) {
+    if (out == &std::cout) {
       std::cerr << "glslc: error: error writing to standard output"
                 << std::endl;
     } else {
@@ -158,6 +188,7 @@ void FileCompiler::SetIndividualCompilationFlag() {
 
 void FileCompiler::SetDisassemblyFlag() {
   if (!preprocess_only_) {
+    output_type_ = OutputType::SpirvAssemblyText;
     disassemble_ = true;
     needs_linking_ = false;
     file_extension_ = ".spvasm";
@@ -165,6 +196,7 @@ void FileCompiler::SetDisassemblyFlag() {
 }
 
 void FileCompiler::SetPreprocessingOnlyFlag() {
+  output_type_ = OutputType::PreprocessedText;
   preprocess_only_ = true;
   needs_linking_ = false;
   if (output_file_name_.empty()) {

--- a/glslc/src/file_compiler.h
+++ b/glslc/src/file_compiler.h
@@ -165,6 +165,9 @@ class FileCompiler {
   //  the extension.
   std::string GetCandidateOutputFileName(std::string input_filename);
 
+  // Returns true if the compiler's output is preprocessed text.
+  bool PreprocessingOnly() { return output_type_ == OutputType::PreprocessedText; }
+
   // Performs actual SPIR-V compilation on the contents of input files.
   shaderc::Compiler compiler_;
 
@@ -180,12 +183,6 @@ class FileCompiler {
 
   // Indicates whether linking is needed to generate the final output.
   bool needs_linking_;
-
-  // Flag for disassembly mode.
-  bool disassemble_ = false;
-
-  // Flag for preprocessing only mode.
-  bool preprocess_only_ = false;
 
   // The ownership of dependency dumping handler.
   std::unique_ptr<DependencyInfoDumpingHandler>

--- a/glslc/src/file_compiler.h
+++ b/glslc/src/file_compiler.h
@@ -37,8 +37,8 @@ class FileCompiler {
 
   // Compiles a shader received in input_file, returning true on success and
   // false otherwise. If force_shader_stage is not shaderc_glsl_infer_source or
-  // any default shader stage then the given shader_stage will be used, otherwise
-  // it will be determined from the source or the file type.
+  // any default shader stage then the given shader_stage will be used,
+  // otherwise it will be determined from the source or the file type.
   //
   // Places the compilation output into a new file whose name is derived from
   // input_file according to the rules from glslc/README.asciidoc.
@@ -111,10 +111,11 @@ class FileCompiler {
     PreprocessedText,   // Preprocessed source code.
   };
 
-  // Compiles the given string a the specified shader kind and using stored
-  // options. On success, writes the result to the given output stream and
-  // returns true.  On failure, returns false, and possibly emit messages to
-  // the standard error stream.
+  // Emits the compilation output from the given result to the given output
+  // stream and returns true if the result represents a successful compilation
+  // step.  Otherwise returns false and possibly emits messages to the standard
+  // error stream.  Accumulates error and warning counts for use by the
+  // OutputMessages() method.
   template <typename CompilationResultType>
   bool EmitCompiledResult(
       const CompilationResultType& result, const std::string& input_file_name,
@@ -136,8 +137,8 @@ class FileCompiler {
   //  If linking is not required, and the input file name does not have a
   //  standard stage extension, then also returns the directory-stripped input
   //  filename, but replaces its extension with the result extension. (If the
-  //  resolved input filename does not have an extension, then appends the result
-  //  extension.)
+  //  resolved input filename does not have an extension, then appends the
+  //  result extension.)
   //
   //  If linking is required and output filename is not specified, returns
   //  "a.spv".
@@ -195,9 +196,9 @@ class FileCompiler {
   // Name of the file where the compilation output will go.
   shaderc_util::string_piece output_file_name_;
 
-  // Counts warnings encountered in compilation.
+  // Counts warnings encountered in all compilations via this object.
   size_t total_warnings_;
-  // Counts errors encountered in compilation.
+  // Counts errors encountered in all compilations via this object.
   size_t total_errors_;
 };
 }  // namespace glslc

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -183,11 +183,9 @@ int main(int argc, char** argv) {
     } else if (arg == "-c") {
       compiler.SetIndividualCompilationFlag();
     } else if (arg == "-E") {
-      compiler.options().SetPreprocessingOnlyMode();
       compiler.SetPreprocessingOnlyFlag();
     } else if (arg == "-M" || arg == "-MM") {
       // -M implies -E and -w
-      compiler.options().SetPreprocessingOnlyMode();
       compiler.SetPreprocessingOnlyFlag();
       compiler.options().SetSuppressWarnings();
       if (compiler.GetDependencyDumpingHandler()->DumpingModeNotSet()) {
@@ -229,7 +227,6 @@ int main(int argc, char** argv) {
       compiler.GetDependencyDumpingHandler()->SetTarget(
           std::string(dep_file_name.data(), dep_file_name.size()));
     } else if (arg == "-S") {
-      compiler.options().SetDisassemblyMode();
       compiler.SetDisassemblyFlag();
     } else if (arg.starts_with("-D")) {
       const size_t length = arg.size();

--- a/libshaderc/CMakeLists.txt
+++ b/libshaderc/CMakeLists.txt
@@ -1,7 +1,11 @@
 project(libshaderc)
 
+# Even though shaderc.hpp is a headers-only library, adding
+# a dependency here will force clients of the library to rebuild
+# when it changes.
 add_library(shaderc STATIC
   include/shaderc/shaderc.h
+  include/shaderc/shaderc.hpp
   src/shaderc.cc
   src/shaderc_private.h
 )

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -239,12 +239,12 @@ typedef struct shaderc_compilation_result* shaderc_compilation_result_t;
 // doesn't have to be a 'file name'.
 // The source string will be compiled into SPIR-V binary and a
 // shaderc_compilation_result will be returned to hold the results.
-// compilation.  The entry_point_name null-terminated string defines the name
-// of the entry point to associate with this GLSL source. If the
-// additional_options parameter is not NULL, then the compilation is modified
-// by any options present. May be safely called from multiple threads without
-// explicit synchronization. If there was failure in allocating the compiler
-// object NULL will be returned.
+// The entry_point_name null-terminated string defines the name of the entry
+// point to associate with this GLSL source. If the additional_options
+// parameter is not null, then the compilation is modified by any options
+// present.  May be safely called from multiple threads without explicit
+// synchronization. If there was failure in allocating the compiler object,
+// null will be returned.
 shaderc_compilation_result_t shaderc_compile_into_spv(
     const shaderc_compiler_t compiler, const char* source_text,
     size_t source_text_size, shaderc_shader_kind shader_kind,

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -154,14 +154,6 @@ void shaderc_compile_options_add_macro_definition(
 void shaderc_compile_options_set_generate_debug_info(
     shaderc_compile_options_t options);
 
-// Sets the compiler mode to emit a disassembly text instead of a binary. In
-// this mode, the byte array result in the shaderc_compilation_result returned
-// from shaderc_compile_into_spv() will consist of SPIR-V assembly text.
-// Note the preprocessing only mode overrides this option, and this option
-// overrides the default mode generating a SPIR-V binary.
-void shaderc_compile_options_set_disassembly_mode(
-    shaderc_compile_options_t options);
-
 // Forces the GLSL language version and profile to a given pair. The version
 // number is the same as would appear in the #version annotation in the source.
 // Version and profile specified here overrides the #version annotation in the
@@ -209,13 +201,6 @@ void shaderc_compile_options_set_includer_callbacks(
     shaderc_compile_options_t options, shaderc_includer_response_get_fn getter,
     shaderc_includer_response_release_fn releaser, void* user_data);
 
-// Sets the compiler mode to do only preprocessing. The byte array stored in the
-// result object returned by the compilation is the text of the preprocessed
-// shader.  This option overrides all other compilation modes, such as
-// disassembly mode and the default mode of compilation to SPIR-V binary.
-void shaderc_compile_options_set_preprocessing_only_mode(
-    shaderc_compile_options_t options);
-
 // Sets the compiler mode to suppress warnings, overriding warnings-as-errors
 // mode. When both suppress-warnings and warnings-as-errors modes are
 // turned on, warning messages will be inhibited, and will not be emitted
@@ -237,7 +222,8 @@ void shaderc_compile_options_set_target_env(shaderc_compile_options_t options,
 void shaderc_compile_options_set_warnings_as_errors(
     shaderc_compile_options_t options);
 
-// An opaque handle to the results of a call to shaderc_compile_into_spv().
+// An opaque handle to the results of a call to any shaderc_compile_into_*()
+// function.
 typedef struct shaderc_compilation_result* shaderc_compilation_result_t;
 
 // Takes a GLSL source string and the associated shader kind, input file
@@ -251,17 +237,32 @@ typedef struct shaderc_compilation_result* shaderc_compilation_result_t;
 // The input_file_name is a null-termintated string. It is used as a tag to
 // identify the source string in cases like emitting error messages. It
 // doesn't have to be a 'file name'.
-// By default the source string will be compiled into SPIR-V binary and a
-// shaderc_compilation_result will be returned to hold the results of the
-// compilation. When disassembly mode or preprocessing only mode is enabled in
-// the additional_options, the source string will be compiled into char strings
-// and held by the returned shaderc_compilation_result. The entry_point_name
-// null-terminated string defines the name of the entry point to associate with
-// this GLSL source. If the additional_options parameter is not NULL, then the
-// compilation is modified by any options present. May be safely called from
-// multiple threads without explicit synchronization. If there was failure in
-// allocating the compiler object NULL will be returned.
+// The source string will be compiled into SPIR-V binary and a
+// shaderc_compilation_result will be returned to hold the results.
+// compilation.  The entry_point_name null-terminated string defines the name
+// of the entry point to associate with this GLSL source. If the
+// additional_options parameter is not NULL, then the compilation is modified
+// by any options present. May be safely called from multiple threads without
+// explicit synchronization. If there was failure in allocating the compiler
+// object NULL will be returned.
 shaderc_compilation_result_t shaderc_compile_into_spv(
+    const shaderc_compiler_t compiler, const char* source_text,
+    size_t source_text_size, shaderc_shader_kind shader_kind,
+    const char* input_file_name, const char* entry_point_name,
+    const shaderc_compile_options_t additional_options);
+
+// Like shaderc_compile_into_spv, but the result contains SPIR-V assembly text
+// instead of a SPIR-V binary module.  The SPIR-V assembly syntax is as defined
+// by the SPIRV-Tools open source project.
+shaderc_compilation_result_t shaderc_compile_into_spv_assembly(
+    const shaderc_compiler_t compiler, const char* source_text,
+    size_t source_text_size, shaderc_shader_kind shader_kind,
+    const char* input_file_name, const char* entry_point_name,
+    const shaderc_compile_options_t additional_options);
+
+// Like shaderc_compile_into_spv, but the result contains preprocessed source
+// code instead of a SPIR-V binary module
+shaderc_compilation_result_t shaderc_compile_into_preprocessed_text(
     const shaderc_compiler_t compiler, const char* source_text,
     size_t source_text_size, shaderc_shader_kind shader_kind,
     const char* input_file_name, const char* entry_point_name,
@@ -275,9 +276,7 @@ shaderc_compilation_result_t shaderc_compile_into_spv(
 void shaderc_result_release(shaderc_compilation_result_t result);
 
 // Returns the number of bytes of the compilation output data in a result
-// object. When the source is compiled with disassembly mode or preprocessing
-// only mode, the result string is a char string. Otherwise, the result string
-// is binary string.
+// object.
 size_t shaderc_result_get_length(const shaderc_compilation_result_t result);
 
 // Returns the number of warnings generated during the compilation.
@@ -295,9 +294,9 @@ shaderc_compilation_status shaderc_result_get_compilation_status(
 
 // Returns a pointer to the start of the compilation output data bytes, either
 // SPIR-V binary or char string. When the source string is compiled into SPIR-V
-// binary, this is guaranteed to be castable to a uint32_t*. If the source
-// string is compiled in disassembly mode or preprocessing only mode, the
-// pointer will point to the result char string.
+// binary, this is guaranteed to be castable to a uint32_t*. If the result
+// contains assembly text or preprocessed source text, the pointer will point to
+// the resulting array of characters.
 const char* shaderc_result_get_bytes(const shaderc_compilation_result_t result);
 
 // Returns a null-terminated string that contains any error messages generated

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -31,6 +31,9 @@ namespace shaderc {
 // Random Access Iterators", Nevin Liber, C++ Library Evolution Working
 // Group Working Paper N3884.
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3884.pdf
+//
+// Methods begin() and end() are also provided to enable range-based for.
+// They are synonyms to cbegin() and cend(), respectively.
 template <typename OutputElementType>
 class CompilationResult {
  public:
@@ -87,6 +90,11 @@ class CompilationResult {
            shaderc_result_get_length(compilation_result_) /
                sizeof(OutputElementType);
   }
+
+  // Returns the same iterator as cbegin().
+  const_iterator begin() const { return cbegin(); }
+  // Returns the same iterator as cend().
+  const_iterator end() const { return cend(); }
 
   // Returns the number of warnings generated during the compilation.
   size_t GetNumWarnings() const {
@@ -188,6 +196,9 @@ class CompileOptions {
   // shaderc_compile_into_spv() will consist of SPIR-V assembly text. Note the
   // preprocessing only mode overrides this option, and this option overrides
   // the default mode generating a SPIR-V binary.
+  //
+  // TODO(dneto): Remove this method. Instead, force disassembly by using
+  // Compiler::CompileGlslToSpvAssembly.
   void SetDisassemblyMode() {
     shaderc_compile_options_set_disassembly_mode(options_);
   }
@@ -206,6 +217,9 @@ class CompileOptions {
   // object returned by the compilation is the text of the preprocessed shader.
   // This option overrides all other compilation modes, such as disassembly mode
   // and the default mode of compilation to SPIR-V binary.
+  //
+  // TODO(dneto): Remove this method. Instead, force preprocessing-only by
+  // using Compiler::PreprocessGlsl.
   void SetPreprocessingOnlyMode() {
     shaderc_compile_options_set_preprocessing_only_mode(options_);
   }

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -72,8 +72,8 @@ class CompilationResult {
     return shaderc_result_get_compilation_status(compilation_result_);
   }
 
-  // Returns an iterator pointing to the start of the compilation
-  // output.  It is valid for the lifetime of this object.
+  // Returns a random access (contiguous) iterator pointing to the start
+  // of the compilation output.  It is valid for the lifetime of this object.
   // If there is no compilation result, then returns nullptr.
   const_iterator cbegin() const {
     if (!compilation_result_) return nullptr;
@@ -81,8 +81,8 @@ class CompilationResult {
         shaderc_result_get_bytes(compilation_result_));
   }
 
-  // Returns an iterator pointing to the end of the compilation
-  // output.  It is valid for the lifetime of this object.
+  // Returns a random access (contiguous) iterator pointing to the end of
+  // the compilation output.  It is valid for the lifetime of this object.
   // If there is no compilation result, then returns nullptr.
   const_iterator cend() const {
     if (!compilation_result_) return nullptr;
@@ -191,18 +191,6 @@ class CompileOptions {
         includer_.get());
   }
 
-  // Sets the compiler to emit a disassembly text instead of a binary. In this
-  // mode, the byte array result in the shaderc_compilation_result returned from
-  // shaderc_compile_into_spv() will consist of SPIR-V assembly text. Note the
-  // preprocessing only mode overrides this option, and this option overrides
-  // the default mode generating a SPIR-V binary.
-  //
-  // TODO(dneto): Remove this method. Instead, force disassembly by using
-  // Compiler::CompileGlslToSpvAssembly.
-  void SetDisassemblyMode() {
-    shaderc_compile_options_set_disassembly_mode(options_);
-  }
-
   // Forces the GLSL language version and profile to a given pair. The version
   // number is the same as would appear in the #version annotation in the
   // source. Version and profile specified here overrides the #version
@@ -211,17 +199,6 @@ class CompileOptions {
   void SetForcedVersionProfile(int version, shaderc_profile profile) {
     shaderc_compile_options_set_forced_version_profile(options_, version,
                                                        profile);
-  }
-
-  // Sets the compiler to do only preprocessing. The byte array in the result
-  // object returned by the compilation is the text of the preprocessed shader.
-  // This option overrides all other compilation modes, such as disassembly mode
-  // and the default mode of compilation to SPIR-V binary.
-  //
-  // TODO(dneto): Remove this method. Instead, force preprocessing-only by
-  // using Compiler::PreprocessGlsl.
-  void SetPreprocessingOnlyMode() {
-    shaderc_compile_options_set_preprocessing_only_mode(options_);
   }
 
   // Sets the compiler mode to suppress warnings. Note this option overrides
@@ -346,10 +323,10 @@ class Compiler {
       const char* source_text, size_t source_text_size,
       shaderc_shader_kind shader_kind, const char* input_file_name,
       const CompileOptions& options) const {
-    // TODO(dneto): Make and use a different C API function.
-    shaderc_compilation_result_t compilation_result = shaderc_compile_into_spv(
-        compiler_, source_text, source_text_size, shader_kind, input_file_name,
-        "main", options.options_);
+    shaderc_compilation_result_t compilation_result =
+        shaderc_compile_into_spv_assembly(
+            compiler_, source_text, source_text_size, shader_kind,
+            input_file_name, "main", options.options_);
     return AssemblyCompilationResult(compilation_result);
   }
 
@@ -371,10 +348,10 @@ class Compiler {
       const char* source_text, size_t source_text_size,
       shaderc_shader_kind shader_kind, const char* input_file_name,
       const CompileOptions& options) const {
-    // TODO(dneto): Make and use a different C API function.
-    shaderc_compilation_result_t compilation_result = shaderc_compile_into_spv(
-        compiler_, source_text, source_text_size, shader_kind, input_file_name,
-        "main", options.options_);
+    shaderc_compilation_result_t compilation_result =
+        shaderc_compile_into_preprocessed_text(
+            compiler_, source_text, source_text_size, shader_kind,
+            input_file_name, "main", options.options_);
     return PreprocessedSourceCompilationResult(compilation_result);
   }
 

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -25,13 +25,15 @@
 
 namespace {
 
+using shaderc::AssemblyCompilationResult;
 using shaderc::CompileOptions;
 using testing::Each;
 using testing::HasSubstr;
 
 // Helper function to check if the compilation result indicates a successful
 // compilation.
-bool CompilationResultIsSuccess(const shaderc::CompilationResult& result) {
+template <typename T>
+bool CompilationResultIsSuccess(const shaderc::CompilationResult<T>& result) {
   return result.GetCompilationStatus() == shaderc_compilation_status_success;
 }
 
@@ -39,12 +41,12 @@ bool CompilationResultIsSuccess(const shaderc::CompilationResult& result) {
 // magic number in the fixed postion of the byte array in the result object.
 // Returns true if the magic number is found at the correct postion, otherwise
 // returns false.
-bool IsValidSpv(const shaderc::CompilationResult& result) {
+template <typename T>
+bool IsValidSpv(const shaderc::CompilationResult<T>& result) {
   if (!CompilationResultIsSuccess(result)) return false;
-  size_t length = result.GetLength();
-  if (length < 20) return false;
-  const uint32_t* bytes =
-      static_cast<const uint32_t*>(static_cast<const void*>(result.GetData()));
+  size_t length_in_words = result.cend() - result.cbegin();
+  if (length_in_words < 5) return false;
+  const uint32_t* bytes = result.cbegin();
   return bytes[0] == spv::MagicNumber;
 }
 
@@ -61,6 +63,14 @@ bool CompilesToValidSpv(const shaderc::Compiler& compiler,
                         const std::string& shader, shaderc_shader_kind kind,
                         const CompileOptions& options) {
   return IsValidSpv(compiler.CompileGlslToSpv(shader, kind, "shader", options));
+}
+
+// Returns the compiler's output from a compilation result as a string.
+template <typename T>
+std::string CompilerOutputAsString(
+    const shaderc::CompilationResult<T>& result) {
+  return std::string(reinterpret_cast<const char*>(result.cbegin()),
+                     reinterpret_cast<const char*>(result.cend()));
 }
 
 class CppInterface : public testing::Test {
@@ -126,12 +136,8 @@ class CppInterface : public testing::Test {
     const auto compilation_result =
         compiler_.CompileGlslToSpv(shader, kind, "shader", options);
     EXPECT_TRUE(CompilationResultIsSuccess(compilation_result)) << kind << '\n';
-    // Use string(const char* s, size_t n) constructor instead of
-    // string(const char* s) to make sure the string has complete binary data.
-    // string(const char* s) assumes a null-terminated C-string, which will cut
-    // the binary data when it sees a '\0' byte.
-    return std::string(compilation_result.GetData(),
-                       compilation_result.GetLength());
+    // Need to make sure you get complete binary data, including embedded nulls.
+    return CompilerOutputAsString(compilation_result);
   }
 
   // For compiling shaders in subclass tests:
@@ -183,10 +189,10 @@ TEST_F(CppInterface, EmptyString) {
 }
 
 TEST_F(CppInterface, ResultObjectMoves) {
-  shaderc::CompilationResult result = compiler_.CompileGlslToSpv(
+  shaderc::SpvCompilationResult result = compiler_.CompileGlslToSpv(
       kMinimalShader, shaderc_glsl_vertex_shader, "shader");
   EXPECT_TRUE(CompilationResultIsSuccess(result));
-  shaderc::CompilationResult result2(std::move(result));
+  shaderc::SpvCompilationResult result2(std::move(result));
   EXPECT_FALSE(CompilationResultIsSuccess(result));
   EXPECT_TRUE(CompilationResultIsSuccess(result2));
 }
@@ -227,22 +233,19 @@ TEST_F(CppInterface, MovedOptions) {
 }
 
 TEST_F(CppInterface, StdAndCString) {
-  shaderc::CompilationResult result1 =
+  shaderc::SpvCompilationResult result1 =
       compiler_.CompileGlslToSpv(kMinimalShader, strlen(kMinimalShader),
                                  shaderc_glsl_fragment_shader, "shader");
-  shaderc::CompilationResult result2 = compiler_.CompileGlslToSpv(
+  shaderc::SpvCompilationResult result2 = compiler_.CompileGlslToSpv(
       std::string(kMinimalShader), shaderc_glsl_fragment_shader, "shader");
   EXPECT_TRUE(CompilationResultIsSuccess(result1));
   EXPECT_TRUE(CompilationResultIsSuccess(result2));
-  EXPECT_EQ(result1.GetLength(), result2.GetLength());
-  EXPECT_EQ(std::vector<char>(result1.GetData(),
-                              result1.GetData() + result1.GetLength()),
-            std::vector<char>(result2.GetData(),
-                              result2.GetData() + result2.GetLength()));
+  EXPECT_EQ(std::vector<uint32_t>(result1.cbegin(), result1.cend()),
+            std::vector<uint32_t>(result2.cbegin(), result2.cend()));
 }
 
 TEST_F(CppInterface, ErrorsReported) {
-  shaderc::CompilationResult result = compiler_.CompileGlslToSpv(
+  shaderc::SpvCompilationResult result = compiler_.CompileGlslToSpv(
       "int f(){return wrongname;}", shaderc_glsl_vertex_shader, "shader");
   ASSERT_FALSE(CompilationResultIsSuccess(result));
   EXPECT_THAT(result.GetErrorMessage(), HasSubstr("wrongname"));
@@ -263,11 +266,11 @@ TEST_F(CppInterface, MultipleThreadsCalling) {
 }
 
 TEST_F(CppInterface, AccessorsOnNullResultObject) {
-  shaderc::CompilationResult result(nullptr);
+  shaderc::SpvCompilationResult result(nullptr);
   EXPECT_FALSE(CompilationResultIsSuccess(result));
   EXPECT_EQ(std::string(), result.GetErrorMessage());
-  EXPECT_EQ(std::string(), result.GetData());
-  EXPECT_EQ(0u, result.GetLength());
+  EXPECT_EQ(result.cend(), result.cbegin());
+  EXPECT_EQ(nullptr, result.cbegin());
 }
 
 TEST_F(CppInterface, MacroCompileOptions) {
@@ -295,34 +298,34 @@ TEST_F(CppInterface, MacroCompileOptions) {
                                  shaderc_glsl_vertex_shader, cloned_options));
 }
 
-TEST_F(CppInterface, DisassemblyOption) {
+TEST_F(CppInterface, D_DisassemblyOption) {
   options_.SetDisassemblyMode();
-  shaderc::CompilationResult result = compiler_.CompileGlslToSpv(
+  const AssemblyCompilationResult result = compiler_.CompileGlslToSpvAssembly(
       kMinimalShader, shaderc_glsl_vertex_shader, "shader", options_);
   EXPECT_TRUE(CompilationResultIsSuccess(result));
   // This should work with both the glslang native disassembly format and the
   // SPIR-V Tools assembly format.
-  EXPECT_THAT(result.GetData(), HasSubstr("Capability Shader"));
-  EXPECT_THAT(result.GetData(), HasSubstr("MemoryModel"));
+  EXPECT_THAT(CompilerOutputAsString(result), HasSubstr("Capability Shader"));
+  EXPECT_THAT(CompilerOutputAsString(result), HasSubstr("MemoryModel"));
 
   CompileOptions cloned_options(options_);
-  shaderc::CompilationResult result_from_cloned_options =
-      compiler_.CompileGlslToSpv(kMinimalShader, shaderc_glsl_vertex_shader,
-                                 "shader", cloned_options);
+  auto result_from_cloned_options = compiler_.CompileGlslToSpv(
+      kMinimalShader, shaderc_glsl_vertex_shader, "shader", cloned_options);
   EXPECT_TRUE(CompilationResultIsSuccess(result_from_cloned_options));
   // The mode should be carried into any clone of the original option object.
-  EXPECT_THAT(result_from_cloned_options.GetData(),
+  EXPECT_THAT(CompilerOutputAsString(result_from_cloned_options),
               HasSubstr("Capability Shader"));
-  EXPECT_THAT(result_from_cloned_options.GetData(), HasSubstr("MemoryModel"));
+  EXPECT_THAT(CompilerOutputAsString(result_from_cloned_options),
+              HasSubstr("MemoryModel"));
 }
 
 TEST_F(CppInterface, DisassembleMinimalShader) {
   options_.SetDisassemblyMode();
-  shaderc::CompilationResult result = compiler_.CompileGlslToSpv(
+  const AssemblyCompilationResult result = compiler_.CompileGlslToSpvAssembly(
       kMinimalShader, shaderc_glsl_vertex_shader, "shader", options_);
   EXPECT_TRUE(CompilationResultIsSuccess(result));
   for (const auto& substring : kMinimalShaderDisassemblySubstrings) {
-    EXPECT_THAT(result.GetData(), HasSubstr(substring));
+    EXPECT_THAT(CompilerOutputAsString(result), HasSubstr(substring));
   }
 }
 
@@ -432,7 +435,7 @@ TEST_F(CppInterface, GenerateDebugInfoDisassemblyClonedOptions) {
 
 TEST_F(CppInterface, GetNumErrors) {
   std::string shader(kTwoErrorsShader);
-  const shaderc::CompilationResult compilation_result =
+  const shaderc::SpvCompilationResult compilation_result =
       compiler_.CompileGlslToSpv(kTwoErrorsShader, strlen(kTwoErrorsShader),
                                  shaderc_glsl_vertex_shader, "shader");
   EXPECT_FALSE(CompilationResultIsSuccess(compilation_result));
@@ -441,7 +444,7 @@ TEST_F(CppInterface, GetNumErrors) {
 }
 
 TEST_F(CppInterface, GetNumWarnings) {
-  const shaderc::CompilationResult compilation_result =
+  const shaderc::SpvCompilationResult compilation_result =
       compiler_.CompileGlslToSpv(kTwoWarningsShader, strlen(kTwoWarningsShader),
                                  shaderc_glsl_vertex_shader, "shader");
   EXPECT_TRUE(CompilationResultIsSuccess(compilation_result));
@@ -450,7 +453,7 @@ TEST_F(CppInterface, GetNumWarnings) {
 }
 
 TEST_F(CppInterface, ZeroErrorsZeroWarnings) {
-  const shaderc::CompilationResult compilation_result =
+  const shaderc::SpvCompilationResult compilation_result =
       compiler_.CompileGlslToSpv(kMinimalShader, strlen(kMinimalShader),
                                  shaderc_glsl_vertex_shader, "shader");
   EXPECT_TRUE(CompilationResultIsSuccess(compilation_result));
@@ -461,7 +464,7 @@ TEST_F(CppInterface, ZeroErrorsZeroWarnings) {
 TEST_F(CppInterface, ErrorTypeUnknownShaderStage) {
   // The shader kind/stage can not be determined, the error type field should
   // indicate the error type is shaderc_shader_kind_error.
-  const shaderc::CompilationResult compilation_result =
+  const shaderc::SpvCompilationResult compilation_result =
       compiler_.CompileGlslToSpv(kMinimalShader, strlen(kMinimalShader),
                                  shaderc_glsl_infer_from_source, "shader");
   EXPECT_EQ(shaderc_compilation_status_invalid_stage,
@@ -471,7 +474,7 @@ TEST_F(CppInterface, ErrorTypeUnknownShaderStage) {
 TEST_F(CppInterface, ErrorTypeCompilationError) {
   // The shader kind is valid, the result object's error type field should
   // indicate this compilaion fails due to compilation errors.
-  const shaderc::CompilationResult compilation_result =
+  const shaderc::SpvCompilationResult compilation_result =
       compiler_.CompileGlslToSpv(kTwoErrorsShader, shaderc_glsl_vertex_shader,
                                  "shader");
   EXPECT_EQ(shaderc_compilation_status_compilation_error,
@@ -480,7 +483,7 @@ TEST_F(CppInterface, ErrorTypeCompilationError) {
 
 TEST_F(CppInterface, ErrorTagIsInputFileName) {
   std::string shader(kTwoErrorsShader);
-  const shaderc::CompilationResult compilation_result =
+  const shaderc::SpvCompilationResult compilation_result =
       compiler_.CompileGlslToSpv(kTwoErrorsShader, strlen(kTwoErrorsShader),
                                  shaderc_glsl_vertex_shader, "SampleInputFile");
   // Expects compilation failure errors. The error tag should be
@@ -492,22 +495,22 @@ TEST_F(CppInterface, ErrorTagIsInputFileName) {
 
 TEST_F(CppInterface, PreprocessingOnlyOption) {
   options_.SetPreprocessingOnlyMode();
-  shaderc::CompilationResult result = compiler_.CompileGlslToSpv(
+  const shaderc::AssemblyCompilationResult result = compiler_.PreprocessGlsl(
       kMinimalShaderWithMacro, shaderc_glsl_vertex_shader, "shader", options_);
   EXPECT_TRUE(CompilationResultIsSuccess(result));
-  EXPECT_THAT(result.GetData(), HasSubstr("void main(){ }"));
+  EXPECT_THAT(CompilerOutputAsString(result), HasSubstr("void main(){ }"));
 
   const std::string kMinimalShaderCloneOption =
       "#version 140\n"
       "#define E_CLONE_OPTION main\n"
       "void E_CLONE_OPTION(){}\n";
   CompileOptions cloned_options(options_);
-  shaderc::CompilationResult result_from_cloned_options =
+  shaderc::SpvCompilationResult result_from_cloned_options =
       compiler_.CompileGlslToSpv(kMinimalShaderCloneOption,
                                  shaderc_glsl_vertex_shader, "shader",
                                  cloned_options);
   EXPECT_TRUE(CompilationResultIsSuccess(result_from_cloned_options));
-  EXPECT_THAT(result_from_cloned_options.GetData(),
+  EXPECT_THAT(CompilerOutputAsString(result_from_cloned_options),
               HasSubstr("void main(){ }"));
 }
 
@@ -516,26 +519,28 @@ TEST_F(CppInterface, PreprocessingOnlyModeFirstOverridesDisassemblyMode) {
   // Preprocessing only mode should override disassembly mode.
   options_.SetPreprocessingOnlyMode();
   options_.SetDisassemblyMode();
-  shaderc::CompilationResult result_preprocessing_mode_first =
-      compiler_.CompileGlslToSpv(kMinimalShaderWithMacro,
-                                 shaderc_glsl_vertex_shader, "shader",
-                                 options_);
+  const shaderc::PreprocessedSourceCompilationResult
+      result_preprocessing_mode_first = compiler_.PreprocessGlsl(
+          kMinimalShaderWithMacro, shaderc_glsl_vertex_shader, "shader",
+          options_);
   EXPECT_TRUE(CompilationResultIsSuccess(result_preprocessing_mode_first));
-  EXPECT_THAT(result_preprocessing_mode_first.GetData(),
+  EXPECT_THAT(CompilerOutputAsString(result_preprocessing_mode_first),
               HasSubstr("void main(){ }"));
 }
 
+// TODO(dneto): Consider removing this test.  The client layer should manage
+// priorities among compiler options.
 TEST_F(CppInterface, PreprocessingOnlyModeSecondOverridesDisassemblyMode) {
   // Sets disassembly mode first, then preprocessing only mode.
   // Preprocessing only mode should still override disassembly mode.
   options_.SetDisassemblyMode();
   options_.SetPreprocessingOnlyMode();
-  shaderc::CompilationResult result_disassembly_mode_first =
-      compiler_.CompileGlslToSpv(kMinimalShaderWithMacro,
-                                 shaderc_glsl_vertex_shader, "shader",
-                                 options_);
+  // TODO(dneto): It's dubious whether we should be able to call
+  // CompileGlslToSpv in this case.
+  const auto result_disassembly_mode_first = compiler_.CompileGlslToSpv(
+      kMinimalShaderWithMacro, shaderc_glsl_vertex_shader, "shader", options_);
   EXPECT_TRUE(CompilationResultIsSuccess(result_disassembly_mode_first));
-  EXPECT_THAT(result_disassembly_mode_first.GetData(),
+  EXPECT_THAT(CompilerOutputAsString(result_disassembly_mode_first),
               HasSubstr("void main(){ }"));
 }
 
@@ -675,11 +680,10 @@ TEST_P(IncluderTests, SetIncluder) {
   CompileOptions options;
   options.SetIncluder(std::unique_ptr<TestIncluder>(new TestIncluder(fs)));
   options.SetPreprocessingOnlyMode();
-  const shaderc::CompilationResult compilation_result =
-      compiler.CompileGlslToSpv(shader.c_str(), shaderc_glsl_vertex_shader,
-                                "shader", options);
+  const auto compilation_result = compiler.PreprocessGlsl(
+      shader.c_str(), shaderc_glsl_vertex_shader, "shader", options);
   // Checks the existence of the expected string.
-  EXPECT_THAT(compilation_result.GetData(),
+  EXPECT_THAT(CompilerOutputAsString(compilation_result),
               HasSubstr(test_case.expected_substring()));
 }
 
@@ -694,11 +698,10 @@ TEST_P(IncluderTests, SetIncluderClonedOptions) {
 
   // Cloned options should have all the settings.
   CompileOptions cloned_options(options);
-  const shaderc::CompilationResult compilation_result =
-      compiler.CompileGlslToSpv(shader.c_str(), shaderc_glsl_vertex_shader,
-                                "shader", cloned_options);
+  const auto compilation_result = compiler.PreprocessGlsl(
+      shader.c_str(), shaderc_glsl_vertex_shader, "shader", cloned_options);
   // Checks the existence of the expected string.
-  EXPECT_THAT(compilation_result.GetData(),
+  EXPECT_THAT(CompilerOutputAsString(compilation_result),
               HasSubstr(test_case.expected_substring()));
 }
 

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -72,7 +72,7 @@ enum class OutputType {
 // Generate a compilation result object with the given compile,
 // shader source, shader kind, input file name, options, and for the
 // specified output type.
-static shaderc_compilation_result_t MakeCompilationResult(
+shaderc_compilation_result_t MakeCompilationResult(
     const shaderc_compiler_t compiler, const std::string& shader,
     shaderc_shader_kind kind, const char* input_file_name,
     const shaderc_compile_options_t options, OutputType output_type) {

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -62,16 +62,52 @@ TEST(Init, SPVVersion) {
   EXPECT_EQ(spv::Revision, revision);
 }
 
+// Determines the kind of output required from the compiler.
+enum class OutputType {
+  SpirvBinary,
+  SpirvAssemblyText,
+  PreprocessedText,
+};
+
+// Generate a compilation result object with the given compile,
+// shader source, shader kind, input file name, options, and for the
+// specified output type.
+static shaderc_compilation_result_t MakeCompilationResult(
+    const shaderc_compiler_t compiler, const std::string& shader,
+    shaderc_shader_kind kind, const char* input_file_name,
+    const shaderc_compile_options_t options, OutputType output_type) {
+  switch (output_type) {
+    case OutputType::SpirvBinary:
+      return shaderc_compile_into_spv(compiler, shader.c_str(), shader.size(),
+                                      kind, input_file_name, "", options);
+      break;
+    case OutputType::SpirvAssemblyText:
+      return shaderc_compile_into_spv_assembly(compiler, shader.c_str(),
+                                               shader.size(), kind,
+                                               input_file_name, "", options);
+      break;
+    case OutputType::PreprocessedText:
+      return shaderc_compile_into_preprocessed_text(
+          compiler, shader.c_str(), shader.size(), kind, input_file_name, "",
+          options);
+      break;
+  }
+  // We shouldn't reach here.  But some compilers might not know that.
+  // Be a little defensive and produce something.
+  return shaderc_compile_into_spv(compiler, shader.c_str(), shader.size(), kind,
+                                  input_file_name, "", options);
+}
+
 // RAII class for shaderc_compilation_result.
 class Compilation {
  public:
   // Compiles shader, keeping the result.
   Compilation(const shaderc_compiler_t compiler, const std::string& shader,
               shaderc_shader_kind kind, const char* input_file_name,
-              const shaderc_compile_options_t options = nullptr)
-      : compiled_result_(
-            shaderc_compile_into_spv(compiler, shader.c_str(), shader.size(),
-                                     kind, input_file_name, "", options)) {}
+              const shaderc_compile_options_t options = nullptr,
+              OutputType output_type = OutputType::SpirvBinary)
+      : compiled_result_(MakeCompilationResult(
+            compiler, shader, kind, input_file_name, options, output_type)) {}
 
   ~Compilation() { shaderc_result_release(compiled_result_); }
 
@@ -113,7 +149,7 @@ bool CompilesToValidSpv(Compiler& compiler, const std::string& shader,
                         shaderc_shader_kind kind,
                         const shaderc_compile_options_t options = nullptr) {
   const Compilation comp(compiler.get_compiler_handle(), shader, kind, "shader",
-                         options);
+                         options, OutputType::SpirvBinary);
   auto result = comp.result();
   if (!CompilationResultIsSuccess(result)) return false;
   size_t length = shaderc_result_get_length(result);
@@ -132,10 +168,11 @@ class CompileStringTest : public testing::Test {
  protected:
   // Compiles a shader and returns true on success, false on failure.
   bool CompilationSuccess(const std::string& shader, shaderc_shader_kind kind,
-                          shaderc_compile_options_t options = nullptr) {
+                          shaderc_compile_options_t options = nullptr,
+                          OutputType output_type = OutputType::SpirvBinary) {
     return CompilationResultIsSuccess(
         Compilation(compiler_.get_compiler_handle(), shader, kind, "shader",
-                    options)
+                    options, output_type)
             .result());
   }
 
@@ -143,9 +180,10 @@ class CompileStringTest : public testing::Test {
   // messages.
   const std::string CompilationWarnings(
       const std::string& shader, shaderc_shader_kind kind,
-      const shaderc_compile_options_t options = nullptr) {
+      const shaderc_compile_options_t options = nullptr,
+      OutputType output_type = OutputType::SpirvBinary) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           "shader", options);
+                           "shader", options, output_type);
     EXPECT_TRUE(CompilationResultIsSuccess(comp.result())) << kind << '\n'
                                                            << shader;
     return shaderc_result_get_error_message(comp.result());
@@ -154,9 +192,10 @@ class CompileStringTest : public testing::Test {
   // Compiles a shader, expects compilation failure, and returns the messages.
   const std::string CompilationErrors(
       const std::string& shader, shaderc_shader_kind kind,
-      const shaderc_compile_options_t options = nullptr) {
+      const shaderc_compile_options_t options = nullptr,
+      OutputType output_type = OutputType::SpirvBinary) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           "shader", options);
+                           "shader", options, output_type);
     EXPECT_FALSE(CompilationResultIsSuccess(comp.result())) << kind << '\n'
                                                             << shader;
     return shaderc_result_get_error_message(comp.result());
@@ -165,9 +204,10 @@ class CompileStringTest : public testing::Test {
   // Compiles a shader and returns the messages.
   const std::string CompilationMessages(
       const std::string& shader, shaderc_shader_kind kind,
-      const shaderc_compile_options_t options = nullptr) {
+      const shaderc_compile_options_t options = nullptr,
+      OutputType output_type = OutputType::SpirvBinary) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           "shader", options);
+                           "shader", options, output_type);
     return shaderc_result_get_error_message(comp.result());
   };
 
@@ -175,9 +215,10 @@ class CompileStringTest : public testing::Test {
   // bytes.
   const std::string CompilationOutput(
       const std::string& shader, shaderc_shader_kind kind,
-      const shaderc_compile_options_t options = nullptr) {
+      const shaderc_compile_options_t options = nullptr,
+      OutputType output_type = OutputType::SpirvBinary) {
     const Compilation comp(compiler_.get_compiler_handle(), shader, kind,
-                           "shader", options);
+                           "shader", options, output_type);
     EXPECT_TRUE(CompilationResultIsSuccess(comp.result())) << kind << '\n'
                                                            << shader;
     // Use string(const char* s, size_t n) constructor instead of
@@ -355,29 +396,20 @@ TEST_F(CompileStringWithOptionsTest, ValuelessMacroCompileOptionsNullPointer) {
 
 TEST_F(CompileStringWithOptionsTest, DisassemblyOption) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
-  shaderc_compile_options_set_disassembly_mode(options_.get());
-  // This should work with both the glslang native disassembly format and the
+  // This should work with both the glslang native assembly format and the
   // SPIR-V tools assembly format.
-  const std::string disassembly_text = CompilationOutput(
-      kMinimalShader, shaderc_glsl_vertex_shader, options_.get());
+  const std::string disassembly_text =
+      CompilationOutput(kMinimalShader, shaderc_glsl_vertex_shader,
+                        options_.get(), OutputType::SpirvAssemblyText);
   EXPECT_THAT(disassembly_text, HasSubstr("Capability Shader"));
   EXPECT_THAT(disassembly_text, HasSubstr("MemoryModel"));
-
-  // The mode should be carried into any clone of the original option object.
-  compile_options_ptr cloned_options(
-      shaderc_compile_options_clone(options_.get()));
-  const std::string disassembly_text_cloned_options = CompilationOutput(
-      kMinimalShader, shaderc_glsl_vertex_shader, cloned_options.get());
-  EXPECT_THAT(disassembly_text_cloned_options, HasSubstr("Capability Shader"));
-  EXPECT_THAT(disassembly_text_cloned_options, HasSubstr("MemoryModel"));
 }
 
 TEST_F(CompileStringWithOptionsTest, DisassembleMinimalShader) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
-  shaderc_compile_options_set_disassembly_mode(options_.get());
-
-  const std::string disassembly_text = CompilationOutput(
-      kMinimalShader, shaderc_glsl_vertex_shader, options_.get());
+  const std::string disassembly_text =
+      CompilationOutput(kMinimalShader, shaderc_glsl_vertex_shader,
+                        options_.get(), OutputType::SpirvAssemblyText);
   for (const auto& substring : kMinimalShaderDisassemblySubstrings) {
     EXPECT_THAT(disassembly_text, HasSubstr(substring));
   }
@@ -489,26 +521,25 @@ TEST_F(CompileStringWithOptionsTest, GenerateDebugInfoBinaryClonedOptions) {
 
 TEST_F(CompileStringWithOptionsTest, GenerateDebugInfoDisassembly) {
   shaderc_compile_options_set_generate_debug_info(options_.get());
-  // Sets compiler to disassembly mode so that we can compare its output as
-  // a string.
-  shaderc_compile_options_set_disassembly_mode(options_.get());
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
+  // Generate assembly text we can compare its output as a string.
   // The disassembly output should contain the name of the vector:
   // debug_info_sample.
-  EXPECT_THAT(CompilationOutput(kMinimalDebugInfoShader,
-                                shaderc_glsl_vertex_shader, options_.get()),
-              HasSubstr("debug_info_sample"));
+  EXPECT_THAT(
+      CompilationOutput(kMinimalDebugInfoShader, shaderc_glsl_vertex_shader,
+                        options_.get(), OutputType::SpirvAssemblyText),
+      HasSubstr("debug_info_sample"));
 }
 
 TEST_F(CompileStringWithOptionsTest, PreprocessingOnlyOption) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
-  shaderc_compile_options_set_preprocessing_only_mode(options_.get());
   const std::string kMinimalShaderWithMacro =
       "#version 150\n"
       "#define E main\n"
       "void E(){}\n";
-  const std::string preprocessed_text = CompilationOutput(
-      kMinimalShaderWithMacro, shaderc_glsl_vertex_shader, options_.get());
+  const std::string preprocessed_text =
+      CompilationOutput(kMinimalShaderWithMacro, shaderc_glsl_vertex_shader,
+                        options_.get(), OutputType::PreprocessedText);
   EXPECT_THAT(preprocessed_text, HasSubstr("void main(){ }"));
 
   const std::string kMinimalShaderWithMacroCloneOption =
@@ -517,9 +548,9 @@ TEST_F(CompileStringWithOptionsTest, PreprocessingOnlyOption) {
       "void E_CLONE_OPTION(){}\n";
   compile_options_ptr cloned_options(
       shaderc_compile_options_clone(options_.get()));
-  const std::string preprocessed_text_cloned_options =
-      CompilationOutput(kMinimalShaderWithMacroCloneOption,
-                        shaderc_glsl_vertex_shader, options_.get());
+  const std::string preprocessed_text_cloned_options = CompilationOutput(
+      kMinimalShaderWithMacroCloneOption, shaderc_glsl_vertex_shader,
+      options_.get(), OutputType::PreprocessedText);
   EXPECT_THAT(preprocessed_text_cloned_options, HasSubstr("void main(){ }"));
 }
 
@@ -672,13 +703,13 @@ TEST_P(IncluderTests, SetIncluderCallbacks) {
   TestIncluder includer(fs);
   Compiler compiler;
   compile_options_ptr options(shaderc_compile_options_initialize());
-  shaderc_compile_options_set_preprocessing_only_mode(options.get());
   shaderc_compile_options_set_includer_callbacks(
       options.get(), TestIncluder::GetIncluderResponseWrapper,
       TestIncluder::ReleaseIncluderResponseWrapper, &includer);
 
   const Compilation comp(compiler.get_compiler_handle(), shader,
-                         shaderc_glsl_vertex_shader, "shader", options.get());
+                         shaderc_glsl_vertex_shader, "shader", options.get(),
+                         OutputType::PreprocessedText);
   // Checks the existence of the expected string.
   EXPECT_THAT(shaderc_result_get_bytes(comp.result()),
               HasSubstr(test_case.expected_substring()));
@@ -691,7 +722,6 @@ TEST_P(IncluderTests, SetIncluderCallbacksClonedOptions) {
   TestIncluder includer(fs);
   Compiler compiler;
   compile_options_ptr options(shaderc_compile_options_initialize());
-  shaderc_compile_options_set_preprocessing_only_mode(options.get());
   shaderc_compile_options_set_includer_callbacks(
       options.get(), TestIncluder::GetIncluderResponseWrapper,
       TestIncluder::ReleaseIncluderResponseWrapper, &includer);
@@ -702,7 +732,7 @@ TEST_P(IncluderTests, SetIncluderCallbacksClonedOptions) {
 
   const Compilation comp(compiler.get_compiler_handle(), shader,
                          shaderc_glsl_vertex_shader, "shader",
-                         cloned_options.get());
+                         cloned_options.get(), OutputType::PreprocessedText);
   // Checks the existence of the expected string.
   EXPECT_THAT(shaderc_result_get_bytes(comp.result()),
               HasSubstr(test_case.expected_substring()));
@@ -904,25 +934,29 @@ TEST_F(CompileStringWithOptionsTest,
   // This test is disabled since some versions of glslang may refuse to compile
   // very old shaders to SPIR-V with OpenGL target. Re-enable and rewrite this
   // test once we have a differential set of environments to test.
-  shaderc_compile_options_set_preprocessing_only_mode(options_.get());
+  const auto output_type = OutputType::PreprocessedText;
 
   EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityFragmentShader,
-                                 shaderc_glsl_fragment_shader, options_.get()));
+                                 shaderc_glsl_fragment_shader, options_.get(),
+                                 output_type));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_opengl_compat, 0);
   EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityFragmentShader,
-                                 shaderc_glsl_fragment_shader, options_.get()));
+                                 shaderc_glsl_fragment_shader, options_.get(),
+                                 output_type));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_opengl, 0);
   EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityFragmentShader,
-                                 shaderc_glsl_fragment_shader, options_.get()));
+                                 shaderc_glsl_fragment_shader, options_.get(),
+                                 output_type));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_vulkan, 0);
   EXPECT_TRUE(CompilationSuccess(kOpenGLCompatibilityFragmentShader,
-                                 shaderc_glsl_fragment_shader, options_.get()));
+                                 shaderc_glsl_fragment_shader, options_.get(),
+                                 output_type));
 }
 
 TEST_F(CompileStringTest, ShaderKindRespected) {


### PR DESCRIPTION
Class shaderc::CompilationResult is a template over the element type for
the compilation output. It has three specializations: for a SPIR-V
binary module (with uint32_t element type), SPIR-V assembly text (char
element type), and preprocessed source (char element type).

TODO: Should probably also change the C API to make different entry points
for different output types.