### PR TITLE
Updated CMake configuration for Android Studio.

### DIFF
--- a/cmake/setup_build.cmake
+++ b/cmake/setup_build.cmake
@@ -1,5 +1,17 @@
 # Find nosetests; see shaderc_add_nosetests() from utils.cmake for opting in to
 # nosetests in a specific directory.
+
+if(NOT COMMAND find_host_package)
+  macro(find_host_package)
+    find_package(${ARGN})
+  endmacro()
+endif()
+if(NOT COMMAND find_host_program)
+  macro(find_host_program)
+    find_program(${ARGN})
+  endmacro()
+endif()
+
 find_program(NOSETESTS_EXE NAMES nosetests PATHS $ENV{PYTHON_PACKAGE_PATH})
 if (NOT NOSETESTS_EXE)
   message(STATUS "nosetests was not found - python code will not be tested")


### PR DESCRIPTION
Small change to fix how we are configured if included by Android Studio.
The main difference between Android Studio CMake, and
android-cmake, at least as far as this is concerned is that Android
Studio does not define find_host*. In this case we can just use
find_package and find_program, so set up the macros in that way.