### PR TITLE
Fix tests for catching up with upstream glslang

### DIFF
--- a/glslc/test/assembly.py
+++ b/glslc/test/assembly.py
@@ -124,8 +124,10 @@ class TestShaderStageWithAssemblyFile(expect.ErrorMessage):
     glslc_args = ['-c', '-fshader-stage=vertex', shader]
 
     expected_error = [
+        shader, ": error: #version: Desktop shaders for Vulkan SPIR-V require "
+        "version 140 or higher\n",
         shader, ":2: error: '' :  syntax error\n",
-        '1 error generated.\n']
+        '2 errors generated.\n']
 
 
 @inside_glslc_testsuite('SpirvAssembly')

--- a/glslc/test/option_dash_E.py
+++ b/glslc/test/option_dash_E.py
@@ -22,24 +22,27 @@ class TestDashCapENoDefs(expect.StdoutMatch):
     """Tests -E without any defines."""
 
     shader = FileShader('#version 140\nvoid main(){}', '.vert')
-    expected_stdout = '#version 140\nvoid main(){ }\n';
+    expected_stdout = '#version 140\nvoid main(){ }\n'
     glslc_args = ['-E', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEGlslFileAccepted(expect.StdoutMatch):
     """Tests -E if we provide a .glsl file without an explicit stage."""
 
     shader = FileShader('#version 140\nvoid main(){}', '.glsl')
-    expected_stdout = '#version 140\nvoid main(){ }\n';
+    expected_stdout = '#version 140\nvoid main(){ }\n'
     glslc_args = ['-E', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapESingleDefine(expect.StdoutMatch):
     """Tests -E with command-line define."""
 
     shader = FileShader('#version 140\nvoid main(){ int a = X; }', '.vert')
-    expected_stdout = '#version 140\nvoid main(){ int a = 4;}\n';
+    expected_stdout = '#version 140\nvoid main(){ int a = 4;}\n'
     glslc_args = ['-DX=4', '-E', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEExpansion(expect.StdoutMatch):
@@ -57,8 +60,9 @@ void main() {
 void main(){
   int a = 4;
 }
-''';
+'''
     glslc_args = ['-E', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEFunctionMacro(expect.StdoutMatch):
@@ -76,8 +80,9 @@ void main() {
 void main(){
   int a = 4 + 1;
 }
-''';
+'''
     glslc_args = ['-E', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEPragma(expect.StdoutMatch):
@@ -93,8 +98,9 @@ void main() {
 #pragma optimize(off)
 void main(){
 }
-''';
+'''
     glslc_args = ['-E', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEExtension(expect.StdoutMatch):
@@ -110,8 +116,9 @@ void main() {
 #extension foo : require
 void main(){
 }
-''';
+'''
     glslc_args = ['-E', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapELine(expect.StdoutMatch):
@@ -135,8 +142,9 @@ void main() {
 
 void main(){
 }
-''';
+'''
     glslc_args = ['-E', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEError(expect.ErrorMessage):
@@ -151,11 +159,12 @@ void main() {
 }
 ''', '.vert')
 
-    expected_error= [
+    expected_error = [
         shader, ':3: error: \'#error\' : This is an error\n',
         '1 error generated.\n']
 
     glslc_args = ['-E', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEStdin(expect.StdoutMatch):
@@ -169,8 +178,9 @@ void main() {
     expected_stdout = '''#version 140
 void main(){
 }
-''';
+'''
     glslc_args = ['-E', '-fshader-stage=vertex', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEStdinDoesNotRequireShaderStage(expect.StdoutMatch):
@@ -185,8 +195,9 @@ void main() {
     expected_stdout = '''#version 140
 void main(){
 }
-''';
+'''
     glslc_args = ['-E', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEMultipleFiles(expect.StdoutMatch):
@@ -206,8 +217,9 @@ void main(){
 #version 140
 void function(){
 }
-''';
+'''
     glslc_args = ['-E', '-fshader-stage=vertex', shader, shader2]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEMultipleFilesWithoutStage(expect.StdoutMatch):
@@ -228,7 +240,7 @@ void main(){
 #version 140
 void function(){
 }
-''';
+'''
     glslc_args = ['-E', shader, shader2]
 
 
@@ -240,36 +252,40 @@ class TestDashCapEOutputFile(expect.SuccessfulReturn, expect.ValidFileContents):
 void function() {
 }
 ''', '.vert')
-    expected_file_contents='''#version 140
+    expected_file_contents = '''#version 140
 void function(){
 }
 '''
-    target_filename='foo'
+    target_filename = 'foo'
     glslc_args = ['-E', shader, '-ofoo']
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEWithS(expect.StdoutMatch):
     """Tests -E in the presence of -S."""
 
     shader = FileShader('#version 140\nvoid main(){}', '.vert')
-    expected_stdout = '#version 140\nvoid main(){ }\n';
+    expected_stdout = '#version 140\nvoid main(){ }\n'
     glslc_args = ['-E', '-S', shader]
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestMultipileDashCapE(expect.StdoutMatch):
     """Tests that using -E multiple times works."""
 
     shader = FileShader('#version 140\nvoid main(){}', '.vert')
-    expected_stdout = '#version 140\nvoid main(){ }\n';
+    expected_stdout = '#version 140\nvoid main(){ }\n'
     glslc_args = ['-E', '-E', shader, '-E']
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEAfterFile(expect.StdoutMatch):
     """Tests that using -E after the filename also works."""
 
     shader = FileShader('#version 140\nvoid main(){}', '.vert')
-    expected_stdout = '#version 140\nvoid main(){ }\n';
+    expected_stdout = '#version 140\nvoid main(){ }\n'
     glslc_args = [shader, '-E']
+
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEWithDashC(expect.StdoutMatch):
@@ -315,9 +331,10 @@ void main() {
         '4 errors generated.\n']
     glslc_args = ['-E', shader]
 
+
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEStdinErrors(expect.ErrorMessage):
-    """Tests to make sure -E outputs error messages correctly for stdin input."""
+    """Tests that -E outputs error messages correctly for stdin input."""
 
     shader = StdinShader('''#version 310 es
 #extension s enable // missing :
@@ -345,15 +362,16 @@ void main(){
 
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEIgnoresTargetEnvOpengl(expect.StdoutMatch):
-    """Tests to make sure --target-env=opengl is ignored when -E is set."""
+    """Tests that --target-env=opengl is ignored when -E is set."""
 
     shader = FileShader(opengl_compat_frag_shader(), '.frag')
     expected_stdout = opengl_compat_frag_shader()
     glslc_args = ['-E', '--target-env=opengl', shader]
 
+
 @inside_glslc_testsuite('OptionCapE')
 class TestDashCapEIgnoresTargetEnvOpenglCompat(expect.StdoutMatch):
-    """Tests to make sure --target-env=opengl_compat is ignored when -E is set."""
+    """Tests that --target-env=opengl_compat is ignored when -E is set."""
 
     shader = FileShader(opengl_compat_frag_shader(), '.frag')
     expected_stdout = opengl_compat_frag_shader()

--- a/glslc/test/option_dash_E.py
+++ b/glslc/test/option_dash_E.py
@@ -350,10 +350,11 @@ void main() {
 
 # OpenGL compatibility fragment shader. Can be compiled to SPIR-V successfully
 # when target environment is set to opengl_compat. Compilation will fail when
-# target environment is set to other values. But preprocessing should succeed
-# with any target environment values.
+# target environment is set to other values. (gl_FragColor is predefined only
+# in the compatibility profile.) But preprocessing should succeed with any
+# target environment values.
 def opengl_compat_frag_shader():
-    return '''#version 140
+    return '''#version 330
 uniform highp sampler2D tex;
 void main(){
   gl_FragColor = texture2D(tex, vec2(0.0, 0.0));
@@ -375,4 +376,4 @@ class TestDashCapEIgnoresTargetEnvOpenglCompat(expect.StdoutMatch):
 
     shader = FileShader(opengl_compat_frag_shader(), '.frag')
     expected_stdout = opengl_compat_frag_shader()
-    glslc_args = ['-E', '--target-env=vulkan', shader]
+    glslc_args = ['-E', '--target-env=opengl_compat', shader]

--- a/glslc/test/option_std.py
+++ b/glslc/test/option_std.py
@@ -52,6 +52,7 @@ class TestStdEqSpaceArg(expect.ErrorMessage):
     glslc_args = ['-c', '-std=', '450core', shader]
     expected_error = ["glslc: error: invalid value '' in '-std='\n"]
 
+
 # TODO(dneto): The error message changes with different versions of glslang.
 @inside_glslc_testsuite('OptionStd')
 class TestMissingVersionAndStd(expect.ErrorMessageSubstr):

--- a/glslc/test/option_target_env.py
+++ b/glslc/test/option_target_env.py
@@ -18,7 +18,7 @@ from placeholder import FileShader
 
 
 def opengl_compat_fragment_shader():
-    return """#version 140
+    return """#version 330
 uniform highp sampler2D tex;
 void main() {
   gl_FragColor = texture2D(tex, vec2(0.0, 0.0));
@@ -26,7 +26,7 @@ void main() {
 
 
 def opengl_vertex_shader():
-    return """#version 150
+    return """#version 330
 void main() { int t = gl_VertexID; }"""
 
 

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -93,7 +93,7 @@ const char kOpenGLCompatibilityFragmentShader[] =
 
 // A shader that compiles under OpenGL core profile rules.
 const char kOpenGLVertexShader[] =
-    R"(#version 140
+    R"(#version 330
        void main() { int t = gl_VertexID; })";
 
 // Empty 310 es shader. It is valid for vertex, fragment, compute shader kind.

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -72,20 +72,16 @@ EShLanguage GetForcedStage(shaderc_shader_kind kind) {
 
 // Converts shaderc_target_env to EShMessages
 EShMessages GetMessageRules(shaderc_target_env target) {
-  EShMessages msgs = EShMsgDefault;
-
   switch (target) {
     case shaderc_target_env_opengl_compat:
       break;
     case shaderc_target_env_opengl:
-      msgs = EShMsgSpvRules;
-      break;
+      return static_cast<EShMessages>(EShMsgSpvRules | EShMsgCascadingErrors);
     case shaderc_target_env_vulkan:
-      msgs = static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules);
-      break;
+      return static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules |
+                                      EShMsgCascadingErrors);
   }
-
-  return msgs;
+  return EShMsgCascadingErrors;
 }
 
 // A wrapper functor class to be used as stage deducer for libshaderc_util
@@ -151,7 +147,7 @@ class StageDeducer {
         return EShLangTessControl;
       case shaderc_glsl_default_tess_evaluation_shader:
         return EShLangTessEvaluation;
-    case shaderc_spirv_assembly:
+      case shaderc_spirv_assembly:
         return EShLangCount;
     }
     assert(0 && "Unhandled shaderc_shader_kind");

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -535,7 +535,7 @@ TEST_F(CppInterface, ErrorTagIsInputFileName) {
   // 'SampleInputFile'
   EXPECT_FALSE(CompilationResultIsSuccess(compilation_result));
   EXPECT_THAT(compilation_result.GetErrorMessage(),
-              HasSubstr("SampleInputFile:4: error:"));
+              HasSubstr("SampleInputFile:3: error:"));
 }
 
 TEST_F(CppInterface, PreprocessingOnlyOption) {

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -99,7 +99,6 @@ class Compiler {
         generate_debug_info_(false),
         message_rules_(GetDefaultRules()) {}
 
-
   // Requests that the compiler place debug information into the object code,
   // such as identifier names and line numbers.
   void SetGenerateDebugInfo();
@@ -172,7 +171,8 @@ class Compiler {
       GlslInitializer* initializer) const;
 
   static EShMessages GetDefaultRules() {
-    return static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules);
+    return static_cast<EShMessages>(EShMsgSpvRules | EShMsgVulkanRules |
+                                    EShMsgCascadingErrors);
   }
 
  protected:
@@ -251,7 +251,6 @@ class Compiler {
   EProfile default_profile_;
   // When true, use the default version and profile from eponymous data members.
   bool force_version_profile_;
-
 
   // Macro definitions that must be available to reference in the shader source.
   MacroDictionary predefined_macros_;

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -58,13 +58,13 @@ const char kOpenGLCompatibilityFragShaderDeducibleStage[] =
 
 // A shader that compiles under OpenGL core profile rules.
 const char kOpenGLVertexShader[] =
-    R"(#version 150
+    R"(#version 330
        void main() { int t = gl_VertexID; })";
 
 // A shader that compiles under OpenGL core profile rules, even when
 // deducing the stage.
 const char kOpenGLVertexShaderDeducibleStage[] =
-    R"(#version 150
+    R"(#version 330
        #pragma shader_stage(vertex)
        void main() { int t = gl_VertexID; })";
 


### PR DESCRIPTION
* Desktop shaders compiling to SPIR-V require version 330 or higher.
* A new control for reporting cascading errors is introduced. (We'd better turn off cascading errors, but that can happen in another PR.)