### PR TITLE
-mfmt=bin/c/num to emit binary as it is, numbers or C init list

### DIFF
--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -252,6 +252,39 @@ code, such as identifier names and line numbers.
 NOTE: Currently this option has no effect.  Full functionality depends on
 glslang support for generating debug info.
 
+==== `-mfmt=<format>`
+
+`-mfmt=<format>` selects output format for compilation output in SPIR-V binary
+code form.  Supported options are listed in the
+<<binary-output-format-options,binary output format options>> table. This
+option is only valid to be used when the compilation output is SPIR-V binary
+code. Specifying any options listed below when the output is not SPIR-V binary
+code, like disassembly (with `-S` specified), text (with `-M`, `-MM` or `-E`
+specified) will trigger an error.
+
+[[binary-output-format-options]]
+.Binary Output Format Options
+[cols="20%,80%"]
+|===
+|Format option  |Description
+
+|bin            |Output SPIR-V binary code as a sequence of binary 32-bitwords
+                 in host native endianness. This is the default format for
+                 SPIR-V binary compilation output.
+|num            |Output SPIR-V binary code as a text file containing a list of
+                 comma-separated hex numbers. +
+                 Example: `glslc -c -mfmt=num main.vert -o output_file.txt` +
+                 Content of the output_file.txt: +
+                 0x07230203,0x00010000,0x00080001,0x00000006...
+|c              |Output SPIR-V binary code as a text file containing C-style +
+                 initializer list. +
+                 This is just wrapping the output of `num` option with curly
+                 brackets. +
+                 Example: `glslc -c -mfmt=c main.vert -o output_file.txt` +
+                 Content of output_file.txt: +
+                 {0x07230203, 0x00010000, 0x00080001, 0x00000006...}
+|===
+
 === Warning and Error Options
 
 ==== `-w`

