### PR TITLE
Invoke python via PYTHON_EXE discovered by cmake

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ Revision history for Shaderc
 
 v2016.1-dev 2016-07-08
  - Start v2016.1
+ - Fixes issues:
+   #238: Fix invocation of python scripts during build
 
 v2016.0 2016-07-07
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,13 +18,13 @@ include(cmake/setup_build.cmake)
 include(cmake/utils.cmake)
 
 add_custom_target(check-copyright ALL
-  ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
+  ${PYTHON_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
   --check
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Check copyright")
 
 add_custom_target(add-copyright
-  ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
+  ${PYTHON_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Add copyright")
 
@@ -54,7 +54,7 @@ add_subdirectory(glslc)
 add_subdirectory(examples)
 
 add_custom_target(build-version
-  ${PYTHON_EXECUTABLE}
+  ${PYTHON_EXE}
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/update_build_version.py
   ${shaderc_SOURCE_DIR} ${spirv-tools_SOURCE_DIR} ${glslang_SOURCE_DIR}
   COMMENT "Update build-version.inc in the Shaderc build directory (if necessary).")

--- a/cmake/setup_build.cmake
+++ b/cmake/setup_build.cmake
@@ -71,7 +71,7 @@ if (ENABLE_CODE_COVERAGE)
     # The symptom is that some .gcno files are wrong after code change and
     # recompiling. We don't know the exact reason yet. Figure it out.
     # Remove all .gcno files in the directory recursively.
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND ${PYTHON_EXE}
     ${shaderc_SOURCE_DIR}/utils/remove-file-by-suffix.py . ".gcno"
     # .gcno files are not tracked by CMake. So no recompiling is triggered
     # even if they are missing. Unfortunately, we just removed all of them

--- a/glslc/test/CMakeLists.txt
+++ b/glslc/test/CMakeLists.txt
@@ -3,7 +3,7 @@ shaderc_add_nosetests(glslc_test_framework)
 
 if(${SHADERC_ENABLE_TESTS})
   add_test(NAME glslc_tests
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND ${PYTHON_EXE}
     ${CMAKE_CURRENT_SOURCE_DIR}/glslc_test_framework.py
     $<TARGET_FILE:glslc_exe> --test-dir ${CMAKE_CURRENT_SOURCE_DIR})
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -64,7 +64,7 @@ if(${SHADERC_ENABLE_TESTS})
   endif()
 
   add_custom_target(copy-tests-if-necessary ALL
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND ${PYTHON_EXE}
       ${shaderc_SOURCE_DIR}/utils/copy-tests-if-necessary.py
       ${GLSLANG_TEST_SRC_DIR} ${GLSLANG_TEST_BIN_DIR} ${GLSLANG_CONFIGURATION_DIR}
     COMMENT "Copying and patching glslang tests if needed")


### PR DESCRIPTION
Previously, the build was invoking python via the undefined
variable PYTHON_EXECUTABLE.

Fixes https://github.com/google/shaderc/issues/238