### PR TITLE
Test Vulkan-specific shaders

### DIFF
--- a/glslc/test/option_target_env.py
+++ b/glslc/test/option_target_env.py
@@ -30,6 +30,11 @@ def opengl_vertex_shader():
 void main() { int t = gl_VertexID; }"""
 
 
+def vulkan_vertex_shader():
+    return """#version 310 es
+void main() { int t = gl_VertexIndex; }"""
+
+
 @inside_glslc_testsuite('OptionTargetEnv')
 class TestTargetEnvEqOpenglCompatWithOpenGlCompatShader(expect.ValidObjectFile):
     """Tests that compiling OpenGL Compatibility Fragment shader with
@@ -63,6 +68,28 @@ class TestTargetEnvEqOpenglWithOpenGlVertexShader(expect.ValidObjectFile):
     generates valid SPIR-V code"""
     shader = FileShader(opengl_vertex_shader(), '.vert')
     glslc_args = ['--target-env=opengl', '-c', shader]
+
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestDefaultTargetEnvWithVulkanShader(expect.ValidObjectFile):
+    """Tests that compiling a Vulkan-specific shader with a default
+    target environment succeeds"""
+    shader = FileShader(vulkan_vertex_shader(), '.vert')
+    glslc_args = ['-c', shader]
+
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqVulkanWithVulkanShader(expect.ValidObjectFile):
+    """Tests that compiling a Vulkan-specific shader succeeds with
+    --target-env=vulkan"""
+    shader = FileShader(vulkan_vertex_shader(), '.vert')
+    glslc_args = ['--target-env=vulkan', '-c', shader]
+
+
+# Note: Negative tests are covered in the libshaderc_util unit tests.
+# For example, that an OpenGL-specific shader should fail to compile
+# for Vulkan, or a Vulkan-specific shader should fail to compile for
+# OpenGL.
 
 
 @inside_glslc_testsuite('OptionTargetEnv')

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -68,6 +68,12 @@ const char kOpenGLVertexShaderDeducibleStage[] =
        #pragma shader_stage(vertex)
        void main() { int t = gl_VertexID; })";
 
+// A shader that compiles under Vulkan rules.
+// See the GL_KHR_vuklan_glsl extension to GLSL.
+const char kVulkanVertexShader[] =
+    R"(#version 310 es
+       void main() { int t = gl_VertexIndex; })";
+
 // A shader that needs valueless macro predefinition E, to be compiled
 // successfully.
 const std::string kValuelessPredefinitionShader =
@@ -145,8 +151,13 @@ TEST_F(CompilerTest, SimpleVertexShaderPreprocessesSuccessfully) {
   EXPECT_TRUE(SimpleCompilationSucceedsForOutputType(
       kVertexShader, EShLangVertex, Compiler::OutputType::PreprocessedText));
 }
+
 TEST_F(CompilerTest, BadVertexShaderFailsCompilation) {
   EXPECT_FALSE(SimpleCompilationSucceeds(" bogus ", EShLangVertex));
+}
+
+TEST_F(CompilerTest, SimpleVulkanShaderCompilesWithDefaultCompilerSettings) {
+  EXPECT_TRUE(SimpleCompilationSucceeds(kVulkanVertexShader, EShLangVertex));
 }
 
 TEST_F(CompilerTest, RespectTargetEnvOnOpenGLCompatibilityShader) {
@@ -197,8 +208,6 @@ TEST_F(CompilerTest, RespectTargetEnvOnOpenGLShader) {
 
   compiler_.SetMessageRules(kOpenGLRules);
   EXPECT_TRUE(SimpleCompilationSucceeds(kOpenGLVertexShader, stage));
-
-  // TODO(dneto): Check Vulkan rules.
 }
 
 TEST_F(CompilerTest, RespectTargetEnvOnOpenGLShaderWhenDeducingStage) {
@@ -211,12 +220,43 @@ TEST_F(CompilerTest, RespectTargetEnvOnOpenGLShaderWhenDeducingStage) {
   compiler_.SetMessageRules(kOpenGLRules);
   EXPECT_TRUE(
       SimpleCompilationSucceeds(kOpenGLVertexShaderDeducibleStage, stage));
-
-  // TODO(dneto): Check Vulkan rules.
 }
 
-TEST_F(CompilerTest, DISABLED_RespectTargetEnvOnVulkanShader) {
-  // TODO(dneto): Add test for a shader that should only compile for Vulkan.
+TEST_F(CompilerTest, RespectTargetEnvOnVulkanShader) {
+  compiler_.SetMessageRules(kVulkanRules);
+  EXPECT_TRUE(SimpleCompilationSucceeds(kVulkanVertexShader, EShLangVertex));
+}
+
+TEST_F(CompilerTest, VulkanSpecificShaderFailsUnderOpenGLCompatibilityRules) {
+  compiler_.SetMessageRules(kOpenGLCompatibilityRules);
+  EXPECT_FALSE(SimpleCompilationSucceeds(kVulkanVertexShader, EShLangVertex));
+}
+
+TEST_F(CompilerTest, DISABLED_VulkanSpecificShaderFailsUnderOpenGLRules) {
+  // This test is disabled due to an apparent bug in Glslang.
+  // https://github.com/KhronosGroup/glslang/issues/229
+  compiler_.SetMessageRules(kOpenGLRules);
+  EXPECT_FALSE(SimpleCompilationSucceeds(kVulkanVertexShader, EShLangVertex));
+}
+
+TEST_F(CompilerTest, OpenGLCompatibilitySpecificShaderFailsUnderDefaultRules) {
+  EXPECT_FALSE(SimpleCompilationSucceeds(kOpenGLCompatibilityFragShader,
+                                         EShLangFragment));
+}
+
+TEST_F(CompilerTest, OpenGLSpecificShaderFailsUnderDefaultRules) {
+  EXPECT_FALSE(SimpleCompilationSucceeds(kOpenGLVertexShader, EShLangVertex));
+}
+
+TEST_F(CompilerTest, OpenGLCompatibilitySpecificShaderFailsUnderVulkanRules) {
+  compiler_.SetMessageRules(kVulkanRules);
+  EXPECT_FALSE(SimpleCompilationSucceeds(kOpenGLCompatibilityFragShader,
+                                         EShLangFragment));
+}
+
+TEST_F(CompilerTest, OpenGLSpecificShaderFailsUnderVulkanRules) {
+  compiler_.SetMessageRules(kVulkanRules);
+  EXPECT_FALSE(SimpleCompilationSucceeds(kOpenGLVertexShader, EShLangVertex));
 }
 
 TEST_F(CompilerTest, AddMacroDefinition) {


### PR DESCRIPTION
Add unit and integration tests check that Vulkan-specific shaders
compile for the default compiler target, and when we explictly specify
the Vulkan target.

Add unit tests to check that OpenGL-specific shaders fail to compile
when targeting Vulkan.