### PR TITLE
Plumb target environment to SPIRV-Tools

### DIFF
--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -295,12 +295,15 @@ shaderc_compilation_result_t shaderc_compile_into_preprocessed_text(
 // (https://github.com/KhronosGroup/SPIRV-Tools/blob/master/syntax.md),
 // assembles it into SPIR-V binary and a shaderc_compilation_result will be
 // returned to hold the results.
+// The assembling will pick options suitable for assembling specified in the
+// additional_options parameter.
 // May be safely called from multiple threads without explicit synchronization.
 // If there was failure in allocating the compiler object, null will be
 // returned.
 shaderc_compilation_result_t shaderc_assemble_into_spv(
     const shaderc_compiler_t compiler, const char* source_assembly,
-    size_t source_assembly_size);
+    size_t source_assembly_size,
+    const shaderc_compile_options_t additional_options);
 
 // The following functions, operating on shaderc_compilation_result_t objects,
 // offer only the basic thread-safety guarantee.

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -334,19 +334,42 @@ class Compiler {
   // (https://github.com/KhronosGroup/SPIRV-Tools/blob/master/syntax.md).
   // It is valid for the returned CompilationResult object to outlive this
   // compiler object.
+  // The assembling will pick options suitable for assembling specified in the
+  // CompileOptions parameter.
+  SpvCompilationResult AssembleToSpv(const char* source_assembly,
+                                     size_t source_assembly_size,
+                                     const CompileOptions& options) const {
+    return SpvCompilationResult(shaderc_assemble_into_spv(
+        compiler_, source_assembly, source_assembly_size, options.options_));
+  }
+
+  // Assembles the given SPIR-V assembly and returns a SPIR-V binary module
+  // compilation result.
+  // Like the first AssembleToSpv method but uses the default compiler options.
   SpvCompilationResult AssembleToSpv(const char* source_assembly,
                                      size_t source_assembly_size) const {
     return SpvCompilationResult(shaderc_assemble_into_spv(
-        compiler_, source_assembly, source_assembly_size));
+        compiler_, source_assembly, source_assembly_size, nullptr));
   }
 
   // Assembles the given SPIR-V assembly and returns a SPIR-V binary module
   // compilation result.
   // Like the first AssembleToSpv method but the source is provided as a
   // std::string.
