### PR TITLE
Add -fentry-point to glslc

### DIFF
--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -13,6 +13,7 @@
 glslc [-c|-S|-E]
       [-x ...] [-std=standard]
       [-fshader-stage=...]
+      [-fentry-point=...]
       [--target-env=...]
       [-g]
       [-O0|-Os]
@@ -148,6 +149,12 @@ need to supply both SPIR-V assembly files and `-fshader-stage=` on the same
 command line, please put SPIR-V assembly files ahead of the first
 `-fshader-stage=`, since `-fshader-stage=` only affects the treatment of
 subsequent files.
+
+[[option-f-entry-point]]
+==== `-fentry-point=`
+
+`-fentry-point=<name>` lets you specify the entry point name.  This is only
+significant for HLSL compilation.  The default is "main".
 
 ==== `-std=`
 

--- a/glslc/src/file_compiler.h
+++ b/glslc/src/file_compiler.h
@@ -25,6 +25,14 @@
 
 namespace glslc {
 
+// Describes an input file to be compiled.
+struct InputFileSpec {
+  std::string name;
+  shaderc_shader_kind stage;
+  shaderc_source_language language;
+  std::string entry_point_name;
+};
+
 // Context for managing compilation of source GLSL files into destination
 // SPIR-V files or preprocessed output.
 class FileCompiler {
@@ -46,10 +54,11 @@ class FileCompiler {
         total_warnings_(0),
         total_errors_(0) {}
 
-  // Compiles a shader received in input_file, returning true on success and
-  // false otherwise. If force_shader_stage is not shaderc_glsl_infer_source or
-  // any default shader stage then the given shader_stage will be used,
-  // otherwise it will be determined from the source or the file type.
+  // Compiles a shader received as specified by input_file, returning true
+  // on success and false otherwise. If force_shader_stage is not
+  // shaderc_glsl_infer_source or any default shader stage then the given
+  // shader_stage will be used, otherwise it will be determined from the source
+  // or the file type.
   //
   // Places the compilation output into a new file whose name is derived from
   // input_file according to the rules from glslc/README.asciidoc.
@@ -59,9 +68,7 @@ class FileCompiler {
   //
   // Any errors/warnings found in the shader source will be output to std::cerr
   // and increment the counts reported by OutputMessages().
-  bool CompileShaderFile(const std::string& input_file,
-                         shaderc_shader_kind shader_stage,
-                         shaderc_source_language lang);
+  bool CompileShaderFile(const InputFileSpec& input_file);
 
   // Adds a directory to be searched when processing #include directives.
   //

--- a/glslc/test/CMakeLists.txt
+++ b/glslc/test/CMakeLists.txt
@@ -5,5 +5,6 @@ if(${SHADERC_ENABLE_TESTS})
   add_test(NAME glslc_tests
     COMMAND ${PYTHON_EXE}
     ${CMAKE_CURRENT_SOURCE_DIR}/glslc_test_framework.py
-    $<TARGET_FILE:glslc_exe> --test-dir ${CMAKE_CURRENT_SOURCE_DIR})
+    $<TARGET_FILE:glslc_exe> $<TARGET_FILE:spirv-dis>
+    --test-dir ${CMAKE_CURRENT_SOURCE_DIR})
 endif()

--- a/glslc/test/expect.py
+++ b/glslc/test/expect.py
@@ -216,11 +216,11 @@ class ValidObjectFile(SuccessfulReturn, CorrectObjectFilePreamble):
 class ValidObjectFileWithAssemblySubstr(SuccessfulReturn, CorrectObjectFilePreamble):
     """Mixin class for checking that every input file generates a valid object
     file following the object file naming rule, there is no output on
-    stdout/stderr, and the disassmbly contains a specified substring."""
+    stdout/stderr, and the disassmbly contains a specified substring per input."""
 
     def check_object_file_disassembly(self, status):
-        for input_filename in status.input_filenames:
-            object_filename = get_object_filename(input_filename)
+        for an_input in status.inputs:
+            object_filename = get_object_filename(an_input.filename)
             obj_file = str(os.path.join(status.directory, object_filename))
             success, message = self.verify_object_file_preamble(obj_file)
             if not success:
@@ -231,10 +231,12 @@ class ValidObjectFileWithAssemblySubstr(SuccessfulReturn, CorrectObjectFilePream
                 stderr=subprocess.PIPE, cwd=status.directory)
             output = process.communicate(None)
             disassembly = output[0]
-        if self.expected_assembly_substr not in disassembly :
-           return False, ('Incorrect disassembly output:\n{asm}\n'
-                  'Expected substring not found:\n{exp}'.format(
-                  asm=disassembly, exp=self.expected_assembly_substr))
+            if not isinstance(an_input.assembly_substr, str):
+                return False, "Missing assembly_substr member"
+            if an_input.assembly_substr not in disassembly:
+                return False, ('Incorrect disassembly output:\n{asm}\n'
+                    'Expected substring not found:\n{exp}'.format(
+                    asm=disassembly, exp=an_input.assembly_substr))
         return True, ''
 
 

--- a/glslc/test/expect.py
+++ b/glslc/test/expect.py
@@ -311,7 +311,12 @@ class ValidAssemblyFile(SuccessfulReturn, CorrectAssemblyFilePreamble):
 class ValidAssemblyFileWithSubstr(ValidAssemblyFile):
     """Mixin class for checking that every input file generates a valid assembly
     file following the assembly file naming rule, there is no output on
-    stdout/stderr, and the assembly file has a given substring."""
+    stdout/stderr, and all assembly files have the given substring specified
+    by expected_assembly_substr.
+
+    To mix in this class, subclasses need to provde expected_assembly_substr
+    as the expected substring.
+    """
 
     def check_assembly_with_substr(self, status):
         for input_filename in status.input_filenames:

--- a/glslc/test/expect.py
+++ b/glslc/test/expect.py
@@ -21,6 +21,7 @@ methods in the mixin classes.
 import difflib
 import os
 import re
+import subprocess
 from glslc_test_framework import GlslCTest
 
 
@@ -212,6 +213,31 @@ class ValidObjectFile(SuccessfulReturn, CorrectObjectFilePreamble):
         return True, ''
 
 
+class ValidObjectFileWithAssemblySubstr(SuccessfulReturn, CorrectObjectFilePreamble):
+    """Mixin class for checking that every input file generates a valid object
+    file following the object file naming rule, there is no output on
+    stdout/stderr, and the disassmbly contains a specified substring."""
+
+    def check_object_file_disassembly(self, status):
+        for input_filename in status.input_filenames:
+            object_filename = get_object_filename(input_filename)
+            obj_file = str(os.path.join(status.directory, object_filename))
+            success, message = self.verify_object_file_preamble(obj_file)
+            if not success:
+                return False, message
+            cmd = [status.test_manager.disassembler_path, '--no-color', obj_file]
+            process = subprocess.Popen(
+                args=cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, cwd=status.directory)
+            output = process.communicate(None)
+            disassembly = output[0]
+        if self.expected_assembly_substr not in disassembly :
+           return False, ('Incorrect disassembly output:\n{asm}\n'
+                  'Expected substring not found:\n{exp}'.format(
+                  asm=disassembly, exp=self.expected_assembly_substr))
+        return True, ''
+
+
 class ValidNamedObjectFile(SuccessfulReturn, CorrectObjectFilePreamble):
     """Mixin class for checking that a list of object files with the given
     names are correctly generated, and there is no output on stdout/stderr.
@@ -277,6 +303,27 @@ class ValidAssemblyFile(SuccessfulReturn, CorrectAssemblyFilePreamble):
                 os.path.join(status.directory, assembly_filename))
             if not success:
                 return False, message
+        return True, ''
+
+
+class ValidAssemblyFileWithSubstr(ValidAssemblyFile):
+    """Mixin class for checking that every input file generates a valid assembly
+    file following the assembly file naming rule, there is no output on
+    stdout/stderr, and the assembly file has a given substring."""
+
+    def check_assembly_with_substr(self, status):
+        for input_filename in status.input_filenames:
+            assembly_filename = get_assembly_filename(input_filename)
+            success, message = self.verify_assembly_file_preamble(
+                os.path.join(status.directory, assembly_filename))
+            if not success:
+                return False, message
+            with open(assembly_filename, 'r') as f:
+                content = f.read()
+                if self.expected_assembly_substr not in convert_to_unix_line_endings(content):
+                   return False, ('Incorrect assembly output:\n{asm}\n'
+                                  'Expected substring not found:\n{exp}'.format(
+                                  asm=content, exp=self.expected_assembly_substr))
         return True, ''
 
 

--- a/glslc/test/expect_nosetest.py
+++ b/glslc/test/expect_nosetest.py
@@ -41,20 +41,20 @@ class TestStdoutMatchADotC(expect.StdoutMatch):
 
 def nosetest_stdout_match_regex_has_match():
     test = TestStdoutMatchADotC()
-    status = TestStatus(returncode=0, stdout='0abc1', stderr=None,
-                        directory=None, input_filenames=None)
+    status = TestStatus(test_manager=None, returncode=0, stdout='0abc1',
+                        stderr=None, directory=None, inputs=None, input_filenames=None)
     assert_true(test.check_stdout_match(status)[0])
 
 
 def nosetest_stdout_match_regex_no_match():
     test = TestStdoutMatchADotC()
-    status = TestStatus(returncode=0, stdout='ab', stderr=None,
-                        directory=None, input_filenames=None)
+    status = TestStatus(test_manager=None, returncode=0, stdout='ab',
+                        stderr=None, directory=None, inputs=None, input_filenames=None)
     assert_false(test.check_stdout_match(status)[0])
 
 
 def nosetest_stdout_match_regex_empty_stdout():
     test = TestStdoutMatchADotC()
-    status = TestStatus(returncode=0, stdout='', stderr=None,
-                        directory=None, input_filenames=None)
+    status = TestStatus(test_manager=None, returncode=0, stdout='', stderr=None,
+                        directory=None, inputs=None, input_filenames=None)
     assert_false(test.check_stdout_match(status)[0])

--- a/glslc/test/glslc_test_framework.py
+++ b/glslc/test/glslc_test_framework.py
@@ -28,7 +28,7 @@ case is then run by the following steps:
      The transformed list elements are then supplied as glslc arguments.
   3. If the environment member variable exists, its write() method will be
      invoked.
-  4. All expected_* member varibles will be inspected and all placeholders in
+  4. All expected_* member variables will be inspected and all placeholders in
      them will be expanded by calling instantiate_for_expectation() on those
      placeholders. After placeholder expansion, if the expected_* variable is
      a list, its element will be joined together with '' to form a single
@@ -141,13 +141,15 @@ class GlslCTest:
 class TestStatus:
     """A struct for holding run status of a test case."""
 
-    def __init__(self, test_manager, returncode, stdout, stderr, directory, input_filenames):
+    def __init__(self, test_manager, returncode, stdout, stderr, directory, inputs, input_filenames):
         self.test_manager = test_manager
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
         # temporary directory where the test runs
         self.directory = directory
+        # List of inputs, as PlaceHolder objects.
+        self.inputs = inputs
         # the names of input shader files (potentially including paths)
         self.input_filenames = input_filenames
 
@@ -238,7 +240,8 @@ class TestCase:
     def __init__(self, test, test_manager):
         self.test = test
         self.test_manager = test_manager
-        self.file_shaders = []  # filenames of shader files
+        self.inputs = []  # inputs, as PlaceHolder objects.
+        self.file_shaders = []  # filenames of shader files.
         self.stdin_shader = None  # text to be passed to glslc as stdin
 
     def setUp(self):
@@ -252,8 +255,8 @@ class TestCase:
             if isinstance(arg, PlaceHolder) else arg
             for arg in self.test.glslc_args]
         # Get all shader files' names
-        self.file_shaders = [
-            arg.filename for arg in glslc_args if isinstance(arg, PlaceHolder)]
+        self.inputs = [arg for arg in glslc_args if isinstance(arg, PlaceHolder)]
+        self.file_shaders = [arg.filename for arg in self.inputs]
 
         if 'environment' in get_all_variables(self.test):
             self.test.environment.write(self.directory)
@@ -298,7 +301,7 @@ class TestCase:
             test_status = TestStatus(
                 self.test_manager,
                 process.returncode, output[0], output[1],
-                self.directory, self.file_shaders)
+                self.directory, self.inputs, self.file_shaders)
             run_results = [getattr(self.test, test_method)(test_status)
                            for test_method in get_all_test_methods(
                                self.test.__class__)]

--- a/glslc/test/option_dash_x.py
+++ b/glslc/test/option_dash_x.py
@@ -51,11 +51,41 @@ class TestDashXGlslOnHlslShader(expect.ErrorMessageSubstr):
 
 
 @inside_glslc_testsuite('OptionDashX')
-class TestDashXHlslOnHlslShader(expect.ValidObjectFile):
-    """Tests -x hlsl on an HLSL shader."""
+class TestDashXHlslOnHlslShaderWithSpecifiedEntryPointInAssembly(expect.ValidAssemblyFileWithSubstr):
+    """Tests -x hlsl on an HLSL shader with -fentry-point and -S."""
 
     shader = FileShader(HLSL_VERTEX_SHADER, '.vert')
-    glslc_args = ['-x', 'hlsl', '-c', shader]
+    glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-S', '-c', shader]
+    expected_assembly_substr = "OpEntryPoint Vertex %EntryPoint \"EntryPoint\""
+
+
+@inside_glslc_testsuite('OptionDashX')
+class TestDashXHlslOnHlslShaderWithSpecifiedEntryPointInDisassembly(expect.ValidObjectFileWithAssemblySubstr):
+    """Tests -x hlsl on an HLSL shader with -fentry-point."""
+
+    shader = FileShader(HLSL_VERTEX_SHADER, '.vert')
+    glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-c', shader]
+    expected_assembly_substr = "OpEntryPoint Vertex %EntryPoint \"EntryPoint\""
+
+
+@inside_glslc_testsuite('OptionDashX')
+class TestDashXHlslDashFEntryPointAffectsAllLaterFiles(expect.ValidObjectFileWithAssemblySubstr):
+    """Tests -x hlsl on an HLSL shader with -fentry-point."""
+
+    shader1 = FileShader(HLSL_VERTEX_SHADER, '.vert')
+    shader2 = FileShader(HLSL_VERTEX_SHADER, '.vert')
+    glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-c', shader1, shader2]
+    expected_assembly_substr = "OpEntryPoint Vertex %EntryPoint \"EntryPoint\""
+
+
+@inside_glslc_testsuite('OptionDashX')
+class TestDashXHlslDashFEntryOverridesItself(expect.ValidObjectFileWithAssemblySubstr):
+    """Tests -x hlsl on an HLSL shader with -fentry-point."""
+
+    shader = FileShader(HLSL_VERTEX_SHADER, '.vert')
+    glslc_args = ['-x', 'hlsl', '-fentry-point=foobar', '-fentry-point=EntryPoint',
+                  '-c', shader]
+    expected_assembly_substr = "OpEntryPoint Vertex %EntryPoint \"EntryPoint\""
 
 
 @inside_glslc_testsuite('OptionDashX')

--- a/glslc/test/option_dash_x.py
+++ b/glslc/test/option_dash_x.py
@@ -51,44 +51,6 @@ class TestDashXGlslOnHlslShader(expect.ErrorMessageSubstr):
 
 
 @inside_glslc_testsuite('OptionDashX')
-class TestDashXHlslOnHlslShaderWithSpecifiedEntryPointInAssembly(expect.ValidAssemblyFileWithSubstr):
-    """Tests -x hlsl on an HLSL shader with -fentry-point and -S."""
-
-    shader = FileShader(HLSL_VERTEX_SHADER, '.vert')
-    glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-S', '-c', shader]
-    expected_assembly_substr = "OpEntryPoint Vertex %EntryPoint \"EntryPoint\""
-
-
-@inside_glslc_testsuite('OptionDashX')
-class TestDashXHlslOnHlslShaderWithSpecifiedEntryPointInDisassembly(expect.ValidObjectFileWithAssemblySubstr):
-    """Tests -x hlsl on an HLSL shader with -fentry-point."""
-
-    shader = FileShader(HLSL_VERTEX_SHADER, '.vert')
-    glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-c', shader]
-    expected_assembly_substr = "OpEntryPoint Vertex %EntryPoint \"EntryPoint\""
-
-
-@inside_glslc_testsuite('OptionDashX')
-class TestDashXHlslDashFEntryPointAffectsAllLaterFiles(expect.ValidObjectFileWithAssemblySubstr):
-    """Tests -x hlsl on an HLSL shader with -fentry-point."""
-
-    shader1 = FileShader(HLSL_VERTEX_SHADER, '.vert')
-    shader2 = FileShader(HLSL_VERTEX_SHADER, '.vert')
-    glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-c', shader1, shader2]
-    expected_assembly_substr = "OpEntryPoint Vertex %EntryPoint \"EntryPoint\""
-
-
-@inside_glslc_testsuite('OptionDashX')
-class TestDashXHlslDashFEntryOverridesItself(expect.ValidObjectFileWithAssemblySubstr):
-    """Tests -x hlsl on an HLSL shader with -fentry-point."""
-
-    shader = FileShader(HLSL_VERTEX_SHADER, '.vert')
-    glslc_args = ['-x', 'hlsl', '-fentry-point=foobar', '-fentry-point=EntryPoint',
-                  '-c', shader]
-    expected_assembly_substr = "OpEntryPoint Vertex %EntryPoint \"EntryPoint\""
-
-
-@inside_glslc_testsuite('OptionDashX')
 class TestDashXHlslOnGlslShader(expect.ErrorMessageSubstr):
     """Tests -x hlsl on a GLSL shader."""
 

--- a/glslc/test/option_fentry_point.py
+++ b/glslc/test/option_fentry_point.py
@@ -1,0 +1,109 @@
+# Copyright 2015 The Shaderc Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import expect
+from glslc_test_framework import inside_glslc_testsuite
+from placeholder import FileShader
+
+MINIMAL_SHADER = "#version 140\nvoid main(){}"
+# This one is valid GLSL but not valid HLSL.
+GLSL_VERTEX_SHADER = "#version 140\nvoid main(){ gl_Position = vec4(1.0);}"
+# This one is valid HLSL but not valid GLSL.
+HLSL_VERTEX_SHADER = "float4 EntryPoint() : SV_POSITION { return float4(1.0); }"
+HLSL_VERTEX_SHADER_WITH_MAIN = "float4 main() : SV_POSITION { return float4(1.0); }"
+HLSL_VERTEX_SHADER_WITH_FOOBAR = "float4 Foobar() : SV_POSITION { return float4(1.0); }"
+
+# Expected assembly code within certain shaders.
+ASSEMBLY_ENTRY_POINT = "OpEntryPoint Vertex %EntryPoint \"EntryPoint\""
+ASSEMBLY_MAIN = "OpEntryPoint Vertex %main \"main\""
+ASSEMBLY_FOOBAR = "OpEntryPoint Vertex %Foobar \"Foobar\""
+
+
+@inside_glslc_testsuite('OptionFEntryPoint')
+class TestEntryPointDefaultsToMainForGlsl(expect.ValidAssemblyFileWithSubstr):
+    """Tests that entry point name defaults to "main" in a GLSL shader."""
+
+    shader = FileShader(GLSL_VERTEX_SHADER, '.vert')
+    glslc_args = ['-S', shader]
+    expected_assembly_substr = "OpEntryPoint Vertex %main \"main\""
+
+
+@inside_glslc_testsuite('OptionFEntryPoint')
+class TestEntryPointDefaultsToMainForHlsl(expect.ValidAssemblyFileWithSubstr):
+    """Tests that entry point name defaults to "main" in an HLSL shader."""
+
+    shader = FileShader(HLSL_VERTEX_SHADER_WITH_MAIN, '.vert')
+    glslc_args = ['-x', 'hlsl', '-S', shader]
+    expected_assembly_substr = "OpEntryPoint Vertex %main \"main\""
+
+
+@inside_glslc_testsuite('OptionFEntryPoint')
+class TestFEntryPointMainOnGlslShader(expect.ValidAssemblyFileWithSubstr):
+    """Tests -fentry-point=main with a GLSL shader."""
+
+    shader = FileShader(GLSL_VERTEX_SHADER, '.vert')
+    glslc_args = ['-fentry-point=main', '-S', shader]
+    expected_assembly_substr = "OpEntryPoint Vertex %main \"main\""
+
+
+@inside_glslc_testsuite('OptionFEntryPoint')
+class TestFEntryPointMainOnHlslShader(expect.ValidAssemblyFileWithSubstr):
+    """Tests -x hlsl on an HLSL shader with -fentry-point=main and -S."""
+
+    shader = FileShader(HLSL_VERTEX_SHADER, '.vert')
+    glslc_args = ['-x', 'hlsl', '-fentry-point=main', '-S', shader]
+    expected_assembly_substr = "OpEntryPoint Vertex %main \"main\""
+
+
+@inside_glslc_testsuite('OptionDashFEntryPoint')
+class TestFEntryPointSpecifiedOnHlslShaderInDisassembly(expect.ValidObjectFileWithAssemblySubstr):
+    """Tests -x hlsl on an HLSL shader with -fentry-point=EntryPoint."""
+
+    shader = FileShader(HLSL_VERTEX_SHADER, '.vert', assembly_substr=ASSEMBLY_ENTRY_POINT)
+    glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-c', shader]
+
+
+@inside_glslc_testsuite('OptionDashFEntryPoint')
+class TestFEntryPointAffectsSubsequentShaderFiles(expect.ValidObjectFileWithAssemblySubstr):
+    """Tests -x hlsl affects several subsequent shader source files."""
+
+    shader1 = FileShader(HLSL_VERTEX_SHADER, '.vert', assembly_substr=ASSEMBLY_ENTRY_POINT)
+    shader2 = FileShader(HLSL_VERTEX_SHADER, '.vert', assembly_substr=ASSEMBLY_ENTRY_POINT)
+    glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-c', shader1, shader2]
+
+
+@inside_glslc_testsuite('OptionDashFEntryPoint')
+class TestFEntryPointOverridesItself(expect.ValidObjectFileWithAssemblySubstr):
+    """Tests that a later -fentry-point option overrides an earlier use."""
+
+    shader = FileShader(HLSL_VERTEX_SHADER, '.vert', assembly_substr=ASSEMBLY_ENTRY_POINT)
+    glslc_args = ['-x', 'hlsl', '-fentry-point=foobar', '-fentry-point=EntryPoint',
+                  '-c', shader]
+
+
+@inside_glslc_testsuite('OptionDashFEntryPoint')
+class TestFEntryPointDefaultAndTwoOthers(expect.ValidObjectFileWithAssemblySubstr):
+    """Tests three shaders with different entry point names. The first uses "main"
+    with default entry point processing, and the remaining shaders get their
+    own -fentry-point argument."""
+
+    shaderMain = FileShader(HLSL_VERTEX_SHADER_WITH_MAIN, '.vert',
+                            assembly_substr=ASSEMBLY_MAIN)
+    shaderEntryPoint = FileShader(HLSL_VERTEX_SHADER, '.vert',
+                                  assembly_substr=ASSEMBLY_ENTRY_POINT)
+    shaderFoobar = FileShader(HLSL_VERTEX_SHADER_WITH_FOOBAR, '.vert',
+                              assembly_substr=ASSEMBLY_FOOBAR)
+    glslc_args = ['-x', 'hlsl', '-c', shaderMain,
+                  '-fentry-point=EntryPoint', shaderEntryPoint,
+                  '-fentry-point=Foobar', shaderFoobar]

--- a/glslc/test/option_fentry_point.py
+++ b/glslc/test/option_fentry_point.py
@@ -1,4 +1,4 @@
-# Copyright 2015 The Shaderc Authors. All rights reserved.
+# Copyright 2016 The Shaderc Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class TestEntryPointDefaultsToMainForGlsl(expect.ValidAssemblyFileWithSubstr):
 
     shader = FileShader(GLSL_VERTEX_SHADER, '.vert')
     glslc_args = ['-S', shader]
-    expected_assembly_substr = "OpEntryPoint Vertex %main \"main\""
+    expected_assembly_substr = ASSEMBLY_MAIN
 
 
 @inside_glslc_testsuite('OptionFEntryPoint')
@@ -45,7 +45,7 @@ class TestEntryPointDefaultsToMainForHlsl(expect.ValidAssemblyFileWithSubstr):
 
     shader = FileShader(HLSL_VERTEX_SHADER_WITH_MAIN, '.vert')
     glslc_args = ['-x', 'hlsl', '-S', shader]
-    expected_assembly_substr = "OpEntryPoint Vertex %main \"main\""
+    expected_assembly_substr = ASSEMBLY_MAIN
 
 
 @inside_glslc_testsuite('OptionFEntryPoint')
@@ -54,7 +54,7 @@ class TestFEntryPointMainOnGlslShader(expect.ValidAssemblyFileWithSubstr):
 
     shader = FileShader(GLSL_VERTEX_SHADER, '.vert')
     glslc_args = ['-fentry-point=main', '-S', shader]
-    expected_assembly_substr = "OpEntryPoint Vertex %main \"main\""
+    expected_assembly_substr = ASSEMBLY_MAIN
 
 
 @inside_glslc_testsuite('OptionFEntryPoint')
@@ -63,10 +63,10 @@ class TestFEntryPointMainOnHlslShader(expect.ValidAssemblyFileWithSubstr):
 
     shader = FileShader(HLSL_VERTEX_SHADER, '.vert')
     glslc_args = ['-x', 'hlsl', '-fentry-point=main', '-S', shader]
-    expected_assembly_substr = "OpEntryPoint Vertex %main \"main\""
+    expected_assembly_substr = ASSEMBLY_MAIN
 
 
-@inside_glslc_testsuite('OptionDashFEntryPoint')
+@inside_glslc_testsuite('OptionFEntryPoint')
 class TestFEntryPointSpecifiedOnHlslShaderInDisassembly(expect.ValidObjectFileWithAssemblySubstr):
     """Tests -x hlsl on an HLSL shader with -fentry-point=EntryPoint."""
 
@@ -74,7 +74,7 @@ class TestFEntryPointSpecifiedOnHlslShaderInDisassembly(expect.ValidObjectFileWi
     glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-c', shader]
 
 
-@inside_glslc_testsuite('OptionDashFEntryPoint')
+@inside_glslc_testsuite('OptionFEntryPoint')
 class TestFEntryPointAffectsSubsequentShaderFiles(expect.ValidObjectFileWithAssemblySubstr):
     """Tests -x hlsl affects several subsequent shader source files."""
 
@@ -83,7 +83,7 @@ class TestFEntryPointAffectsSubsequentShaderFiles(expect.ValidObjectFileWithAsse
     glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-c', shader1, shader2]
 
 
-@inside_glslc_testsuite('OptionDashFEntryPoint')
+@inside_glslc_testsuite('OptionFEntryPoint')
 class TestFEntryPointOverridesItself(expect.ValidObjectFileWithAssemblySubstr):
     """Tests that a later -fentry-point option overrides an earlier use."""
 
@@ -92,7 +92,7 @@ class TestFEntryPointOverridesItself(expect.ValidObjectFileWithAssemblySubstr):
                   '-c', shader]
 
 
-@inside_glslc_testsuite('OptionDashFEntryPoint')
+@inside_glslc_testsuite('OptionFEntryPoint')
 class TestFEntryPointDefaultAndTwoOthers(expect.ValidObjectFileWithAssemblySubstr):
     """Tests three shaders with different entry point names. The first uses "main"
     with default entry point processing, and the remaining shaders get their

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -61,6 +61,9 @@ Options:
                     Treat subsequent input files as having stage <stage>.
                     Valid stages are vertex, fragment, tesscontrol, tesseval,
                     geometry, and compute.
+  -fentry-point=<name>
+                    Specify the entry point name for HLSL compilation, for
+                    all subsequent source files.  Default is "main".
   -g                Generate source-level debug information.
                     Currently this option has no effect.
   --help            Display available options.

--- a/glslc/test/placeholder.py
+++ b/glslc/test/placeholder.py
@@ -59,12 +59,15 @@ class PlaceHolder(object):
 class FileShader(PlaceHolder):
     """Stands for a shader whose source code is in a file."""
 
-    def __init__(self, source, suffix):
+    def __init__(self, source, suffix, assembly_substr=None):
         assert isinstance(source, str)
         assert isinstance(suffix, str)
         self.source = source
         self.suffix = suffix
         self.filename = None
+        # If provided, this is a substring which is expected to be in
+        # the disassembly of the module generated from this input file.
+        self.assembly_substr = assembly_substr
 
     def instantiate_for_glslc_args(self, testcase):
         """Creates a temporary file and writes the source into it.


### PR DESCRIPTION
Add test mixin classes to check for substring in assembly
output.

Pass the path to the spirv-dis to the tests, and store
it in the test manager class.