### PR TITLE
Add Bindings section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,7 @@ directory.
 [khr-glslang]: https://github.com/KhronosGroup/glslang
 [google-glslang]: https://github.com/google/glslang
 [spirv-tools]: https://github.com/KhronosGroup/SPIRV-Tools
+
+## Bindings
+
+**Python:** [pyshaderc](https://github.com/realitix/pyshaderc)


### PR DESCRIPTION
It's a good idea to reference shaderc binding in this Readme.
What do you think about that ?