### PR TITLE
Support Glslang with its new HLSL parser library

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -10,6 +10,7 @@ ALL_LIBS:=libglslang.a \
 	libshaderc.a \
 	libshaderc_util.a \
 	libSPIRV.a \
+	libHLSL.a \
 	libSPIRV-Tools.a
 
 define gen_libshaderc

--- a/glslc/CMakeLists.txt
+++ b/glslc/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(glslc STATIC
 shaderc_default_compile_options(glslc)
 target_include_directories(glslc PUBLIC ${glslang_SOURCE_DIR})
 target_link_libraries(glslc PRIVATE glslang OSDependent OGLCompiler
-  glslang SPIRV ${CMAKE_THREAD_LIBS_INIT})
+  HLSL glslang SPIRV ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(glslc PRIVATE shaderc_util shaderc)
 
 add_executable(glslc_exe src/main.cc)

--- a/libshaderc_util/CMakeLists.txt
+++ b/libshaderc_util/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(shaderc_util
   PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
 find_package(Threads)
 target_link_libraries(shaderc_util PRIVATE
-  glslang OSDependent OGLCompiler glslang SPIRV
+  glslang OSDependent OGLCompiler HLSL glslang SPIRV
   SPIRV-Tools ${CMAKE_THREAD_LIBS_INIT})
 
 shaderc_add_tests(

--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -39,6 +39,20 @@ LOCAL_C_INCLUDES:=$(GLSLANG_LOCAL_PATH)/OGLCompiler
 LOCAL_STATIC_LIBRARIES:=OSDependent
 include $(BUILD_STATIC_LIBRARY)
 
+
+# Build Glslang's HLSL parser library.
+include $(CLEAR_VARS)
+LOCAL_MODULE:=HLSL
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti
+LOCAL_SRC_FILES:= \
+		hlsl/hlslGrammar.cpp \
+		hlsl/hlslParseHelper.cpp \
+		hlsl/hlslScanContext.cpp
+LOCAL_C_INCLUDES:=$(GLSLANG_LOCAL_PATH) \
+	$(GLSLANG_LOCAL_PATH)/hlsl
+include $(BUILD_STATIC_LIBRARY)
+
+
 include $(CLEAR_VARS)
 
 GLSLANG_OUT_PATH=$(abspath $(TARGET_OUT))
@@ -79,7 +93,7 @@ LOCAL_SRC_FILES:= \
 LOCAL_C_INCLUDES:=$(GLSLANG_LOCAL_PATH) \
 	$(GLSLANG_LOCAL_PATH)/glslang/MachineIndependent \
 	$(GLSLANG_OUT_PATH)
-LOCAL_STATIC_LIBRARIES:=OSDependent OGLCompiler SPIRV
+LOCAL_STATIC_LIBRARIES:=OSDependent OGLCompiler SPIRV HLSL
 include $(BUILD_STATIC_LIBRARY)
 
 
@@ -113,12 +127,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := SPIRV-Tools
 LOCAL_C_INCLUDES := \
 		$(SPVTOOLS_LOCAL_PATH)/include \
-		$(SPVTOOLS_LOCAL_PATH)/external/include \
 		$(SPVTOOLS_LOCAL_PATH)/source \
 		$(SPVTOOLS_OUT_PATH)
 LOCAL_EXPORT_C_INCLUDES := \
-		$(SPVTOOLS_LOCAL_PATH)/include \
-		$(SPVTOOLS_LOCAL_PATH)/external/include
+		$(SPVTOOLS_LOCAL_PATH)/include
 LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti
 LOCAL_SRC_FILES:= \
 		source/assembly_grammar.cpp \


### PR DESCRIPTION
This commit requires a matching update to
github.com/google/glslang to catch up to
github.com/KhronosGroup/glslang.

Also remove include directories for SPIRV-Tools that no
longer exist.