### PR TITLE
Set the tool to Google Shaderc over Glslang

### DIFF
--- a/glslc/test/assembly.py
+++ b/glslc/test/assembly.py
@@ -21,7 +21,7 @@ def assembly_comments():
     return """
     ; SPIR-V
     ; Version: 1.0
-    ; Generator: Khronos Glslang Reference Front End; 1
+    ; Generator: Google Shaderc over Glslang; 1
     ; Bound: 6
     ; Schema: 0"""
 

--- a/glslc/test/expect.py
+++ b/glslc/test/expect.py
@@ -165,8 +165,9 @@ class CorrectObjectFilePreamble(GlslCTest):
             # SPIR-V version number
             if read_word(preamble, 1, little_endian) != 0x00010000:
                 return False, 'Incorrect SPV binary: wrong version number'
-            # glslang (0x0008....) or SPIRV-Tools (0x0007....) generator number
-            if read_word(preamble, 2, little_endian) != 0x00080001 and \
+            # Shaderc-over-Glslang (0x000d....) or
+            # SPIRV-Tools (0x0007....) generator number
+            if read_word(preamble, 2, little_endian) != 0x000d0001 and \
                     read_word(preamble, 2, little_endian) != 0x00070000:
                 return False, ('Incorrect SPV binary: wrong generator magic '
                                'number')
@@ -192,7 +193,7 @@ class CorrectAssemblyFilePreamble(GlslCTest):
 
         if (line1 != '; SPIR-V\n' or
             line2 != '; Version: 1.0\n' or
-            line3 != '; Generator: Khronos Glslang Reference Front End; 1\n'):
+            line3 != '; Generator: Google Shaderc over Glslang; 1\n'):
             return False, 'Incorrect SPV assembly'
 
         return True, ''

--- a/glslc/test/option_dash_cap_O.py
+++ b/glslc/test/option_dash_cap_O.py
@@ -23,7 +23,7 @@ EMPTY_SHADER_IN_CWD = Directory('.', [File('shader.vert', MINIMAL_SHADER)])
 ASSEMBLY_WITH_DEBUG = [
     '; SPIR-V\n',
     '; Version: 1.0\n',
-    '; Generator: Khronos Glslang Reference Front End; 1\n',
+    '; Generator: Google Shaderc over Glslang; 1\n',
     '; Bound: 6\n',
     '; Schema: 0\n',
     '               OpCapability Shader\n',
@@ -44,7 +44,7 @@ ASSEMBLY_WITH_DEBUG = [
 ASSEMBLY_WITHOUT_DEBUG = [
     '; SPIR-V\n',
     '; Version: 1.0\n',
-    '; Generator: Khronos Glslang Reference Front End; 1\n',
+    '; Generator: Google Shaderc over Glslang; 1\n',
     '; Bound: 6\n',
     '; Schema: 0\n',
     '               OpCapability Shader\n',

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -189,7 +189,7 @@ const char kVertexOnlyShaderWithInvalidPragma[] =
 const char* kMinimalShaderDisassemblySubstrings[] = {
     "; SPIR-V\n"
     "; Version: 1.0\n"
-    "; Generator: Khronos Glslang Reference Front End; 1\n"
+    "; Generator: Google Shaderc over Glslang; 1\n"
     "; Bound:",
 
     "               OpCapability Shader\n",
@@ -201,7 +201,7 @@ const char* kMinimalShaderDisassemblySubstrings[] = {
 const char kMinimalShaderAssembly[] = R"(
     ; SPIR-V
     ; Version: 1.0
-    ; Generator: Khronos Glslang Reference Front End; 1
+    ; Generator: Google Shaderc over Glslang; 1
     ; Bound: 6
     ; Schema: 0
 

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -230,6 +230,14 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   // Note the call to GlslangToSpv also populates compilation_output_data.
   glslang::GlslangToSpv(*program.getIntermediate(used_shader_stage), spirv);
 
+  // Set the tool field (the top 16-bits) in the generator word to
+  // 'Shaderc over Glslang'.
+  const uint32_t shaderc_generator_word = 13; // From SPIR-V XML Registry
+  const uint32_t generator_word_index = 2; // SPIR-V 2.3: Physical layout
+  assert(spirv.size() > generator_word_index);
+  spirv[generator_word_index] =
+      (spirv[generator_word_index] & 0xffff) | (shaderc_generator_word << 16);
+
   if (!enabled_opt_passes_.empty()) {
     std::string opt_errors;
     if (!SpirvToolsOptimize(target_env_, enabled_opt_passes_, &spirv,


### PR DESCRIPTION
It's the top 16 bits of the generator word.

Test output expects a relatively recent versions of:
- SPIRV-Tools: parses tools identities from the SPIR-V XML Registry file
- SPIRV-Headers: defines the "Google over Shaderc" generator as tool #13