### PR TITLE
Update tests for more strict glslango

### DIFF
--- a/glslc/test/option_dash_x.py
+++ b/glslc/test/option_dash_x.py
@@ -20,7 +20,8 @@ MINIMAL_SHADER = "#version 140\nvoid main(){}"
 # This one is valid GLSL but not valid HLSL.
 GLSL_VERTEX_SHADER = "#version 140\nvoid main(){ gl_Position = vec4(1.0);}"
 # This one is valid HLSL but not valid GLSL.
-HLSL_VERTEX_SHADER = "float4 EntryPoint() : SV_POSITION { return float4(1.0); }"
+# Use entry point "main" so we don't have to specify -fentry-point
+HLSL_VERTEX_SHADER = "float4 main() : SV_POSITION { return float4(1.0); }"
 
 @inside_glslc_testsuite('OptionDashX')
 class TestDashXNoArg(expect.ErrorMessage):

--- a/glslc/test/option_fentry_point.py
+++ b/glslc/test/option_fentry_point.py
@@ -58,17 +58,21 @@ class TestFEntryPointMainOnGlslShader(expect.ValidAssemblyFileWithSubstr):
 
 
 @inside_glslc_testsuite('OptionFEntryPoint')
-class TestFEntryPointMainOnHlslShader(expect.ValidAssemblyFileWithSubstr):
-    """Tests -x hlsl on an HLSL shader with -fentry-point=main and -S."""
+class TestFEntryPointMainOnHlslShaderNotMatchingSource(expect.ValidObjectFileWithWarning):
+    """Tests -x hlsl on an HLSL shader with -fentry-point=main
+    not matching the source."""
 
     shader = FileShader(HLSL_VERTEX_SHADER, '.vert')
-    glslc_args = ['-x', 'hlsl', '-fentry-point=main', '-S', shader]
-    expected_assembly_substr = ASSEMBLY_MAIN
+    glslc_args = ['-x', 'hlsl', '-fentry-point=main', '-c', shader]
+    expected_warning = [shader,
+                        ': warning: Linking vertex stage: Entry point not found\n'
+                        '1 warning generated.\n']
 
 
 @inside_glslc_testsuite('OptionFEntryPoint')
 class TestFEntryPointSpecifiedOnHlslShaderInDisassembly(expect.ValidObjectFileWithAssemblySubstr):
-    """Tests -x hlsl on an HLSL shader with -fentry-point=EntryPoint."""
+    """Tests -x hlsl on an HLSL shader with -fentry-point=EntryPoint
+    matching source."""
 
     shader = FileShader(HLSL_VERTEX_SHADER, '.vert', assembly_substr=ASSEMBLY_ENTRY_POINT)
     glslc_args = ['-x', 'hlsl', '-fentry-point=EntryPoint', '-c', shader]

--- a/glslc/test/option_shader_stage.py
+++ b/glslc/test/option_shader_stage.py
@@ -25,7 +25,8 @@ def simple_vertex_shader():
 
 
 def simple_hlsl_vertex_shader():
-    return """float4 EntryPoint() : SV_POSITION { return float4(1.0); } """
+    # Use "main" so we don't have to specify -fentry-point
+    return """float4 main() : SV_POSITION { return float4(1.0); } """
 
 
 def simple_fragment_shader():

--- a/glslc/test/option_std.py
+++ b/glslc/test/option_std.py
@@ -29,7 +29,8 @@ def core_frag_shader_without_version():
 
 
 def hlsl_compute_shader_with_barriers():
-    return 'void Entry() { AllMemoryBarrierWithGroupSync(); }'
+    # Use "main" to avoid the need for -fentry-point
+    return 'void main() { AllMemoryBarrierWithGroupSync(); }'
 
 
 @inside_glslc_testsuite('OptionStd')


### PR DESCRIPTION
Glslang now warns when an HLSL shader entry point can't
be found that either matches the default of "main" or
one specified via -fentry-point.