### PR TITLE
DO NOT MERGE: Support Linux-to-Windows cross compile via MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,18 @@ enable_testing()
 
 message(STATUS "Shaderc: build type is \"${CMAKE_BUILD_TYPE}\".")
 
+option(SHADERC_SKIP_TESTS
+       "Skip building unit tests based on googlemock and googletest"
+       ${SHADERC_SKIP_TESTS})
+if(NOT ${SHADERC_SKIP_TESTS})
+  set(SHADERC_ENABLE_TESTS ON)
+endif()
+if(${SHADERC_ENABLE_TESTS})
+  message(STATUS "Configuring Shaderc to build unit tests.")
+else()
+  message(STATUS "Configuring Shaderc to avoid building unit tests.")
+endif()
+
 include(cmake/setup_build.cmake)
 include(cmake/utils.cmake)
 

--- a/cmake/linux-mingw-toolchain.cmake
+++ b/cmake/linux-mingw-toolchain.cmake
@@ -1,0 +1,21 @@
+SET(CMAKE_SYSTEM_NAME Windows)
+
+set(MINGW_COMPILER_PREFIX "i686-w64-mingw32" CACHE STRING
+    "What compiler prefix to use for mingw")
+
+set(MINGW_SYSROOT "/usr/${MINGW_COMPILER_PREFIX}" CACHE STRING
+    "What sysroot to use for mingw")
+
+# Which compilers to use for C and C++
+find_program(CMAKE_RC_COMPILER NAMES ${MINGW_COMPILER_PREFIX}-windres)
+find_program(CMAKE_C_COMPILER NAMES ${MINGW_COMPILER_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${MINGW_COMPILER_PREFIX}-g++)
+
+SET(CMAKE_FIND_ROOT_PATH ${MINGW_SYSROOT})
+
+# Adjust the default behaviour of the FIND_XXX() commands:
+# Search headers and libraries in the target environment; search
+# programs in the host environment.
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/libshaderc_util/CMakeLists.txt
+++ b/libshaderc_util/CMakeLists.txt
@@ -38,8 +38,10 @@ shaderc_add_tests(
     io
     message)
 
-target_include_directories(shaderc_util_counting_includer_test
-  PRIVATE ${glslang_SOURCE_DIR})
+if(${SHADERC_ENABLE_TESTS})
+  target_include_directories(shaderc_util_counting_includer_test
+    PRIVATE ${glslang_SOURCE_DIR})
+endif()
 
 shaderc_add_tests(
   TEST_PREFIX shaderc_util
@@ -52,7 +54,9 @@ shaderc_add_tests(
 add_custom_target(testdata COMMAND
   ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/testdata/copy-to-build.cmake)
 
-add_dependencies(shaderc_util_file_finder_test testdata)
-add_dependencies(shaderc_util_io_test testdata)
+if(${SHADERC_ENABLE_TESTS})
+  add_dependencies(shaderc_util_file_finder_test testdata)
+  add_dependencies(shaderc_util_io_test testdata)
+endif()
 
 add_definitions(-DCURRENT_DIR="${CMAKE_CURRENT_BINARY_DIR}")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -2,11 +2,14 @@
 set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS -w)
 
 # Configure third party projects.
-if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
-  add_subdirectory(googletest)
-endif()
-if (NOT TARGET gmock)
-  message(FATAL_ERROR "gmock was not found - required for tests")
+
+if(${SHADERC_ENABLE_TESTS})
+  if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/googletest)
+    add_subdirectory(googletest)
+  endif()
+  if (NOT TARGET gmock)
+    message(FATAL_ERROR "gmock was not found - required for tests")
+  endif()
 endif()
 
 set(OLD_PLATFORM_TOOLSET ${CMAKE_GENERATOR_TOOLSET})


### PR DESCRIPTION
Requires similar changes in Glslang and SPIRV-Tools.

Passes tests on Linux.
Compiles executables on Windows.  However, MinGW can't compile googletest, so test executables are skipped.