### PR TITLE
Adapt to Glslang include message changes

### DIFF
--- a/glslc/test/include.py
+++ b/glslc/test/include.py
@@ -49,7 +49,7 @@ class VerifyIncludeNotFound(expect.ErrorMessage):
 
     glslc_args = ['-E', 'a.vert']
     expected_error = [
-        "a.vert:3: error: '#include' : Cannot find or open include file.\n",
+        "a.vert:3: error: '#include' : Cannot find or open include file. for header name: b\n",
         '1 error generated.\n'
     ]
 
@@ -64,7 +64,7 @@ class VerifyCompileIncludeOneSibling(expect.ValidObjectFile):
     glslc_args = ['a.vert']
 
 @inside_glslc_testsuite('Include')
-class VerifyIncludeWithoutNewline(expect.StdoutMatch):
+class VerifyIncludeWithoutNewline(expect.ErrorMessageSubstr):
     """Tests a #include without a newline."""
 
     environment = Directory('.', [
@@ -73,16 +73,8 @@ class VerifyIncludeWithoutNewline(expect.StdoutMatch):
 
     glslc_args = ['-E', 'a.vert']
 
-    expected_stdout = \
-"""#version 140
-#extension GL_GOOGLE_include_directive : enable
-#line 0 "a.vert"
+    expected_error_substr = 'expected newline after header name: b'
 
-#line 0 "b"
-content b
-#line 2 "a.vert"
-
-"""
 
 @inside_glslc_testsuite('Include')
 class VerifyCompileIncludeWithoutNewline(expect.ValidObjectFile):
@@ -506,7 +498,8 @@ class VerifyRelativeOnlyToSelf(expect.ErrorMessage):
     glslc_args = ['-E', 'a.vert']
 
     expected_error = [
-        "foo/b.glsl:1: error: '#include' : Cannot find or open include file.\n",
+        "foo/b.glsl:1: error: '#include' : "
+        'Cannot find or open include file. for header name: c.glsl\n',
         '1 error generated.\n'
     ]
 

--- a/glslc/test/line.py
+++ b/glslc/test/line.py
@@ -243,7 +243,8 @@ class TestErrorsFromMultipleFiles(expect.ErrorMessage):
     including_file = '''#version 310 es
 #include "error.glsl"
 int no_return() {}
-#include "main.glsl"'''
+#include "main.glsl"
+'''
 
     environment = Directory('.', [
         File('a.vert', including_file),
@@ -272,7 +273,8 @@ int plus1(int a) { return a + 1; }
 #include "inc.glsl"
 int plus2(int a) { return a + 2; }
 #line 55555
-#include "main.glsl"'''
+#include "main.glsl"
+'''
 
     environment = Directory('.', [
         File('a.vert', including_file),

--- a/glslc/test/option_dash_M.py
+++ b/glslc/test/option_dash_M.py
@@ -309,7 +309,7 @@ class TestDashCapMSingleInputAbsolutePathWithIncludeSubdir(
     environment = Directory('.', [
         Directory('include', [File('b.vert', 'void foo(){}\n')]),
     ])
-    shader_main = FileShader('#version 140\n#include "include/b.vert"',
+    shader_main = FileShader('#version 140\n#include "include/b.vert"\n',
                              '.vert')
     glslc_args = ['-M', shader_main]
     dependency_rules_expected = [{


### PR DESCRIPTION
Also the #include directive now requires a newline at the end.
That is a requirement from C++.

This is required so we can refresh google/shaderc from upstream