### PR TITLE
C, C++ APIs are sensitive to entry_point_name

### DIFF
--- a/libshaderc/CMakeLists.txt
+++ b/libshaderc/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(shaderc PRIVATE SPIRV-Tools)
 shaderc_add_tests(
   TEST_PREFIX shaderc
   LINK_LIBS shaderc
-  INCLUDE_DIRS include ${glslang_SOURCE_DIR}
+  INCLUDE_DIRS include ${glslang_SOURCE_DIR} ${spirv-tools_SOURCE_DIR}/include
   TEST_NAMES
     shaderc
     shaderc_cpp)
@@ -34,7 +34,7 @@ shaderc_combine_static_lib(shaderc_combined shaderc)
 shaderc_add_tests(
   TEST_PREFIX shaderc_combined
   LINK_LIBS shaderc_combined ${CMAKE_THREAD_LIBS_INIT}
-  INCLUDE_DIRS include ${glslang_SOURCE_DIR}
+  INCLUDE_DIRS include ${glslang_SOURCE_DIR} ${spirv-tools_SOURCE_DIR}/include
   TEST_NAMES
     shaderc
     shaderc_cpp)

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -279,6 +279,9 @@ class Compiler {
   // The input_file_name is a null-termintated string. It is used as a tag to
   // identify the source string in cases like emitting error messages. It
   // doesn't have to be a 'file name'.
+  // The entry_point_name parameter is a null-terminated string specifying
+  // the entry point name for HLSL compilation.  For GLSL compilation, the
+  // entry point name is assumed to be "main".
   // The compilation is passed any options specified in the CompileOptions
   // parameter.
   // It is valid for the returned CompilationResult object to outlive this
@@ -290,16 +293,30 @@ class Compiler {
                                         size_t source_text_size,
                                         shaderc_shader_kind shader_kind,
                                         const char* input_file_name,
+                                        const char* entry_point_name,
                                         const CompileOptions& options) const {
     shaderc_compilation_result_t compilation_result = shaderc_compile_into_spv(
         compiler_, source_text, source_text_size, shader_kind, input_file_name,
-        "main", options.options_);
+        entry_point_name, options.options_);
     return SpvCompilationResult(compilation_result);
+  }
+
+  // Compiles the given source shader and returns a SPIR-V binary module
+  // compilation result.
+  // Like the first CompileGlslToSpv method but assumes the entry point name
+  // is "main".
+  SpvCompilationResult CompileGlslToSpv(const char* source_text,
+                                        size_t source_text_size,
+                                        shaderc_shader_kind shader_kind,
+                                        const char* input_file_name,
+                                        const CompileOptions& options) const {
+    return CompileGlslToSpv(source_text, source_text_size, shader_kind,
+                            input_file_name, "main", options);
   }
 
   // Compiles the given source GLSL and returns a SPIR-V binary module
   // compilation result.
