### PR TITLE
glslc: expose HLSL compilation support from Glslang

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
 Revision history for Shaderc
 
 v2016.2-dev 2016-10-12
+ - Support HLSL compilation, exposing functionality in Glslang.
+   - Supported in C, C++ API
+   - glslc accepts "-x hlsl", and assumes .hlsl files are HLSL.
 
 v2016.1 2016-10-12
  - C API for assembling now takes an options object

--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -11,8 +11,7 @@
 
 ----
 glslc [-c|-S|-E]
-      [-x glsl] [-std=standard]
-      [-x hlsl]
+      [-x ...] [-std=standard]
       [-fshader-stage=...]
       [--target-env=...]
       [-g]
@@ -191,7 +190,7 @@ under Vulkan semantics.
 ==== `-x`
 
 `-x` lets you specify the language of the input shader files. Valid languages
-are 'glsl' and 'hlsl'.  If the file extension is `hlsl` then the default language
+are `glsl` and `hlsl`.  If the file extension is `hlsl` then the default language
 is HLSL.  Otherwise the default is 'glsl'.
 
 [[compilation-stage-selection-options]]

--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -12,6 +12,7 @@
 ----
 glslc [-c|-S|-E]
       [-x glsl] [-std=standard]
+      [-x hlsl]
       [-fshader-stage=...]
       [--target-env=...]
       [-g]
@@ -189,8 +190,9 @@ under Vulkan semantics.
 
 ==== `-x`
 
-`-x` lets you specify the language of the input shader files. Right now, the
-only accepted argument is `glsl`.
+`-x` lets you specify the language of the input shader files. Valid languages
+are 'glsl' and 'hlsl'.  If the file extension is `hlsl` then the default language
+is HLSL.  Otherwise the default is 'glsl'.
 
 [[compilation-stage-selection-options]]
 === Compilation Stage Selection Options

--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -158,7 +158,8 @@ GLSL, e.g., `450`.
 
 `-std=` behaves as follows:
 
-* `-std=` affects the version of all inputs passed to `glslc`.
+* `-std=` affects the version of all GLSL inputs passed to `glslc`.
+* `-std=` is ignored for HLSL inputs.
 * `-std=` overwrites `#version` directives in all input shaders, including those
   preceding the argument.
 * If a `-std=` argument specifies a different version from a `#version`

--- a/glslc/src/file.h
+++ b/glslc/src/file.h
@@ -32,9 +32,13 @@ inline bool IsStageFile(const shaderc_util::string_piece& filename) {
          extension == "tese" || extension == "geom" || extension == "comp";
 }
 
-// Returns true if the given file name has extension "glsl".
-inline bool IsGlslFile(const shaderc_util::string_piece& filename) {
-  return glslc::GetFileExtension(filename) == "glsl";
+// Returns the file extension if is either "glsl" or "hlsl", or an empty
+// string otherwise.
+inline std::string GetGlslOrHlslExtension(
+    const shaderc_util::string_piece& filename) {
+  auto extension = glslc::GetFileExtension(filename);
+  if ((extension == "glsl") || (extension == "hlsl")) return extension.str();
+  return "";
 }
 
 }  // namespace glslc

--- a/glslc/src/file_compiler.h
+++ b/glslc/src/file_compiler.h
@@ -60,7 +60,8 @@ class FileCompiler {
   // Any errors/warnings found in the shader source will be output to std::cerr
   // and increment the counts reported by OutputMessages().
   bool CompileShaderFile(const std::string& input_file,
-                         shaderc_shader_kind shader_stage);
+                         shaderc_shader_kind shader_stage,
+                         shaderc_source_language lang);
 
   // Adds a directory to be searched when processing #include directives.
   //

