### PR TITLE
Removed SPIRV-Tools source/instruction.cpp

### DIFF
--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -177,7 +177,6 @@ LOCAL_SRC_FILES:= \
 		source/diagnostic.cpp \
 		source/disassemble.cpp \
 		source/ext_inst.cpp \
-		source/instruction.cpp \
 		source/libspirv.cpp \
 		source/name_mapper.cpp \
 		source/opcode.cpp \


### PR DESCRIPTION
Goes with https://github.com/KhronosGroup/SPIRV-Tools/pull/453