--- a/glslc/src/file_compiler.h
+++ b/glslc/src/file_compiler.h
@@ -29,8 +29,19 @@ namespace glslc {
 // SPIR-V files or preprocessed output.
 class FileCompiler {
  public:
+  enum class SpirvBinaryEmissionFormat {
+    Unspecified,  // No binary output format specified, this is the only valid
+                  // option when the compilation output is not in SPIR-V binary
+                  // code form.
+    Binary,       // Emits SPIR-V binary code directly.
+    Numbers,      // Emits SPIR-V binary code as a list of hex numbers.
+    CInitList,    // Emits SPIR-V bianry code as a C-style initializer list
+                  // of hex numbers.
+  };
+
   FileCompiler()
       : output_type_(OutputType::SpirvBinary),
+        binary_emission_format_(SpirvBinaryEmissionFormat::Unspecified),
         needs_linking_(true),
         total_warnings_(0),
         total_errors_(0) {}
@@ -61,6 +72,11 @@ class FileCompiler {
   // Sets the output filename. A name of "-" indicates standard output.
   void SetOutputFileName(const shaderc_util::string_piece& file) {
     output_file_name_ = file;
+  }
+
+  // Sets the format for SPIR-V binary compilation output.
+  void SetSpirvBinaryOutputFormat(SpirvBinaryEmissionFormat format) {
+    binary_emission_format_ = format;
   }
 
   // Returns false if any options are incompatible. The num_files parameter
@@ -166,7 +182,9 @@ class FileCompiler {
   std::string GetCandidateOutputFileName(std::string input_filename);
 
   // Returns true if the compiler's output is preprocessed text.
-  bool PreprocessingOnly() { return output_type_ == OutputType::PreprocessedText; }
+  bool PreprocessingOnly() {
+    return output_type_ == OutputType::PreprocessedText;
+  }
 
   // Performs actual SPIR-V compilation on the contents of input files.
   shaderc::Compiler compiler_;
@@ -177,6 +195,10 @@ class FileCompiler {
 
   // What kind of output will be produced?
   OutputType output_type_;
+
+  // The Flag to indicate to which format the output SPIR-V binary code should
+  // be emitted.
+  SpirvBinaryEmissionFormat binary_emission_format_;
 
   // A FileFinder used to substitute #include directives in the source code.
   shaderc_util::FileFinder include_file_finder_;

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -59,6 +59,10 @@ Options:
   -std=<value>      Version and profile for input files. Possible values
                     are concatenations of version and profile, e.g. 310es,
                     450core, etc.
+  -mfmt=<format>    Output SPIR-V binary code using the selected format. This
+                    option may be specified only when the compilation output is
+                    in SPIR-V binary code form. Available options include bin, c
+                    and num. By default the binary output format is bin.
   -M                Generate make dependencies. Implies -E and -w.
   -MM               An alias for -M.
   -MD               Generate make dependencies and compile.
@@ -167,6 +171,23 @@ int main(int argc, char** argv) {
         return 1;
       }
       compiler.options().SetTargetEnvironment(target_env, 0);
+    } else if (arg.starts_with("-mfmt=")) {
+      const string_piece binary_output_format =
+          arg.substr(std::strlen("-mfmt="));
+      if (binary_output_format == "bin") {
+        compiler.SetSpirvBinaryOutputFormat(
+            glslc::FileCompiler::SpirvBinaryEmissionFormat::Binary);
+      } else if (binary_output_format == "num") {
+        compiler.SetSpirvBinaryOutputFormat(
+            glslc::FileCompiler::SpirvBinaryEmissionFormat::Numbers);
+      } else if (binary_output_format == "c") {
+        compiler.SetSpirvBinaryOutputFormat(
+            glslc::FileCompiler::SpirvBinaryEmissionFormat::CInitList);
+      } else {
+        std::cerr << "glslc: error: invalid value '" << binary_output_format
+                  << "' in '-mfmt=" << binary_output_format << "'" << std::endl;
+        return 1;
+      }
     } else if (arg.starts_with("-x")) {
       string_piece option_arg;
       if (!GetOptionArgument(argc, argv, &i, "-x", &option_arg)) {

--- a/glslc/test/expect.py
+++ b/glslc/test/expect.py
@@ -19,6 +19,7 @@ as superclass and providing the expected_* variables required by the check_*()
 methods in the mixin classes.
 """
 import os
+import re
 from glslc_test_framework import GlslCTest
 
 
@@ -238,11 +239,20 @@ class ValidFileContents(GlslCTest):
             return False, 'Cannot find file: ' + target_filename
         with open(target_filename, 'r') as target_file:
             file_contents = target_file.read()
-            if file_contents == self.expected_file_contents:
-                return True, ''
-            return False, ('Incorrect file output: \n{act}\nExpected:\n{exp}'
-                           ''.format(act=file_contents,
-                                     exp=self.expected_file_contents))
+            if type(self.expected_file_contents) == str:
+                if file_contents == self.expected_file_contents:
+                    return True, ''
+                return False, ('Incorrect file output: \n{act}\nExpected:\n{exp}'
+                               ''.format(act=file_contents,
+                                         exp=self.expected_file_contents))
+            elif isinstance(self.expected_file_contents, type(re.compile(''))):
+                if self.expected_file_contents.search(file_contents):
+                    return True, ''
+                return False, (
+                    'Incorrect file output: \n{act}\n'
+                    'Expected matching regex pattern:\n{exp}'.format(
+                        act=file_contents,
+                        exp=self.expected_file_contents.pattern))
         return False, ('Could not open target file ' + target_filename +
                        ' for reading')
 

--- a/glslc/test/option_mfmt.py
+++ b/glslc/test/option_mfmt.py
@@ -1,0 +1,197 @@
+# Copyright 2016 The Shaderc Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import expect
+import re
+from glslc_test_framework import inside_glslc_testsuite
+from placeholder import FileShader
+
+MINIMAL_SHADER = '#version 140\nvoid main() {}'
+# Regular expression patterns for the minimal shader. The magic number should
+# match exactly, and there should not be a trailing comma at the end of the
+# list. When -mfmt=c is specified, curly brackets should be presented.
+MINIMAL_SHADER_NUM_FORMAT_PATTERN = "^0x07230203.*[0-9a-f]$"
+MINIMAL_SHADER_C_FORMAT_PATTERN = "^\{0x07230203.*[0-9a-f]\}"
+ERROR_SHADER = '#version 140\n#error\nvoid main() {}'
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtCWorksWithDashC(expect.ValidFileContents):
+    """Tests that -mfmt=c works with -c for single input file. SPIR-V binary
+    code output should be emitted as a C-style initializer list in the output
+    file.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-c', '-mfmt=c', '-o', 'output_file']
+    target_filename = 'output_file'
+    expected_file_contents = re.compile(MINIMAL_SHADER_C_FORMAT_PATTERN, re.S)
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtNumWorksWithDashC(expect.ValidFileContents):
+    """Tests that -mfmt=num works with -c for single input file. SPIR-V binary
+    code output should be emitted as a list of hex numbers in the output file.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-c', '-mfmt=num', '-o', 'output_file']
+    target_filename = 'output_file'
+    expected_file_contents = re.compile(MINIMAL_SHADER_NUM_FORMAT_PATTERN, re.S)
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtBinWorksWithDashC(expect.ValidObjectFile):
+    """Tests that -mfmt=bin works with -c for single input file. This test
+    should simply have the SPIR-V binary generated.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-c', '-mfmt=bin']
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtCWithLinking(expect.ValidFileContents):
+    """Tests that -mfmt=c works when linkding is enabled (no -c specified).
+    SPIR-V binary code should be emitted as a C-style initializer list in the
+    output file.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=c']
+    target_filename = 'a.spv'
+    expected_file_contents = re.compile(MINIMAL_SHADER_C_FORMAT_PATTERN, re.S)
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtNumWithLinking(expect.ValidFileContents):
+    """Tests that -mfmt=num works when linkding is enabled (no -c specified).
+    SPIR-V binary code should be emitted as a C-style initializer list in the
+    output file.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=num']
+    target_filename = 'a.spv'
+    expected_file_contents = re.compile(MINIMAL_SHADER_NUM_FORMAT_PATTERN, re.S)
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtCErrorWhenOutputDisasembly(expect.ErrorMessage):
+    """Tests that specifying '-mfmt=c' when the compiler is set to
+    disassembly mode should trigger an error.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=c', '-S', '-o', 'output_file']
+    expected_error = ("glslc: error: cannot emit output as a C-style "
+                      "initializer list when the output is not SPIR-V "
+                      "binary code\n")
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtNumErrorWhenOutputDisasembly(expect.ErrorMessage):
+    """Tests that specifying '-mfmt=num' when the compiler is set to
+    disassembly mode should trigger an error.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=num', '-S', '-o', 'output_file']
+    expected_error = (
+        "glslc: error: cannot emit output as a list of hex numbers "
+        "when the output is not SPIR-V binary code\n")
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtBinErrorWhenOutputDisasembly(expect.ErrorMessage):
+    """Tests that specifying '-mfmt=bin' when the compiler is set to
+    disassembly mode should trigger an error.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=bin', '-S', '-o', 'output_file']
+    expected_error = ("glslc: error: cannot emit output as a binary "
+                      "when the output is not SPIR-V binary code\n")
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtNumErrorWhenOutputPreprocess(expect.ErrorMessage):
+    """Tests that specifying '-mfmt=num' when the compiler is set to
+    preprocessing only mode should trigger an error.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=num', '-E', '-o', 'output_file']
+    expected_error = (
+        "glslc: error: cannot emit output as a list of hex numbers "
+        "when the output is not SPIR-V binary code\n")
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtCErrorWithDashCapM(expect.ErrorMessage):
+    """Tests that specifying '-mfmt=c' should trigger an error when the
+    compiler is set to dump dependency info as the output (-M or -MM is
+    specified).
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=c', '-M', '-o', 'output_file']
+    expected_error = ("glslc: error: cannot emit output as a C-style "
+                      "initializer list when the output is not SPIR-V "
+                      "binary code\n")
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtCWorksWithDashCapMD(expect.ValidFileContents):
+    """Tests that -mfmt=c works with '-c -MD'. SPIR-V binary code
+    should be emitted as a C-style initializer list in the output file.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=c', '-c', '-MD', '-o', 'output_file']
+    target_filename = 'output_file'
+    expected_file_contents = re.compile(MINIMAL_SHADER_C_FORMAT_PATTERN, re.S)
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtNumWorksWithDashCapMD(expect.ValidFileContents):
+    """Tests that -mfmt=num works with '-c -MD'. SPIR-V binary code
+    should be emitted as a C-style initializer list in the output file.
+    """
+    shader = FileShader(MINIMAL_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=num', '-c', '-MD', '-o', 'output_file']
+    target_filename = 'output_file'
+    expected_file_contents = re.compile(MINIMAL_SHADER_NUM_FORMAT_PATTERN, re.S)
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtCExitsElegantlyWithErrorInShader(expect.ErrorMessage):
+    """Tests that the compiler fails elegantly with -mfmt=c when there are
+    errors in the input shader.
+    """
+    shader = FileShader(ERROR_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=c']
+    expected_error = [shader, ':3: error: \'#error\' :\n',
+                      '1 error generated.\n']
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtNumExitsElegantlyWithErrorInShader(expect.ErrorMessage):
+    """Tests that the compiler fails elegantly with -mfmt=num when there are
+    errors in the input shader.
+    """
+    shader = FileShader(ERROR_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=num']
+    expected_error = [shader, ':3: error: \'#error\' :\n',
+                      '1 error generated.\n']
+
+
+@inside_glslc_testsuite('OptionMfmt')
+class TestFmtBinExitsElegantlyWithErrorInShader(expect.ErrorMessage):
+    """Tests that the compiler fails elegantly with -mfmt=binary when there are
+    errors in the input shader.
+    """
+    shader = FileShader(ERROR_SHADER, '.vert')
+    glslc_args = [shader, '-mfmt=bin']
+    expected_error = [shader, ':3: error: \'#error\' :\n',
+                      '1 error generated.\n']

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -71,6 +71,10 @@ Options:
   -std=<value>      Version and profile for input files. Possible values
                     are concatenations of version and profile, e.g. 310es,
                     450core, etc.
+  -mfmt=<format>    Output SPIR-V binary code using the selected format. This
+                    option may be specified only when the compilation output is
+                    in SPIR-V binary code form. Available options include bin, c
+                    and num. By default the binary output format is bin.
   -M                Generate make dependencies. Implies -E and -w.
   -MM               An alias for -M.
   -MD               Generate make dependencies and compile.


### PR DESCRIPTION
Issue: #214

Add command line option: -masm=c-init-list to emit SPIRV binary code as
a C-style uint32_t array initializer list in the output file.

-masm=c-init-list should only be specified when the compilation output
is SPIRV binary code. When used with disassembly mode (-S) and
preprocessing-only mode (-E), it will result in error and fail the
compilation. Note that dumping dependency info as compilation output (-M
or -MM) also implies preprocessing-only (-E) and will lead to error.
But dumpping dependency info to extra .d file (-MD or -MMD) won't cause
error as the compilation output is still SPIRV binary code.