### PR TITLE
libspirv.h in SPIRV-Tools removed macros for version and revision.

### DIFF
--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -119,9 +119,9 @@ int main(int argc, char** argv) {
       return 0;
     } else if (arg == "--version") {
       std::cout << kBuildVersion << std::endl;
-      std::cout << "Target: SPIR-V " << SPV_SPIRV_VERSION_MAJOR << "."
-                << SPV_SPIRV_VERSION_MINOR << " rev "
-                << SPV_SPIRV_VERSION_REVISION << std::endl;
+      std::cout << "Target: "
+                << spvTargetEnvDescription(SPV_ENV_UNIVERSAL_1_0_4)
+                << std::endl;
       return 0;
     } else if (arg.starts_with("-o")) {
       string_piece file_name;

--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -123,11 +123,12 @@ LOCAL_SRC_FILES:= \
 		source/operand.cpp \
 		source/print.cpp \
 		source/spirv_endian.cpp \
+		source/spirv_target_env.cpp \
 		source/table.cpp \
 		source/text.cpp \
 		source/text_handler.cpp \
-		source/validate_cfg.cpp \
 		source/validate.cpp \
+		source/validate_cfg.cpp \
 		source/validate_id.cpp \
 		source/validate_instruction.cpp \
 		source/validate_layout.cpp \


### PR DESCRIPTION
Counterpart for https://github.com/KhronosGroup/SPIRV-Tools/pull/170