### PR TITLE
Update Travis CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ compiler:
 matrix:
   fast_finish: true # Show final status immediately if a test fails.
   exclude:
-    # Skip GCC builds on Mac OS X.
+    # Skip GCC builds on macOS.
     - os: osx
       compiler: gcc
   include:
@@ -48,8 +48,8 @@ addons:
       - lcov
 
 before_install:
-  # Install ninja on Mac OS X.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install ninja; fi
+  # Install ninja on macOS.
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja; fi
   - if [[ "$BUILD_NDK" == "ON" ]]; then
       git clone --depth=1 https://github.com/urho3d/android-ndk.git $HOME/android-ndk;
       export ANDROID_NDK=$HOME/android-ndk;
@@ -68,10 +68,10 @@ install:
     fi
 
 before_script:
-  - git clone https://github.com/google/googletest.git          third_party/googletest
-  - git clone https://github.com/google/glslang.git             third_party/glslang
-  - git clone https://github.com/KhronosGroup/SPIRV-Tools.git   third_party/spirv-tools
-  - git clone https://github.com/KhronosGroup/SPIRV-Headers.git third_party/spirv-tools/external/spirv-headers
+  - git clone --depth=1 https://github.com/google/googletest          third_party/googletest
+  - git clone --depth=1 https://github.com/google/glslang             third_party/glslang
+  - git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Tools   third_party/spirv-tools
+  - git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Headers third_party/spirv-tools/external/spirv-headers
 
 script:
   - mkdir build && cd build
@@ -88,7 +88,12 @@ script:
             -GNinja ..;
     fi
   - ninja
-  - if [[ "$BUILD_NDK" != "ON" ]]; then ctest -j`nproc` --output_on_failure; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      export NPROC=`nproc`;
+    else
+      export NPROC=`sysctl -n hw.ncpu`;
+    fi
+  - if [[ "$BUILD_NDK" != "ON" ]]; then ctest -j${NPROC} --output_on_failure; fi
 
 after_success:
   # Collect coverage and push to coveralls.info.


### PR DESCRIPTION
* We do not require sudo privilege.
* No need for brew update.
* Mac OS X is renamed to macOS.
* Reduce the clone depth of third party projects to speed up.
* `nproc`'s counterpart on macOS is `sysctl -n hw.ncpu`.