### PR TITLE
Add a platform-independent build script

### DIFF
--- a/utils/build.py
+++ b/utils/build.py
@@ -15,43 +15,36 @@
 # limitations under the License.
 
 """
-Builds the Shaderc project, on Linux, Darwin, or Windows.
-
-For windows, we assume we have bash and basic shell commands, and we'll
-use the MSVC compiler.
-
-For Linux and Mac, use the default C++ compiler.
-
-We require cmake and ninja commands to be present under the prebuilts
-directory in the specified root directory.
+Builds the Shaderc project, on Linux, Mac, or Windows.
 """
 
+from __future__ import print_function
 import argparse
 import os
-import os.path
+import platform
 import subprocess
 import sys
 
 
-def run(args, cmd, cwd):
+def run(cmd, cwd, justprint):
     """Prints a command to run, and optionally runs it.
 
     Raises a RuntimeError if the command does not launch or otherwise fails.
 
     Args:
-      args: Options.  If args.dry_run is true, then only print the command.
-            Otherwise run the command after printing it.
-      cmd:  List of words in the command.
-      cwd:  Working directory for the command.
+      justprint: If true, then only print the command. Otherwise run the 
+                   command after printing it.
+      cmd:       List of words in the command.
+      cwd:       Working directory for the command.
     """
-    print cmd
-    if args.dry_run:
+    print(cmd)
+    if justprint:
         return
 
     p = subprocess.Popen(cmd, cwd=cwd)
     (_, _) = p.communicate()
-    if p.returncode !=0:
-        raise RuntimeError("Failed to run %s in %s" % (cmd, dir))
+    if p.returncode != 0:
+        raise RuntimeError("Failed to run %s in %s" % (cmd, cwd))
 
 
 def build(args):
@@ -59,57 +52,50 @@ def build(args):
 
     Args:
         args: An object with attributes:
-            prebuiltdir: where prebuilts can be found
+            cmake: path to the cmake executable
+            ninja: path to the ninja executable
             srcdir: where Shaderc source can be found
             builddir: build working directory
             installdir: install directory
-            platform: assumed value of sys.platform
     """
 
     if not os.path.isdir(args.srcdir):
         raise RuntimeError("Soure directory %s does not exist" % (args.srcdir))
-    if not os.path.isdir(args.prebuiltdir):
-        raise RuntimeError("Prebuilt directory %s does not exist" % (args.prebuiltdir))
 
     # Make paths absolute, and enusre directories exist.
     for d in [args.builddir, args.installdir]:
         if not os.path.isdir(d):
             os.makedirs(d)
-    args.prebuiltdir = os.path.abspath(args.prebuiltdir)
+    cmake = os.path.abspath(args.cmake) if args.cmake else 'cmake'
+    ninja = os.path.abspath(args.ninja) if args.ninja else 'ninja'
     args.srcdir = os.path.abspath(args.srcdir)
     args.builddir = os.path.abspath(args.builddir)
     args.installdir = os.path.abspath(args.installdir)
 
-    OS = None
-    if args.platform.startswith('linux'):
-        OS='linux-x86'
-    if args.platform.startswith('darwin'):
-        OS='darwin-x86'
-    if args.platform.startswith('win') or args.platform.startswith('cygwin'):
-        OS='windows-x86'
-    if OS is None:
-        raise RuntimeError("Unknown platform: %s" % (args.platform))
+    print('Building Shaderc:')
+    print('   Source     : ', args.srcdir)
+    print('   Cmake      : ', cmake)
+    print('   Ninja      : ', ninja)
+    print('   Build dir  : ', args.builddir)
+    print('   Install dir: ', args.installdir)
+    cmake_command = [cmake, args.srcdir, '-GNinja',
+                     '-DCMAKE_BUILD_TYPE=%s' % args.buildtype,
+                     '-DCMAKE_INSTALL_PREFIX=%s' % (args.installdir)]
 
-    cmake = os.path.join(args.prebuiltdir, 'prebuilts', 'cmake', OS, 'bin', 'cmake')
-    ninja = os.path.join(args.prebuiltdir, 'prebuilts', 'ninja', OS, 'ninja')
-
-    print 'Building Shaderc:'
-    print '   Source     : ', args.srcdir
-    print '   Prebuilt   : ', args.prebuiltdir
-    print '   Build dir  : ', args.builddir
-    print '   Install dir: ', args.installdir
-    cmake_command = [cmake, '-GNinja', '-DCMAKE_BUILD_TYPE=RelWithDebInfo',
-                    '-DCMAKE_INSTALL_PREFIX=%s' % (args.installdir),
-                     args.srcdir]
-
-    # Force use of MSVC on Windows.
-    if OS is 'windows-x86':
-        cmake_command.append('-DCMAKE_CXX_COMPILER=cl')
-
-    # Configure the project.
-    run(args, cmake_command, args.builddir)
-    # Install, after building necessary components.
-    run(args, [ninja, 'install'], args.builddir)
+    if (platform.system() == 'Windows'):
+        bat_content = '''
+call "%VS140COMNTOOLS%..\..\VC\\vcvarsall.bat"
+{cmake_command}
+{ninja} install
+        '''.strip().format(cmake_command=' '.join(cmake_command), ninja=ninja)
+        script = '%s/build.bat' % args.builddir
+        open(script, 'w').write(bat_content)
+        run(script, args.builddir, args.dry_run)
+    else:
+        # Configure the project.
+        run(cmake_command, args.builddir, args.dry_run)
+        # Install, after building necessary components.
+        run([ninja, 'install'], args.builddir, args.dry_run)
 
 
 def main():
@@ -124,19 +110,21 @@ def main():
                              ' to be run')
     parser.add_argument('-j', type=int, dest='j', default=4,
                         help='Number of parallel build processes. Default is 4')
-    parser.add_argument('--prebuiltdir', dest='prebuiltdir', default=os.getcwd(),
-                        help='Directory where we can find prebuilts for'
-                             ' cmake and ninja. Default is current dir.')
-    parser.add_argument('--srcdir', dest='srcdir', default='src/shaderc',
-                        help='Shaderc source directory. Default src/shaderc')
-    parser.add_argument('--builddir', dest='builddir', default='out',
-                        help='Build directory. Default is out')
+    parser.add_argument('--cmake', dest='cmake', default=False,
+                        help='Path to the cmake executable. If absent, cmake '
+                        'must be in PATH.')
+    parser.add_argument('--ninja', dest='ninja', default=False,
+                        help='Path to the ninja executable. If absent, ninja '
+                        'must be in PATH.')
+    parser.add_argument('--srcdir', dest='srcdir', default='.',
+                        help='Shaderc source directory. Default is current '
+                        'directory.')
+    parser.add_argument('--builddir', dest='builddir', required=True,
+                        help='Build directory. Required.')
     parser.add_argument('--installdir', dest='installdir', required=True,
                         help='Installation directory. Required.')
     parser.add_argument('--type', dest='buildtype', default='RelWithDebInfo',
                         help='Build type. Default is RelWithDebInfo')
-    parser.add_argument('--platform', dest='platform', default=sys.platform,
-                        help='Assumed platform. Default is current platform.')
 
     args = parser.parse_args()
 

--- a/utils/build.py
+++ b/utils/build.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Builds the Shaderc project, on Linux, Mac, or Windows.
+"""Builds the Shaderc project, on Linux, Mac, or Windows.
 """
 
 from __future__ import print_function
@@ -46,7 +45,7 @@ def run(cmd, cwd, justprint):
     p = subprocess.Popen(cmd, cwd=cwd)
     (_, _) = p.communicate()
     if p.returncode != 0:
-        raise RuntimeError("Failed to run %s in %s" % (cmd, cwd))
+        raise RuntimeError('Failed to run %s in %s' % (cmd, cwd))
 
 
 def quote(string):
@@ -58,8 +57,8 @@ def quote_some(command, indices):
     joining its elements, but with quotes around those elements in the
     indices list.
     """
