### PR TITLE
Fix directory-existence check in build.py.

### DIFF
--- a/utils/build.py
+++ b/utils/build.py
@@ -65,7 +65,7 @@ def build(args):
 
     # Make paths absolute, and ensure directories exist.
     for d in [args.builddir, args.installdir]:
-        if not os.path.isdir(d):
+        if not os.path.exists(d):
             os.makedirs(d)
     args.srcdir = os.path.abspath(args.srcdir)
     args.builddir = os.path.abspath(args.builddir)


### PR DESCRIPTION
Apparently, `os.path.isdir()` returns false on Windows when the directory is a symlink.