### PR TITLE
Enabled relative includes in glslc.

### DIFF
--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -210,7 +210,10 @@ empty value.
 
 `-I` adds the specified directory to the search path for include files.
 
-WARNING: Implementation is not complete yet.
+Only `""` style includes are permitted. When searching for included files, first
+the directory of the current file is attempted. If this fails each directory
+supplied via `-I` on the command line is searched in the given order for the
+file.
 
 === Code Generation Options
 
@@ -386,3 +389,11 @@ output.
 
 The `GL_GOOGLE_cpp_style_line_directive` extension is implicitly turned on by
 the `GL_GOOGLE_include_directive` extension.
+
+It is invalid to have any '\' or '/' characters in any filename provided to
+an `#include` directive. The presence of any such characters may lead to
+unexpected behavior on different systems.
+
+Furthermore it is not possible to escape any characters in an `#include`
+directive and as such, any special characters that would have to be escaped in
+C may not show up in file names either.

--- a/glslc/src/file_includer.cc
+++ b/glslc/src/file_includer.cc
@@ -25,13 +25,16 @@ shaderc_include_result* MakeErrorIncludeResult(const char* message) {
   return new shaderc_include_result{"", 0, message, strlen(message)};
 }
 
-shaderc_include_result* FileIncluder::GetInclude(const char* requested_source,
-                                                 shaderc_include_type,
-                                                 const char*, size_t) {
-  // TODO(dneto): Be sensitive to requesting_source
-  // We don't actually care about the include type.
+shaderc_include_result* FileIncluder::GetInclude(
+    const char* requested_source, shaderc_include_type include_type,
+    const char* requesting_source, size_t) {
+
   const std::string full_path =
-      file_finder_.FindReadableFilepath(requested_source);
+      (include_type == shaderc_include_type_relative)
+          ? file_finder_.FindRelativeReadableFilepath(requesting_source,
+                                                      requested_source)
+          : file_finder_.FindReadableFilepath(requested_source);
+
   if (full_path.empty())
     return MakeErrorIncludeResult("Cannot find or open include file.");
 

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -112,8 +112,6 @@ int main(int argc, char** argv) {
   bool success = true;
   bool has_stdin_input = false;
 
-  compiler.AddIncludeDirectory("");
-
   for (int i = 1; i < argc; ++i) {
     const string_piece arg = argv[i];
     if (arg == "--help") {

--- a/glslc/test/glslc_test_framework.py
+++ b/glslc/test/glslc_test_framework.py
@@ -269,6 +269,10 @@ class TestCase:
                 setattr(
                     self.test, expectation_name,
                     ''.join(expanded_expections))
+            elif isinstance(expectation, PlaceHolder):
+                setattr(self.test, expectation_name,
+                        expectation.instantiate_for_expectation(self))
+
 
     def tearDown(self):
         """Removes the directory if we were not instructed to do otherwise."""

--- a/glslc/test/placeholder.py
+++ b/glslc/test/placeholder.py
@@ -22,6 +22,7 @@ argument to the instantiate_*() methods.
 """
 import os
 import tempfile
+from string import Template
 
 
 class PlaceHolderException(Exception):
@@ -115,3 +116,24 @@ class TempFileName(PlaceHolder):
 
     def instantiate_for_expectation(self, testcase):
         return os.path.join(testcase.directory, self.filename)
+
+
+class SpecializedString(PlaceHolder):
+    """Returns a string that has been specialized based on TestCase.
+
+    The string is specialized by expanding it as a string.Template
+    with all of the specialization being done with each $param replaced
+    by the associated member on TestCase.
+    """
+
+    def __init__(self, filename):
+        assert isinstance(filename, str)
+        assert filename != ''
+        self.filename = filename
+
+    def instantiate_for_glslc_args(self, testcase):
+        return Template(self.filename).substitute(vars(testcase))
+
+    def instantiate_for_expectation(self, testcase):
+        return Template(self.filename).substitute(vars(testcase))
+

--- a/libshaderc_util/include/libshaderc_util/counting_includer.h
+++ b/libshaderc_util/include/libshaderc_util/counting_includer.h
@@ -43,7 +43,8 @@ class CountingIncluder : public glslang::TShader::Includer {
       const char* requesting_source,
       size_t include_depth) final {
     ++num_include_directives_;
-    return include_delegate(requested_source, type, requesting_source, include_depth);
+    return include_delegate(requested_source, type, requesting_source,
+                            include_depth);
   }
 
   // Releases the given IncludeResult.

--- a/libshaderc_util/include/libshaderc_util/file_finder.h
+++ b/libshaderc_util/include/libshaderc_util/file_finder.h
@@ -33,13 +33,17 @@ class FileFinder {
   // If a search_path() element is non-empty and not ending in a slash, then a
   // slash is inserted between it and filename before its search attempt. An
   // empty string in search_path() means that the filename is tried as-is.
-  //
-  // Usage advice: when searching #include files, you almost certainly want ""
-  // to be the first element in search_path().  That way both relative and
-  // absolute filenames will work as expected.  Note that a "." entry on the
-  // search path may be prepended to an absolute filename (eg, "/a/b/c") to
-  // create a relative result (eg, ".//a/b/c").
   std::string FindReadableFilepath(const std::string& filename) const;
+
+  // Searches for a read-openable file based on filename, which must be
+  // non-empty. The search is first attempted as a path relative to
+  // the requesting_file parameter. If no file is found relative to the
+  // requesting_file then this acts as FindReadableFilepath does. If
+  // requesting_file does not contain a '/' or a '\' character then it is
+  // assumed to be a filename and the request will be relative to the
+  // current directory.
+  std::string FindRelativeReadableFilepath(const std::string& requesting_file,
+                                           const std::string& filename) const;
 
   // Search path for Find().  Users may add/remove elements as desired.
   std::vector<std::string>& search_path() { return search_path_; }


### PR DESCRIPTION
glslc will now by default try and resolve #included files relative to
the current file first, only after that fails will it try to include
files based on the -I parameters.