-    quoted =[ (quote(e) if i in indices else e)
-              for (i, e) in enumerate(command) ]
+    quoted = [(quote(e) if i in indices else e)
+              for (i, e) in enumerate(command)]
     return ' '.join(quoted)
 
 
@@ -76,7 +75,7 @@ def build(args):
     """
 
     if not os.path.isdir(args.srcdir):
-        raise RuntimeError("Soure directory %s does not exist" % (args.srcdir))
+        raise RuntimeError('Soure directory %s does not exist' % (args.srcdir))
 
     # Make paths absolute, and ensure directories exist.
     for d in [args.builddir, args.installdir]:
@@ -124,11 +123,11 @@ def main():
     files, level of parallelism, and whether it's a dry run that should
     skip actual compilation and installation."""
 
-    parser = argparse.ArgumentParser(description="Build Shaderc simply")
+    parser = argparse.ArgumentParser(description='Build Shaderc simply')
     parser.add_argument('-n', '--dry_run', dest='dry_run', default=False,
                         action='store_true',
                         help='Dry run: Make dirs and only print commands '
-                             ' to be run')
+                        ' to be run')
     parser.add_argument('-j', type=int, dest='j', default=4,
                         help='Number of parallel build processes. Default is 4')
     parser.add_argument('--srcdir', dest='srcdir', default='src/shaderc',

--- a/utils/build.py
+++ b/utils/build.py
@@ -53,13 +53,13 @@ def quote(string):
     return '"%s"' % string.replace('"', '\\"')
 
 
-def cmake_batline(cmake_command):
-    """Transforms cmake_command (a list of strings) into a single string
-    suitable for inserting into a .bat script.
+def quote_some(command, indices):
+    """Transforms command (a list of strings) into a single string by
+    joining its elements, but with quotes around those elements in the
+    indices list.
     """
-    args_to_quote = [0, 1, 4]
-    quoted =[ (quote(e) if i in args_to_quote else e)
-              for (i, e) in enumerate(cmake_command) ]
+    quoted =[ (quote(e) if i in indices else e)
+              for (i, e) in enumerate(command) ]
     return ' '.join(quoted)
 
 
@@ -103,13 +103,13 @@ def build(args):
                      '-DCMAKE_INSTALL_PREFIX=%s' % (args.installdir)]
 
     if (OS == 'Windows' or OS.startswith('CYGWIN')):
-        bat_content = '''
-call "%VS140COMNTOOLS%..\..\VC\\vcvarsall.bat"
+        bat_content = R'''
+call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat"
 {cmake_batline}
 {ninja} install
 {ctest}
-        '''.strip().format(cmake_batline=cmake_batline(cmake_command),
-                           ninja=ninja, ctest=ctest)
+        '''.strip().format(cmake_batline=quote_some(cmake_command, [0, 1, 4]),
+                           ninja=quote(ninja), ctest=quote(ctest))
         bat_filename = os.path.join(args.builddir, 'build.bat')
         open(bat_filename, 'w').write(bat_content)
         run(bat_filename, args.builddir, args.dry_run)


### PR DESCRIPTION
Take over from #161.  Implement that PR's feedback.  Make the Windows build self-contained so it works from any environment.