### PR TITLE
Update Dockerfile to pull SPIRV-Headers before building.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ FROM alpine
 MAINTAINER Google Shaderc Team
 
 RUN apk add --update \
-    bison \
     build-base \
     cmake \
     git \
@@ -29,9 +28,10 @@ RUN apk add --update \
 WORKDIR /root
 RUN git clone https://github.com/google/shaderc
 WORKDIR shaderc
-RUN git clone https://github.com/google/googletest.git        third_party/googletest
-RUN git clone https://github.com/google/glslang.git           third_party/glslang
-RUN git clone https://github.com/KhronosGroup/SPIRV-Tools.git third_party/spirv-tools
+RUN git clone https://github.com/google/googletest.git          third_party/googletest
+RUN git clone https://github.com/google/glslang.git             third_party/glslang
+RUN git clone https://github.com/KhronosGroup/SPIRV-Tools.git   third_party/spirv-tools
+RUN git clone https://github.com/KhronosGroup/SPIRV-Headers.git third_party/spirv-tools/external/spirv-headers
 
 WORKDIR build
 RUN cmake -GNinja \


### PR DESCRIPTION
Also use this to trigger a rebuild on bots.