### PR TITLE
Changing Vulkan vs. GL doesn't force teardown of glslang

### DIFF
--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -37,9 +37,7 @@ namespace shaderc_util {
 //                  remove this class.
 class GlslInitializer {
  public:
-  GlslInitializer() : last_messages_(EShMsgDefault) {
-    glslang::InitializeProcess();
-  }
+  GlslInitializer() { glslang::InitializeProcess(); }
 
   ~GlslInitializer() { glslang::FinalizeProcess(); }
 
@@ -70,17 +68,8 @@ class GlslInitializer {
 
   // Obtains exclusive access to the glslang state. The state remains
   // exclusive until the Initialization Token has been destroyed.
-  // Re-initializes glsl state iff the previous messages and the current
-  // messages are incompatible.
-  InitializationToken Acquire(EShMessages new_messages) {
+  InitializationToken Acquire() {
     state_lock_.lock();
-
-    if ((last_messages_ ^ new_messages) &
-        (EShMsgVulkanRules | EShMsgSpvRules)) {
-      glslang::FinalizeProcess();
-      glslang::InitializeProcess();
-    }
-    last_messages_ = new_messages;
     return InitializationToken(this);
   }
 
@@ -89,7 +78,6 @@ class GlslInitializer {
 
   friend class InitializationToken;
 
-  EShMessages last_messages_;
   mutex state_lock_;
 };
 

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -87,7 +87,7 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   std::vector<uint32_t>& compilation_output_data = std::get<1>(result_tuple);
   size_t& compilation_output_data_size_in_bytes = std::get<2>(result_tuple);
 
-  auto token = initializer->Acquire(GetMessageRules());
+  auto token = initializer->Acquire();
   EShLanguage used_shader_stage = forced_shader_stage;
   const std::string macro_definitions =
       shaderc_util::format(predefined_macros_, "#define ", " ", "\n");


### PR DESCRIPTION
Glslang's builtin function table cache is now sensitive
to the Spv vs. non-Spv and Vulkan vs. GL.
That is https://github.com/KhronosGroup/glslang/issues/166 is fixed.
So now we don't have to tear down Glslang's internal state when
the "message rules" change. That's how Vulkan vs. GL is encoded.