--- a/glslc/src/file_test.cc
+++ b/glslc/src/file_test.cc
@@ -14,14 +14,15 @@
 
 #include "file.h"
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 namespace {
 
 using glslc::GetFileExtension;
 using glslc::IsStageFile;
-using glslc::IsGlslFile;
+using glslc::GetGlslOrHlslExtension;
 using shaderc_util::string_piece;
+using testing::Eq;
 
 class FileExtensionTest : public testing::Test {
  protected:
@@ -36,7 +37,10 @@ class FileExtensionTest : public testing::Test {
   string_piece geom_ext = "shader.geom";
   string_piece comp_ext = "shader.comp";
   string_piece glsl_ext = "shader.glsl";
+  string_piece hlsl_ext = "shader.hlsl";
   string_piece multi_dot = "shader.some..ext";
+  string_piece both_hg_ext = "shader.hlsl.glsl";
+  string_piece both_gh_ext = "shader.glsl.hlsl";
 };
 
 TEST_F(FileExtensionTest, GetFileExtension) {
@@ -52,21 +56,26 @@ TEST_F(FileExtensionTest, GetFileExtension) {
   EXPECT_EQ("comp", GetFileExtension(comp_ext));
   EXPECT_EQ("glsl", GetFileExtension(glsl_ext));
   EXPECT_EQ("ext", GetFileExtension(multi_dot));
+  EXPECT_EQ("glsl", GetFileExtension(both_hg_ext));
+  EXPECT_EQ("hlsl", GetFileExtension(both_gh_ext));
 }
 
-TEST_F(FileExtensionTest, IsGlslFile) {
-  EXPECT_FALSE(IsGlslFile(empty));
-  EXPECT_FALSE(IsGlslFile(dot));
-  EXPECT_FALSE(IsGlslFile(no_ext));
-  EXPECT_FALSE(IsGlslFile(trailing_dot));
-  EXPECT_FALSE(IsGlslFile(vert_ext));
-  EXPECT_FALSE(IsGlslFile(frag_ext));
-  EXPECT_FALSE(IsGlslFile(tesc_ext));
-  EXPECT_FALSE(IsGlslFile(tese_ext));
-  EXPECT_FALSE(IsGlslFile(geom_ext));
-  EXPECT_FALSE(IsGlslFile(comp_ext));
-  EXPECT_TRUE(IsGlslFile(glsl_ext));
-  EXPECT_FALSE(IsGlslFile(multi_dot));
+TEST_F(FileExtensionTest, GetGlslOrHlslExtension) {
+  EXPECT_THAT(GetGlslOrHlslExtension(empty), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(dot), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(no_ext), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(trailing_dot), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(vert_ext), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(frag_ext), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(tesc_ext), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(tese_ext), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(geom_ext), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(comp_ext), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(glsl_ext), Eq("glsl"));
+  EXPECT_THAT(GetGlslOrHlslExtension(hlsl_ext), Eq("hlsl"));
+  EXPECT_THAT(GetGlslOrHlslExtension(multi_dot), Eq(""));
+  EXPECT_THAT(GetGlslOrHlslExtension(both_hg_ext), Eq("glsl"));
+  EXPECT_THAT(GetGlslOrHlslExtension(both_gh_ext), Eq("hlsl"));
 }
 
 TEST_F(FileExtensionTest, IsStageFile) {

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -64,9 +64,9 @@ Options:
   -I <value>        Add directory to include search path.
   -o <file>         Write output to <file>.
                     A file name of '-' represents standard output.
-  -std=<value>      Version and profile for input files. Possible values
+  -std=<value>      Version and profile for GLSL input files. Possible values
                     are concatenations of version and profile, e.g. 310es,
-                    450core, etc.
+                    450core, etc.  Ignored for HLSL files.
   -mfmt=<format>    Output SPIR-V binary code using the selected format. This
                     option may be specified only when the compilation output is
                     in SPIR-V binary code form. Available options include bin, c

--- a/glslc/test/option_shader_stage.py
+++ b/glslc/test/option_shader_stage.py
@@ -24,6 +24,10 @@ def simple_vertex_shader():
     }"""
 
 
+def simple_hlsl_vertex_shader():
+    return """float4 EntryPoint() : SV_POSITION { return float4(1.0); } """
+
+
 def simple_fragment_shader():
     return """#version 310 es
     void main() {
@@ -62,6 +66,14 @@ class TestShaderStageWithGlslExtension(expect.ValidObjectFile):
     """Tests -fshader-stage with .glsl extension."""
 
     shader = FileShader(simple_vertex_shader(), '.glsl')
+    glslc_args = ['-c', '-fshader-stage=vertex', shader]
+
+
+@inside_glslc_testsuite('OptionShaderStage')
+class TestShaderStageWithHlslExtension(expect.ValidObjectFile):
+    """Tests -fshader-stage with .hlsl extension."""
+
+    shader = FileShader(simple_hlsl_vertex_shader(), '.hlsl')
     glslc_args = ['-c', '-fshader-stage=vertex', shader]
 
 
@@ -185,6 +197,18 @@ class TestShaderStageGlslExtensionMissingShaderStage(expect.ErrorMessage):
     expected_error = [
         "glslc: error: '", shader,
         "': .glsl file encountered but no -fshader-stage specified ahead\n"]
+
+
+@inside_glslc_testsuite('OptionShaderStage')
+class TestShaderStageHlslExtensionMissingShaderStage(expect.ErrorMessage):
+    """Tests that missing -fshader-stage for .hlsl extension results in
+    an error."""
+
+    shader = FileShader(simple_hlsl_vertex_shader(), '.hlsl')
+    glslc_args = ['-c', '-x', 'hlsl', shader]
+    expected_error = [
+        "glslc: error: '", shader,
+        "': .hlsl file encountered but no -fshader-stage specified ahead\n"]
 
 
 @inside_glslc_testsuite('OptionShaderStage')

--- a/glslc/test/option_std.py
+++ b/glslc/test/option_std.py
@@ -28,6 +28,10 @@ def core_frag_shader_without_version():
     return 'void main() { int temp = gl_SampleID; }'
 
 
+def hlsl_compute_shader_with_barriers():
+    return 'void Entry() { AllMemoryBarrierWithGroupSync(); }'
+
+
 @inside_glslc_testsuite('OptionStd')
 class TestStdNoArg(expect.ErrorMessage):
     """Tests -std alone."""
@@ -69,6 +73,15 @@ class TestMissingVersionButHavingStd(expect.ValidObjectFile):
 
     shader = FileShader(core_frag_shader_without_version(), '.frag')
     glslc_args = ['-c', '-std=450core', shader]
+
+
+@inside_glslc_testsuite('OptionStd')
+class TestStdIgnoredInHlsl(expect.ValidObjectFile):
+    """Tests HLSL compilation ignores -std."""
+
+    # Compute shaders are not available in OpenGL 150
+    shader = FileShader(hlsl_compute_shader_with_barriers(), '.comp')
+    glslc_args = ['-c', '-x', 'hlsl', '-std=150', shader]
 
 
 @inside_glslc_testsuite('OptionStd')

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -89,7 +89,9 @@ Options:
   -w                Suppresses all warning messages.
   -Werror           Treat all warnings as errors.
   -x <language>     Treat subsequent input files as having type <language>.
-                    The only supported language is glsl.
+                    Valid languages are: glsl, hlsl.
+                    For files ending in .hlsl the default is hlsl.
+                    Otherwise the default is glsl.
 '''
 
     expected_stderr = ''

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -68,9 +68,9 @@ Options:
   -I <value>        Add directory to include search path.
   -o <file>         Write output to <file>.
                     A file name of '-' represents standard output.
-  -std=<value>      Version and profile for input files. Possible values
+  -std=<value>      Version and profile for GLSL input files. Possible values
                     are concatenations of version and profile, e.g. 310es,
-                    450core, etc.
+                    450core, etc.  Ignored for HLSL files.
   -mfmt=<format>    Output SPIR-V binary code using the selected format. This
                     option may be specified only when the compilation output is
                     in SPIR-V binary code form. Available options include bin, c

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -1293,7 +1293,7 @@ TEST_F(CompileStringTest, NullSourceNameFailsCompilingToPreprocessedText) {
 }
 
 const char kGlslVertexShader[] =
-      "#version 140\nvoid main(){ gl_Position = vec4(0);}";
+    "#version 140\nvoid main(){ gl_Position = vec4(0);}";
 
 const char kHlslVertexShader[] =
     "float4 EntryPoint(uint index : SV_VERTEXID) : SV_POSITION\n"
@@ -1302,34 +1302,29 @@ const char kHlslVertexShader[] =
 TEST_F(CompileStringTest, LangGlslOnGlslVertexSucceeds) {
   shaderc_compile_options_set_source_language(options_.get(),
                                               shaderc_source_language_glsl);
-  EXPECT_TRUE(CompilationSuccess(kGlslVertexShader,
-                                 shaderc_glsl_vertex_shader,
+  EXPECT_TRUE(CompilationSuccess(kGlslVertexShader, shaderc_glsl_vertex_shader,
                                  options_.get()));
 }
 
 TEST_F(CompileStringTest, LangGlslOnHlslVertexFails) {
   shaderc_compile_options_set_source_language(options_.get(),
                                               shaderc_source_language_glsl);
-  EXPECT_FALSE(CompilationSuccess(kHlslVertexShader,
-                                  shaderc_glsl_vertex_shader,
+  EXPECT_FALSE(CompilationSuccess(kHlslVertexShader, shaderc_glsl_vertex_shader,
                                   options_.get()));
 }
 
 TEST_F(CompileStringTest, LangHlslOnGlslVertexFails) {
   shaderc_compile_options_set_source_language(options_.get(),
                                               shaderc_source_language_hlsl);
-  EXPECT_FALSE(CompilationSuccess(kGlslVertexShader,
-                                  shaderc_glsl_vertex_shader,
+  EXPECT_FALSE(CompilationSuccess(kGlslVertexShader, shaderc_glsl_vertex_shader,
                                   options_.get()));
 }
 
 TEST_F(CompileStringTest, LangHlslOnHlslVertexSucceeds) {
   shaderc_compile_options_set_source_language(options_.get(),
                                               shaderc_source_language_hlsl);
-  EXPECT_TRUE(CompilationSuccess(kHlslVertexShader,
-                                 shaderc_glsl_vertex_shader,
+  EXPECT_TRUE(CompilationSuccess(kHlslVertexShader, shaderc_glsl_vertex_shader,
                                  options_.get()));
 }
-
 
 }  // anonymous namespace


### PR DESCRIPTION
Support "-x hlsl", i.e. hlsl is a valid language specifier.

Files with .hlsl extension default to HLSL.