### PR TITLE
Added simple C smoke test to prevent future C breakages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(MSVC)
         string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
       endif(${flag_var} MATCHES "/MD")
     endforeach(flag_var)
-  endif(SHADERC_ENABLE_SHARED_CRT)
+  endif(NOT SHADERC_ENABLE_SHARED_CRT)
 endif(MSVC)
 
 # Configure subdirectories.

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -7,9 +7,9 @@ function (shaderc_use_gmock TARGET)
   target_link_libraries(${TARGET} PRIVATE gmock gtest_main)
 endfunction(shaderc_use_gmock)
 
-function(shaderc_default_compile_options TARGET)
+function(shaderc_default_c_compile_options TARGET)
   if (NOT "${MSVC}")
-    target_compile_options(${TARGET} PRIVATE -std=c++11 -fPIC -Wall -Werror)
+    target_compile_options(${TARGET} PRIVATE -Wall -Werror)
     if (ENABLE_CODE_COVERAGE)
       # The --coverage option is a synonym for -fprofile-arcs -ftest-coverage
       # when compiling.
@@ -23,6 +23,13 @@ function(shaderc_default_compile_options TARGET)
     # disable warning C4800: 'int' : forcing value to bool 'true' or 'false'
     # (performance warning)
     target_compile_options(${TARGET} PRIVATE /wd4800)
+  endif()
+endfunction(shaderc_default_c_compile_options)
+
+function(shaderc_default_compile_options TARGET)
+  shaderc_default_c_compile_options(${TARGET})
+  if (NOT "${MSVC}")
+    target_compile_options(${TARGET} PRIVATE -std=c++11)
   endif()
 endfunction(shaderc_default_compile_options)
 

--- a/libshaderc/CMakeLists.txt
+++ b/libshaderc/CMakeLists.txt
@@ -37,3 +37,10 @@ INCLUDE_DIRS include ${glslang_SOURCE_DIR}
 TEST_NAMES
   shaderc
   shaderc_cpp)
+
+add_executable(shaderc_c_smoke_test ./src/shaderc_c_smoke_test.c)
+shaderc_default_c_compile_options(shaderc_c_smoke_test)
+
+target_link_libraries(shaderc_c_smoke_test PRIVATE shaderc)
+add_test(NAME shaderc_c_smoke_test COMMAND shaderc_c_smoke_test)
+

--- a/libshaderc/src/shaderc_c_smoke_test.c
+++ b/libshaderc/src/shaderc_c_smoke_test.c
@@ -1,0 +1,54 @@
+// Copyright 2016 The Shaderc Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "shaderc/shaderc.h"
+#include <assert.h>
+#include <string.h>
+
+// Because we want to test this as a plain old C file, we cannot use
+// gtest, so just run a simple smoke test.
+
+int main() {
+  const char* test_program =
+      "#version 310 es\n"
+      "layout(location = 0) in highp vec4 vtxColor;\n"
+      "layout(location = 0) out highp vec4 outColor;\n"
+      "void main() {\n"
+      "  outColor = vtxColor;"
+      "}\n";
+  shaderc_compiler_t compiler;
+  shaderc_compilation_result_t result;
+  shaderc_compile_options_t options;
+
+  compiler = shaderc_compiler_initialize();
+  options = shaderc_compile_options_initialize();
+  shaderc_compile_options_add_macro_definition(options, "FOO", 3, "1", 1);
+  result = shaderc_compile_into_spv(
+      compiler, test_program, strlen(test_program),
+      shaderc_glsl_fragment_shader, "a.glsl", "main", options);
+
+  assert(result);
+
+  if (shaderc_result_get_compilation_status(result) !=
+      shaderc_compilation_status_success) {
+    // Early exit on failure.
+    return -1;
+  }
+  shaderc_result_release(result);
+  shaderc_compile_options_release(options);
+  shaderc_compiler_release(compiler);
+
+  return 0;
+}
+


### PR DESCRIPTION
This C file just compiles a single shader, but is sufficient
to make sure that shaderc.h can always be included from C.