+  SpvCompilationResult AssembleToSpv(const std::string& source_assembly,
+                                     const CompileOptions& options) const {
+    return SpvCompilationResult(
+        shaderc_assemble_into_spv(compiler_, source_assembly.data(),
+                                  source_assembly.size(), options.options_));
+  }
+
+  // Assembles the given SPIR-V assembly and returns a SPIR-V binary module
+  // compilation result.
+  // Like the first AssembleToSpv method but the source is provided as a
+  // std::string and also uses default compiler options.
   SpvCompilationResult AssembleToSpv(const std::string& source_assembly) const {
     return SpvCompilationResult(shaderc_assemble_into_spv(
-        compiler_, source_assembly.data(), source_assembly.size()));
+        compiler_, source_assembly.data(), source_assembly.size(), nullptr));
   }
 
   // Compiles the given source GLSL and returns the SPIR-V assembly text

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -458,7 +458,8 @@ shaderc_compilation_result_t shaderc_compile_into_preprocessed_text(
 
 shaderc_compilation_result_t shaderc_assemble_into_spv(
     const shaderc_compiler_t compiler, const char* source_assembly,
-    size_t source_assembly_size) {
+    size_t source_assembly_size,
+    const shaderc_compile_options_t /* additional_options */) {
   auto* result = new (std::nothrow) shaderc_compilation_result_spv_binary;
   if (!result) return nullptr;
   result->compilation_status = shaderc_compilation_status_invalid_assembly;

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -130,15 +130,17 @@ class CppInterface : public testing::Test {
   }
 
   // Assembles the given SPIR-V assembly and returns true on success.
-  bool AssemblingSuccess(const std::string& shader) const {
-    return compiler_.AssembleToSpv(shader).GetCompilationStatus() ==
+  bool AssemblingSuccess(const std::string& shader,
+                         const CompileOptions& options) const {
+    return compiler_.AssembleToSpv(shader, options).GetCompilationStatus() ==
            shaderc_compilation_status_success;
   }
 
   // Assembles the given SPIR-V assembly and returns true if the result contains
   // a valid SPIR-V module.
-  bool AssemblingValid(const std::string& shader) const {
-    return IsValidSpv(compiler_.AssembleToSpv(shader));
+  bool AssemblingValid(const std::string& shader,
+                       const CompileOptions& options) const {
+    return IsValidSpv(compiler_.AssembleToSpv(shader, options));
   }
 
   // Compiles a shader, expects compilation success, and returns the output
@@ -218,7 +220,7 @@ TEST_F(CppInterface, EmptyString) {
 }
 
 TEST_F(CppInterface, AssembleEmptyString) {
-  EXPECT_TRUE(AssemblingSuccess(""));
+  EXPECT_TRUE(AssemblingSuccess("", options_));
 }
 
 TEST_F(CppInterface, ResultObjectMoves) {
@@ -236,10 +238,18 @@ TEST_F(CppInterface, GarbageString) {
 }
 
 TEST_F(CppInterface, AssembleGarbageString) {
-  const auto result = compiler_.AssembleToSpv("jfalkds");
+  const auto result = compiler_.AssembleToSpv("jfalkds", options_);
   EXPECT_FALSE(CompilationResultIsSuccess(result));
   EXPECT_EQ(0u, result.GetNumWarnings());
   EXPECT_EQ(1u, result.GetNumErrors());
+}
+
+// TODO(antiagainst): right now there is no assembling difference for all the
+// target environments exposed by shaderc. So the following is just testing the
+// target environment is accepted.
+TEST_F(CppInterface, AssembleTargetEnv) {
+  options_.SetTargetEnvironment(shaderc_target_env_opengl, 0);
+  EXPECT_TRUE(AssemblingValid("OpCapability Shader", options_));
 }
 
 TEST_F(CppInterface, MinimalShader) {
@@ -250,7 +260,7 @@ TEST_F(CppInterface, MinimalShader) {
 }
 
 TEST_F(CppInterface, AssembleMinimalShader) {
-  EXPECT_TRUE(AssemblingValid(kMinimalShaderAssembly));
+  EXPECT_TRUE(AssemblingValid(kMinimalShaderAssembly, options_));
 }
 
 TEST_F(CppInterface, BasicOptions) {

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -122,9 +122,10 @@ class Compilation {
 class Assembling {
  public:
   // Assembles shader and keeps the result.
-  Assembling(const shaderc_compiler_t compiler, const std::string& assembly)
+  Assembling(const shaderc_compiler_t compiler, const std::string& assembly,
+             const shaderc_compile_options_t options = nullptr)
       : compiled_result_(shaderc_assemble_into_spv(compiler, assembly.data(),
-                                                   assembly.size())) {}
+                                                   assembly.size(), options)) {}
 
   ~Assembling() { shaderc_result_release(compiled_result_); }
 

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -111,6 +111,8 @@ class Compiler {
     Size,  // Optimization towards reducing code size.
   };
 
+  // Creates an default compiler instance targeting at Vulkan environment. Uses
+  // version 110 and no profile specification as the default for GLSL.
   Compiler()
       // The default version for glsl is 110, or 100 if you are using an es
       // profile. But we want to default to a non-es profile.

--- a/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
+++ b/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
@@ -18,21 +18,23 @@
 #include <string>
 #include <vector>
 
-#include "libshaderc_util/string_piece.h"
-
 #include "spirv-tools/libspirv.hpp"
+
+#include "libshaderc_util/compiler.h"
+#include "libshaderc_util/string_piece.h"
 
 namespace shaderc_util {
 // Assembles the given assembly. On success, returns true, writes the assembled
 // binary to *binary, and clears *errors. Otherwise, writes the error message
 // into *errors.
-bool SpirvToolsAssemble(const string_piece assembly, spv_binary* binary,
-                        std::string* errors);
+bool SpirvToolsAssemble(Compiler::TargetEnv env, const string_piece assembly,
+                        spv_binary* binary, std::string* errors);
 
 // Disassembles the given binary. Returns true and writes the disassembled text
 // to *text_or_error if successful. Otherwise, writes the error message to
 // *text_or_error.
-bool SpirvToolsDisassemble(const std::vector<uint32_t>& binary,
+bool SpirvToolsDisassemble(Compiler::TargetEnv env,
+                           const std::vector<uint32_t>& binary,
                            std::string* text_or_error);
 
 // The ids of a list of supported optimization passes.
@@ -46,7 +48,8 @@ enum class PassId {
 // in enabled_passes, without de-duplication. Returns true and writes the
 // optimized binary back to *binary if successful. Otherwise, writes errors to
 // *errors and the content of binary may be in an invalid state.
-bool SpirvToolsOptimize(const std::vector<PassId>& enabled_passes,
+bool SpirvToolsOptimize(Compiler::TargetEnv env,
+                        const std::vector<PassId>& enabled_passes,
                         std::vector<uint32_t>* binary, std::string* errors);
 
 }  // namespace shaderc_util


### PR DESCRIPTION
Address #251.

* Chanage the C interface for assembling to accept options.

Also together with the C interface change, new overloads for assembling
are added into the C++ interface.

* Sort out target environments used in different components.

SPIRV-Tools has its own target environment definition, and public
shaderc API has its own. A new one is added into `Compiler` in
`shaderc_util`, for better isolation.

Now `shaderc_util::Compiler`'s interface accepts target environment,
not glslang messages anymore. All the conversion to glslang messages
are done in the implementation now.