### PR TITLE
SPIRV-Tools now requires SPIRV-Headers.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,9 +27,10 @@ init:
 
 # scripts that run after cloning repository
 install:
-  - git clone https://github.com/google/googletest.git third_party/googletest
-  - git clone https://github.com/google/glslang.git third_party/glslang
-  - git clone https://github.com/KhronosGroup/SPIRV-Tools.git third_party/spirv-tools
+  - git clone https://github.com/google/googletest.git          third_party/googletest
+  - git clone https://github.com/google/glslang.git             third_party/glslang
+  - git clone https://github.com/KhronosGroup/SPIRV-Tools.git   third_party/spirv-tools
+  - git clone https://github.com/KhronosGroup/SPIRV-Headers.git third_party/spirv-tools/external/spirv-headers
 
 build:
   parallel: true  # enable MSBuild parallel builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,10 @@ install:
     fi
 
 before_script:
-  - git clone https://github.com/google/googletest.git        third_party/googletest
-  - git clone https://github.com/google/glslang.git           third_party/glslang
-  - git clone https://github.com/KhronosGroup/SPIRV-Tools.git third_party/spirv-tools
+  - git clone https://github.com/google/googletest.git          third_party/googletest
+  - git clone https://github.com/google/glslang.git             third_party/glslang
+  - git clone https://github.com/KhronosGroup/SPIRV-Tools.git   third_party/spirv-tools
+  - git clone https://github.com/KhronosGroup/SPIRV-Headers.git third_party/spirv-tools/external/spirv-headers
 
 script:
   - mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ cd $SOURCE_DIR/third_party
 git clone https://github.com/google/googletest.git
 git clone https://github.com/google/glslang.git
 git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
+git clone https://github.com/KhronosGroup/SPIRV-Headers.git spirv-tools/external/spirv-headers
 cd $SOURCE_DIR/
 ```
 


### PR DESCRIPTION
Counterpart of https://github.com/KhronosGroup/SPIRV-Tools/pull/186.