### PR TITLE
Export the includes in the android.mk file

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -26,7 +26,33 @@ $(1)/libshaderc_combined.a: $(addprefix $(1)/, $(ALL_LIBS)) $(1)/combine.ar
 	@cd $(1) && $(2)ar -M < combine.ar && cd -
 	@$(2)objcopy --strip-debug $(1)/libshaderc_combined.a
 
-libshaderc_combined:$(1)/libshaderc_combined.a
+$(NDK_APP_LIBS_OUT)/$(APP_STL)/$(TARGET_ARCH_ABI)/libshaderc.a: \
+		$(1)/libshaderc_combined.a
+	$(call host-mkdir,$(NDK_APP_LIBS_OUT)/$(APP_STL)/$(TARGET_ARCH_ABI))
+	$(call host-cp,$(1)/libshaderc_combined.a \
+		$(NDK_APP_LIBS_OUT)/$(APP_STL)/$(TARGET_ARCH_ABI)/libshaderc.a)
+
+ifndef HEADER_TARGET
+HEADER_TARGET=1
+$(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.hpp: \
+		$(ROOT_SHADERC_PATH)/libshaderc/include/shaderc/shaderc.hpp
+	$(call host-mkdir,$(NDK_APP_LIBS_OUT)/../include/shaderc)
+	$(call host-cp,$(ROOT_SHADERC_PATH)/libshaderc/include/shaderc/shaderc.hpp \
+		$(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.hpp)
+
+$(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.h: \
+	$(ROOT_SHADERC_PATH)/libshaderc/include/shaderc/shaderc.h
+	$(call host-mkdir,$(NDK_APP_LIBS_OUT)/../include/shaderc)
+	$(call host-cp,$(ROOT_SHADERC_PATH)/libshaderc/include/shaderc/shaderc.h \
+		$(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.h)
+endif
+
+libshaderc_combined: \
+	$(NDK_APP_LIBS_OUT)/$(APP_STL)/$(TARGET_ARCH_ABI)/libshaderc.a
+
 endef
+libshaderc_combined: $(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.hpp \
+	$(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.h
 
 $(eval $(call gen_libshaderc,$(TARGET_OUT),$(TOOLCHAIN_PREFIX)))
+

--- a/android_test/test.cpp
+++ b/android_test/test.cpp
@@ -1,4 +1,4 @@
-#include "shaderc.hpp"
+#include "shaderc/shaderc.hpp"
 #include <android_native_app_glue.h>
 
 void android_main(struct android_app* state) {


### PR DESCRIPTION
When we generate libshaderc_combined in Android.mk, also
create a libs/ and include/ directory that contains the actual
libraries.

This means a library can be created containing the libraries and
include files with the following style command.

ndk-build APP_PROJECT_PATH=<path/to/shaderc>
APP_BUILD_SCRIPT=<path/to/shaderc/Android.mk> APP_STL=<stl_version>
APP_ABI=<abis_to_build> NDK_APP_LIBS_OUT=<target_dir>

This will generate a target_dir with the following format
<target_dir> /
  include /
    shaderc /
      shaderc.h
      shaderc.hpp
  libs /
    <abis>
      libshaderc.a