### PR TITLE
Fixed CMake to use PYTHON_EXECUTABLE everywhere.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,13 @@ include(cmake/setup_build.cmake)
 include(cmake/utils.cmake)
 
 add_custom_target(check-copyright ALL
-  ${PYTHON_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py --check
+  ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
+  --check
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Check copyright")
 
 add_custom_target(add-copyright
-  ${PYTHON_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
+  ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Add copyright")
 
@@ -27,7 +28,7 @@ add_subdirectory(glslc)
 add_subdirectory(examples)
 
 add_custom_target(build-version
-  ${PYTHON_EXE}
+  ${PYTHON_EXECUTABLE}
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/update_build_version.py
   ${shaderc_SOURCE_DIR} ${spirv-tools_SOURCE_DIR} ${glslang_SOURCE_DIR}
   COMMENT "Update build-version.inc in the Shaderc build directory (if necessary).")

--- a/cmake/setup_build.cmake
+++ b/cmake/setup_build.cmake
@@ -71,7 +71,7 @@ if (ENABLE_CODE_COVERAGE)
     # The symptom is that some .gcno files are wrong after code change and
     # recompiling. We don't know the exact reason yet. Figure it out.
     # Remove all .gcno files in the directory recursively.
-    COMMAND ${PYTHON_EXE}
+    COMMAND ${PYTHON_EXECUTABLE}
     ${shaderc_SOURCE_DIR}/utils/remove-file-by-suffix.py . ".gcno"
     # .gcno files are not tracked by CMake. So no recompiling is triggered
     # even if they are missing. Unfortunately, we just removed all of them

--- a/glslc/test/CMakeLists.txt
+++ b/glslc/test/CMakeLists.txt
@@ -2,6 +2,7 @@ shaderc_add_nosetests(expect)
 shaderc_add_nosetests(glslc_test_framework)
 
 add_test(NAME glslc_tests
-  COMMAND ${PYTHON_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/glslc_test_framework.py
+  COMMAND ${PYTHON_EXECUTABLE}
+  ${CMAKE_CURRENT_SOURCE_DIR}/glslc_test_framework.py
   $<TARGET_FILE:glslc_exe> --test-dir ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -48,7 +48,8 @@ if (CMAKE_CONFIGURATION_TYPES)
 endif()
 
 add_custom_target(copy-tests-if-necessary ALL
-  COMMAND ${PYTHON_EXE} ${shaderc_SOURCE_DIR}/utils/copy-tests-if-necessary.py
+  COMMAND ${PYTHON_EXECUTABLE}
+    ${shaderc_SOURCE_DIR}/utils/copy-tests-if-necessary.py
     ${GLSLANG_TEST_SRC_DIR} ${GLSLANG_TEST_BIN_DIR} ${GLSLANG_CONFIGURATION_DIR}
   COMMENT "Copying and patching glslang tests if needed")
 


### PR DESCRIPTION
It looks like some verisons of cmake set PYTHON_EXE but others
do not. According to the documentation PYTHON_EXECUTABLE
is the correct way to do it.