### PR TITLE
Make tests detect working directory at runtime

### DIFF
--- a/libshaderc_util/CMakeLists.txt
+++ b/libshaderc_util/CMakeLists.txt
@@ -65,5 +65,3 @@ if(${SHADERC_ENABLE_TESTS})
   add_dependencies(shaderc_util_file_finder_test testdata)
   add_dependencies(shaderc_util_io_test testdata)
 endif()
-
-add_definitions(-DCURRENT_DIR="${CMAKE_CURRENT_BINARY_DIR}")

--- a/libshaderc_util/src/file_finder_test.cc
+++ b/libshaderc_util/src/file_finder_test.cc
@@ -16,17 +16,36 @@
 
 #include <gtest/gtest.h>
 
+// We need getcwd
+#if WIN32
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "death_test.h"
+
 
 namespace {
 
 using shaderc_util::FileFinder;
 
-const std::string kCurrentDir = CURRENT_DIR;  // A macro set by cmake.
+// Returns the absolute path of the current working directory.
+std::string GetCurrentDir() {
+  // Provide generous space to write the path.
+  char buf[1000];
+#if WIN32
+  return _getcwd(buf, sizeof(buf));
+#else
+  return getcwd(buf, sizeof(buf));
+#endif
+}
 
 class FileFinderTest : public testing::Test {
  protected:
   FileFinder finder;
+  // Absolute path of the current working directory.
+  const std::string current_dir = GetCurrentDir();
 };
 
 TEST_F(FileFinderTest, PathStartsEmpty) {
@@ -89,28 +108,28 @@ TEST_F(FileFinderTest, IrrelevantPaths) {
 }
 
 TEST_F(FileFinderTest, CurrentDirectory) {
-  ASSERT_GE(kCurrentDir.size(), 0u);
+  ASSERT_GE(current_dir.size(), 0u);
   // Either the directory should start with / (if we are on Linux),
   // Or it should beither X:/ or X:\ or // (if we are on Windows).
-  ASSERT_TRUE(kCurrentDir.front() == '\\' || kCurrentDir.front() == '/' ||
-    (kCurrentDir.size() >= 3u && kCurrentDir[1] == ':' &&
-    (kCurrentDir[2] == '\\' || kCurrentDir[2] == '/')));
+  ASSERT_TRUE(current_dir.front() == '\\' || current_dir.front() == '/' ||
+    (current_dir.size() >= 3u && current_dir[1] == ':' &&
+    (current_dir[2] == '\\' || current_dir[2] == '/')));
 }
 
 TEST_F(FileFinderTest, AbsolutePath) {
-  ASSERT_NE('/', kCurrentDir.back());
-  finder.search_path() = {kCurrentDir};
-  EXPECT_EQ(kCurrentDir + "/include_file.1",
+  ASSERT_NE('/', current_dir.back());
+  finder.search_path() = {current_dir};
+  EXPECT_EQ(current_dir + "/include_file.1",
             finder.FindReadableFilepath("include_file.1"));
-  EXPECT_EQ(kCurrentDir + "/dir/subdir/include_file.2",
+  EXPECT_EQ(current_dir + "/dir/subdir/include_file.2",
             finder.FindReadableFilepath("dir/subdir/include_file.2"));
 }
 
 TEST_F(FileFinderTest, AbsoluteFilename) {
-  ASSERT_NE('/', kCurrentDir.back());
+  ASSERT_NE('/', current_dir.back());
 
   finder.search_path() = {""};
-  const std::string absolute_file1 = kCurrentDir + "/include_file.1";
+  const std::string absolute_file1 = current_dir + "/include_file.1";
   EXPECT_EQ(absolute_file1, finder.FindReadableFilepath(absolute_file1));
   EXPECT_EQ("", finder.FindReadableFilepath("/dir/subdir/include_file.2"));
 


### PR DESCRIPTION
This allows us run a test exectuable against a different
copy of the source tree.

Facilitates testing of MinGW-built executables on Windows.