-  // Like the first CompileGlslToSpv method but uses default options.
+  // Like the previous CompileGlslToSpv method but uses default options.
   SpvCompilationResult CompileGlslToSpv(const char* source_text,
                                         size_t source_text_size,
                                         shaderc_shader_kind shader_kind,
@@ -310,10 +327,10 @@ class Compiler {
     return SpvCompilationResult(compilation_result);
   }
 
-  // Compiles the given source GLSL and returns a SPIR-V binary module
+  // Compiles the given source shader and returns a SPIR-V binary module
   // compilation result.
   // Like the first CompileGlslToSpv method but the source is provided as
-  // a std::string.
+  // a std::string, and we assume the entry point is "main".
   SpvCompilationResult CompileGlslToSpv(const std::string& source_text,
                                         shaderc_shader_kind shader_kind,
                                         const char* input_file_name,
@@ -322,10 +339,23 @@ class Compiler {
                             input_file_name, options);
   }
 
-  // Compiles the given source GLSL and returns a SPIR-V binary module
+  // Compiles the given source shader and returns a SPIR-V binary module
   // compilation result.
   // Like the first CompileGlslToSpv method but the source is provided as
-  // a std::string and also uses default compiler options.
+  // a std::string.
+  SpvCompilationResult CompileGlslToSpv(const std::string& source_text,
+                                        shaderc_shader_kind shader_kind,
+                                        const char* input_file_name,
+                                        const char* entry_point_name,
+                                        const CompileOptions& options) const {
+    return CompileGlslToSpv(source_text.data(), source_text.size(), shader_kind,
+                            input_file_name, entry_point_name, options);
+  }
+
+  // Compiles the given source GLSL and returns a SPIR-V binary module
+  // compilation result.
+  // Like the previous CompileGlslToSpv method but assumes the entry point
+  // name is "main".
   SpvCompilationResult CompileGlslToSpv(const std::string& source_text,
                                         shaderc_shader_kind shader_kind,
                                         const char* input_file_name) const {
@@ -383,12 +413,23 @@ class Compiler {
   AssemblyCompilationResult CompileGlslToSpvAssembly(
       const char* source_text, size_t source_text_size,
       shaderc_shader_kind shader_kind, const char* input_file_name,
-      const CompileOptions& options) const {
+      const char* entry_point_name, const CompileOptions& options) const {
     shaderc_compilation_result_t compilation_result =
         shaderc_compile_into_spv_assembly(
             compiler_, source_text, source_text_size, shader_kind,
-            input_file_name, "main", options.options_);
+            input_file_name, entry_point_name, options.options_);
     return AssemblyCompilationResult(compilation_result);
+  }
+
+  // Compiles the given source GLSL and returns the SPIR-V assembly text
+  // compilation result.
+  // Similare to the previous method, but assumes entry point name is "main".
+  AssemblyCompilationResult CompileGlslToSpvAssembly(
+      const char* source_text, size_t source_text_size,
+      shaderc_shader_kind shader_kind, const char* input_file_name,
+      const CompileOptions& options) const {
+    return CompileGlslToSpvAssembly(source_text, source_text_size, shader_kind,
+                                    input_file_name, "main", options);
   }
 
   // Compiles the given source GLSL and returns the SPIR-V assembly text
@@ -397,9 +438,21 @@ class Compiler {
   // the first CompileToSpv method.
   AssemblyCompilationResult CompileGlslToSpvAssembly(
       const std::string& source_text, shaderc_shader_kind shader_kind,
-      const char* input_file_name, const CompileOptions& options) const {
+      const char* input_file_name, const char* entry_point_name,
+      const CompileOptions& options) const {
     return CompileGlslToSpvAssembly(source_text.data(), source_text.size(),
-                                    shader_kind, input_file_name, options);
+                                    shader_kind, input_file_name,
+                                    entry_point_name, options);
+  }
+
+  // Compiles the given source GLSL and returns the SPIR-V assembly text
+  // result. Like the previous  CompileGlslToSpvAssembly method but assumes
+  // the entry point name is "main".
+  AssemblyCompilationResult CompileGlslToSpvAssembly(
+      const std::string& source_text, shaderc_shader_kind shader_kind,
+      const char* input_file_name, const CompileOptions& options) const {
+    return CompileGlslToSpvAssembly(source_text, shader_kind, input_file_name,
+                                    "main", options);
   }
 
   // Preprocesses the given source GLSL and returns the preprocessed

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -394,7 +394,7 @@ shaderc_compilation_result_t CompileToSpecifiedOutputType(
       std::tie(compilation_succeeded, compilation_output_data,
                compilation_output_data_size_in_bytes) =
           additional_options->compiler.Compile(
-              source_string, forced_stage, input_file_name_str,
+              source_string, forced_stage, input_file_name_str, entry_point_name,
               // stage_deducer has a flag: error_, which we need to check later.
               // We need to make this a reference wrapper, so that std::function
               // won't make a copy for this callable object.
@@ -406,7 +406,7 @@ shaderc_compilation_result_t CompileToSpecifiedOutputType(
       std::tie(compilation_succeeded, compilation_output_data,
                compilation_output_data_size_in_bytes) =
           shaderc_util::Compiler().Compile(
-              source_string, forced_stage, input_file_name_str,
+              source_string, forced_stage, input_file_name_str, entry_point_name,
               std::ref(stage_deducer), includer, output_type, &errors,
               &total_warnings, &total_errors, compiler->initializer);
     }

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -94,7 +94,7 @@ class Compiler {
  public:
   // Source language
   enum class SourceLanguage {
-    GLSL, // The default
+    GLSL,  // The default
     HLSL,
   };
 
@@ -168,6 +168,11 @@ class Compiler {
   // If the forced_shader stage parameter is not EShLangCount then
   // the shader is assumed to be of the given stage.
   //
+  // For HLSL compilation, entry_point_name is the null-terminated string for
+  // the
+  // entry point.  For GLSL compilation, entry_point_name is ignored, and
+  // compilation assumes the entry point is named "main".
+  //
   // The stage_callback function will be called if a shader_stage has
   // not been forced and the stage can not be determined
   // from the shader text. Any #include directives are parsed with the given
@@ -194,7 +199,7 @@ class Compiler {
   // If the output is a text string, the size equals the length of that string.
   std::tuple<bool, std::vector<uint32_t>, size_t> Compile(
       const string_piece& input_source_string, EShLanguage forced_shader_stage,
-      const std::string& error_tag,
+      const std::string& error_tag, const char* entry_point_name,
       const std::function<EShLanguage(std::ostream* error_stream,
                                       const string_piece& error_tag)>&
           stage_callback,


### PR DESCRIPTION
Before, the C API ignored the entry point name.
Before, the C++ API didn't have entry points that accepted
an entry point name.