### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Optionally, the following tools may be installed on any OS:
  - [`asciidoctor`](http://asciidoctor.org/): for generating documenation.
    - [`pygments.rb`](https://rubygems.org/gems/pygments.rb) required by
      `asciidoctor` for syntax highlighting.
- - [`nosetests`](https://nose.readthedocs.org): for testing the Python code.
+ - [`nosetests`](https://nose.readthedocs.io): for testing the Python code.
 
 ### Building and running Shderc using Docker
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.