### PR TITLE
Update glslang error messages about entry points

### DIFF
--- a/glslc/test/messages_tests.py
+++ b/glslc/test/messages_tests.py
@@ -23,7 +23,7 @@ class MultipleErrors(expect.ErrorMessage):
     shader = FileShader('#version 140\nint main() {}', '.vert')
     glslc_args = ['-c', shader]
     expected_error = [
-        shader, ":2: error: 'int' :  main function cannot return a value\n",
+        shader, ":2: error: 'int' :  entry point cannot return a value\n",
         shader, ":2: error: '' : function does not return a value: main\n",
         '2 errors generated.\n']
 
@@ -178,7 +178,7 @@ class WarningAndError(expect.ErrorMessage):
     expected_error = [
         shader, ':2: warning: attribute deprecated in version 130; ',
         'may be removed in future release\n',
-        shader, ":3: error: 'int' :  main function cannot return a value\n",
+        shader, ":3: error: 'int' :  entry point cannot return a value\n",
         shader, ":3: error: '' : function does not return a value: main\n",
         '1 warning and 2 errors generated.\n']
 
@@ -195,7 +195,7 @@ class SuppressedWarningAndError(expect.ErrorMessage):
     glslc_args = ['-c', shader, '-w']
 
     expected_error = [
-        shader, ":3: error: 'int' :  main function cannot return a value\n",
+        shader, ":3: error: 'int' :  entry point cannot return a value\n",
         shader, ":3: error: '' : function does not return a value: main\n",
         '2 errors generated.\n']
 
@@ -214,7 +214,7 @@ class WarningAsErrorAndError(expect.ErrorMessage):
     expected_error = [
         shader, ':2: error: attribute deprecated in version 130; ',
         'may be removed in future release\n',
-        shader, ":3: error: 'int' :  main function cannot return a value\n",
+        shader, ":3: error: 'int' :  entry point cannot return a value\n",
         shader, ":3: error: '' : function does not return a value: main\n",
         '3 errors generated.\n']
 


### PR DESCRIPTION
Change "main function" to "entry point".

This is required to update to latest Glslang sources:
https://github.com/KhronosGroup/glslang/commit/6fccb3cd75cdc34b63461dff19a1d2bd0ef9159f