### PR TITLE
fixed missing typedef in shaderc.h

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -18,3 +18,4 @@ Mark Adams <marka@nvidia.com>
 Jason Ekstrand <jason.ekstrand@intel.com>
 Damien Mabin <dmabin@google.com>
 Qining Lu <qining@google.com>
+Jakob Vogel <JakobpunktVogel@gmail.com>

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -175,12 +175,12 @@ void shaderc_compile_options_set_forced_version_profile(
 //  go to /path/to/include/b to find the file b.
 //  This needs context info from compiler to client includer, and may needs
 //  interface changes.
-struct shaderc_includer_response {
+typedef struct {
   const char* path;
   size_t path_length;
   const char* content;
   size_t content_length;
-};
+} shaderc_includer_response;
 
 // A function mapping a #include argument to its includer response.  The
 // includer retains memory ownership of the response object.


### PR DESCRIPTION
if not typedefed, C compilers will generate a syntax error for "shaderc_includer_response_get_fn" and "shaderc_includer_response_release_fn" because the "struct" keyword is missing.