### PR TITLE
Fixed Android.mk for Windows.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -24,14 +24,14 @@ $(1)/combine.ar: $(addprefix $(1)/, $(ALL_LIBS))
 
 $(1)/libshaderc_combined.a: $(addprefix $(1)/, $(ALL_LIBS)) $(1)/combine.ar
 	@echo "[$(TARGET_ARCH_ABI)] Combine: libshaderc_combined.a <= $(ALL_LIBS)"
-	@cd $(1) && $(2)ar -M < combine.ar && cd -
+	@cd $(1) && $(2)ar -M < combine.ar && cd $(ROOT_SHADERC_PATH)
 	@$(2)objcopy --strip-debug $(1)/libshaderc_combined.a
 
 $(NDK_APP_LIBS_OUT)/$(APP_STL)/$(TARGET_ARCH_ABI)/libshaderc.a: \
 		$(1)/libshaderc_combined.a
 	$(call host-mkdir,$(NDK_APP_LIBS_OUT)/$(APP_STL)/$(TARGET_ARCH_ABI))
 	$(call host-cp,$(1)/libshaderc_combined.a \
-		$(NDK_APP_LIBS_OUT)/$(APP_STL)/$(TARGET_ARCH_ABI)/libshaderc.a)
+		,$(NDK_APP_LIBS_OUT)/$(APP_STL)/$(TARGET_ARCH_ABI)/libshaderc.a)
 
 ifndef HEADER_TARGET
 HEADER_TARGET=1
@@ -39,13 +39,13 @@ $(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.hpp: \
 		$(ROOT_SHADERC_PATH)/libshaderc/include/shaderc/shaderc.hpp
 	$(call host-mkdir,$(NDK_APP_LIBS_OUT)/../include/shaderc)
 	$(call host-cp,$(ROOT_SHADERC_PATH)/libshaderc/include/shaderc/shaderc.hpp \
-		$(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.hpp)
+		,$(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.hpp)
 
 $(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.h: \
 	$(ROOT_SHADERC_PATH)/libshaderc/include/shaderc/shaderc.h
 	$(call host-mkdir,$(NDK_APP_LIBS_OUT)/../include/shaderc)
 	$(call host-cp,$(ROOT_SHADERC_PATH)/libshaderc/include/shaderc/shaderc.h \
-		$(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.h)
+		,$(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.h)
 endif
 
 libshaderc_combined: \
@@ -56,4 +56,3 @@ libshaderc_combined: $(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.hpp \
 	$(NDK_APP_LIBS_OUT)/../include/shaderc/shaderc.h
 
 $(eval $(call gen_libshaderc,$(TARGET_OUT),$(TOOLCHAIN_PREFIX)))
-


### PR DESCRIPTION
Missing , in $(call host-cp) merged arguments on windows into broken
path.

cd - does not work on windows, replace with cd $(ROOT_SHADERC_PATH)