### PR TITLE
Adapt to Glslang Includer interface changes.

### DIFF
--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -162,18 +162,18 @@ class InternalFileIncluder : public shaderc_util::CountingIncluder {
     return resolver_ != nullptr && result_releaser_ != nullptr;
   }
 
-  // Maps a shaderc_include_type to the correpsonding Glslang include type.
-  shaderc_include_type GetIncludeType(
-      glslang::TShader::Includer::IncludeType type) {
+  // Maps CountingIncluder IncludeType value to a shaderc_include_type
+  // value.
+  shaderc_include_type GetIncludeType(IncludeType type) {
     switch (type) {
-      case glslang::TShader::Includer::EIncludeRelative:
+      case IncludeType::Local:
         return shaderc_include_type_relative;
-      case glslang::TShader::Includer::EIncludeStandard:
+      case IncludeType::System:
         return shaderc_include_type_standard;
       default:
         break;
     }
-    assert(0 && "Unhandled shaderc_include_type");
+    assert(0 && "Unhandled IncludeType");
     return shaderc_include_type_relative;
   }
 
@@ -185,9 +185,8 @@ class InternalFileIncluder : public shaderc_util::CountingIncluder {
   // resolved name member is an empty string, and the contents members
   // contains error details.
   virtual glslang::TShader::Includer::IncludeResult* include_delegate(
-      const char* requested_source,
-      glslang::TShader::Includer::IncludeType type,
-      const char* requesting_source, size_t include_depth) override {
+      const char* requested_source, const char* requesting_source,
+      IncludeType type, size_t include_depth) override {
     if (!AreValidCallbacks()) {
       const char kUnexpectedIncludeError[] =
           "#error unexpected include directive";
@@ -213,7 +212,7 @@ class InternalFileIncluder : public shaderc_util::CountingIncluder {
       glslang::TShader::Includer::IncludeResult* result) override {
     if (result && result_releaser_) {
       result_releaser_(user_data_,
-                       static_cast<shaderc_include_result*>(result->user_data));
+                       static_cast<shaderc_include_result*>(result->userData));
     }
     delete result;
   }

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -90,8 +90,7 @@ class DummyCountingIncluder : public shaderc_util::CountingIncluder {
  private:
   // Returns a pair of empty strings.
   virtual glslang::TShader::Includer::IncludeResult* include_delegate(
-      const char*, glslang::TShader::Includer::IncludeType, const char*,
-      size_t) override {
+      const char*, const char*, IncludeType, size_t) override {
     return nullptr;
   }
   virtual void release_delegate(

--- a/libshaderc_util/src/counting_includer_test.cc
+++ b/libshaderc_util/src/counting_includer_test.cc
@@ -19,16 +19,12 @@
 
 namespace {
 
-const auto kRelative = glslang::TShader::Includer::EIncludeRelative;
-const auto kStandard = glslang::TShader::Includer::EIncludeStandard;
-
 // A trivial implementation of CountingIncluder's virtual methods, so tests can
 // instantiate.
 class ConcreteCountingIncluder : public shaderc_util::CountingIncluder {
  public:
   virtual glslang::TShader::Includer::IncludeResult* include_delegate(
-      const char* requested, glslang::TShader::Includer::IncludeType,
-      const char* requestor,
+      const char* requested, const char* requestor, IncludeType,
       size_t) override {
     const char kError[] = "Unexpected #include";
     return new glslang::TShader::Includer::IncludeResult{
@@ -44,36 +40,37 @@ TEST(CountingIncluderTest, InitialCount) {
   EXPECT_EQ(0, ConcreteCountingIncluder().num_include_directives());
 }
 
-TEST(CountingIncluderTest, OneInclude) {
+TEST(CountingIncluderTest, OneIncludeLocal) {
   ConcreteCountingIncluder includer;
-  includer.include("random file name", kRelative, "from me", 0);
+  includer.includeLocal("random file name", "from me", 0);
   EXPECT_EQ(1, includer.num_include_directives());
 }
 
 TEST(CountingIncluderTest, TwoIncludesAnyIncludeType) {
   ConcreteCountingIncluder includer;
-  includer.include("name1", kRelative, "from me", 0);
-  includer.include("name2", kStandard, "me", 0);
+  includer.includeSystem("name1", "from me", 0);
+  includer.includeLocal("name2", "me", 0);
   EXPECT_EQ(2, includer.num_include_directives());
 }
 
 TEST(CountingIncluderTest, ManyIncludes) {
   ConcreteCountingIncluder includer;
   for (int i = 0; i < 100; ++i) {
-    includer.include("filename", kRelative, "from me", i);
+    includer.includeLocal("filename", "from me", i);
+    includer.includeSystem("filename", "from me", i);
   }
-  EXPECT_EQ(100, includer.num_include_directives());
+  EXPECT_EQ(200, includer.num_include_directives());
 }
 
 #ifndef SHADERC_DISABLE_THREADED_TESTS
 TEST(CountingIncluderTest, ThreadedIncludes) {
   ConcreteCountingIncluder includer;
   std::thread t1(
-      [&includer]() { includer.include("name1", kRelative, "me", 0); });
+      [&includer]() { includer.includeLocal("name1", "me", 0); });
   std::thread t2(
-      [&includer]() { includer.include("name2", kRelative, "me", 1); });
+      [&includer]() { includer.includeSystem("name2", "me", 1); });
   std::thread t3(
-      [&includer]() { includer.include("name3", kRelative, "me", 2); });
+      [&includer]() { includer.includeLocal("name3", "me", 2); });
   t1.join();
   t2.join();
   t3.join();


### PR DESCRIPTION
See Glslang test https://github.com/KhronosGroup/glslang/pull/663

All Shaderc tests pass with this change and the Glslang change.