### PR TITLE
Add pervasive dependency to extension_enum.inc

### DIFF
--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -112,6 +112,61 @@ LOCAL_PATH := $(SPVTOOLS_LOCAL_PATH)
 SPVTOOLS_OUT_PATH=$(if $(call host-path-is-absolute,$(TARGET_OUT)),$(TARGET_OUT),$(abspath $(TARGET_OUT)))
 SPVHEADERS_LOCAL_PATH := $(THIRD_PARTY_PATH)/spirv-tools/external/spirv-headers
 
+SPVTOOLS_SRC_FILES := \
+		source/assembly_grammar.cpp \
+		source/binary.cpp \
+		source/diagnostic.cpp \
+		source/disassemble.cpp \
+		source/ext_inst.cpp \
+		source/enum_string_mapping.cpp \
+		source/extensions.cpp \
+		source/libspirv.cpp \
+		source/name_mapper.cpp \
+		source/opcode.cpp \
+		source/operand.cpp \
+		source/parsed_operand.cpp \
+		source/print.cpp \
+		source/software_version.cpp \
+		source/spirv_endian.cpp \
+		source/spirv_target_env.cpp \
+		source/spirv_validator_options.cpp \
+		source/table.cpp \
+		source/text.cpp \
+		source/text_handler.cpp \
+		source/util/parse_number.cpp \
+		source/util/string_utils.cpp \
+		source/val/basic_block.cpp \
+		source/val/construct.cpp \
+		source/val/function.cpp \
+		source/val/instruction.cpp \
+		source/val/validation_state.cpp \
+		source/validate.cpp \
+		source/validate_cfg.cpp \
+		source/validate_capability.cpp \
+		source/validate_datarules.cpp \
+		source/validate_decorations.cpp \
+		source/validate_id.cpp \
+		source/validate_instruction.cpp \
+		source/validate_layout.cpp \
+		source/validate_type_unique.cpp
+
+SPVTOOLS_OPT_SRC_FILES := \
+		source/opt/build_module.cpp \
+		source/opt/def_use_manager.cpp \
+		source/opt/eliminate_dead_constant_pass.cpp \
+		source/opt/fold_spec_constant_op_and_composite_pass.cpp \
+		source/opt/freeze_spec_constant_value_pass.cpp \
+		source/opt/function.cpp \
+		source/opt/instruction.cpp \
+		source/opt/ir_loader.cpp \
+		source/opt/module.cpp \
+		source/opt/optimizer.cpp \
+		source/opt/pass_manager.cpp \
+		source/opt/set_spec_constant_default_value_pass.cpp \
+		source/opt/strip_debug_info_pass.cpp \
+		source/opt/type_manager.cpp \
+		source/opt/types.cpp \
+		source/opt/unify_const_pass.cpp
 # Locations of grammar files.
 SPV_CORE10_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.0/spirv.core.grammar.json
 SPV_CORE11_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.1/spirv.core.grammar.json
@@ -157,8 +212,11 @@ $(1)/extension_enum.inc $(1)/enum_string_mapping.inc: \
 		                --spirv-core-grammar=$(SPV_CORE11_GRAMMAR) \
 		                --extension-enum-output=$(1)/extension_enum.inc \
 		                --enum-string-mapping-output=$(1)/enum_string_mapping.inc
-		@echo "[$(TARGET_ARCH_ABI)] Enum<->string mapping <= grammar JSON files"
-$(SPVTOOLS_LOCAL_PATH)/source/extension.h: $(1)/extension_enum.inc
+		@echo "[$(TARGET_ARCH_ABI)] Generate enum<->string mapping <= grammar JSON files"
+# Generated header extension_enum.inc is transitively included by table.h, which is
+# used pervasively.  Capture the pervasive dependency.
+$(foreach F,$(SPVTOOLS_SRC_FILES) $(SPVTOOLS_OPT_SRC_FILES),$(SPVTOOLS_LOCAL_PATH)/$F ) \
+  : $(1)/extension_enum.inc
 $(SPVTOOLS_LOCAL_PATH)/source/enum_string_mapping.cpp: $(1)/enum_string_mapping.inc
 endef
 $(eval $(call gen_spvtools_enum_string_mapping,$(SPVTOOLS_OUT_PATH)))
@@ -198,44 +256,7 @@ LOCAL_C_INCLUDES := \
 LOCAL_EXPORT_C_INCLUDES := \
 		$(SPVTOOLS_LOCAL_PATH)/include
 LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti -Werror
-LOCAL_SRC_FILES:= \
-		source/assembly_grammar.cpp \
-		source/binary.cpp \
-		source/diagnostic.cpp \
-		source/disassemble.cpp \
-		source/ext_inst.cpp \
-		source/enum_string_mapping.cpp \
-		source/extensions.cpp \
-		source/extensions.h \
-		source/libspirv.cpp \
-		source/name_mapper.cpp \
-		source/opcode.cpp \
-		source/operand.cpp \
-		source/parsed_operand.cpp \
-		source/print.cpp \
-		source/software_version.cpp \
-		source/spirv_endian.cpp \
-		source/spirv_target_env.cpp \
-		source/spirv_validator_options.cpp \
-		source/table.cpp \
-		source/text.cpp \
-		source/text_handler.cpp \
-		source/util/parse_number.cpp \
-		source/util/string_utils.cpp \
-		source/val/basic_block.cpp \
-		source/val/construct.cpp \
-		source/val/function.cpp \
-		source/val/instruction.cpp \
-		source/val/validation_state.cpp \
-		source/validate.cpp \
-		source/validate_cfg.cpp \
-		source/validate_capability.cpp \
-		source/validate_datarules.cpp \
-		source/validate_decorations.cpp \
-		source/validate_id.cpp \
-		source/validate_instruction.cpp \
-		source/validate_layout.cpp \
-		source/validate_type_unique.cpp
+LOCAL_SRC_FILES:= $(SPVTOOLS_SRC_FILES)
 include $(BUILD_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
@@ -247,21 +268,5 @@ LOCAL_C_INCLUDES := \
 		$(SPVTOOLS_OUT_PATH)
 LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti -Werror
 LOCAL_STATIC_LIBRARIES:=SPIRV-Tools
-LOCAL_SRC_FILES:= \
-		source/opt/build_module.cpp \
-		source/opt/def_use_manager.cpp \
-		source/opt/eliminate_dead_constant_pass.cpp \
-		source/opt/fold_spec_constant_op_and_composite_pass.cpp \
-		source/opt/freeze_spec_constant_value_pass.cpp \
-		source/opt/function.cpp \
-		source/opt/instruction.cpp \
-		source/opt/ir_loader.cpp \
-		source/opt/module.cpp \
-		source/opt/optimizer.cpp \
-		source/opt/pass_manager.cpp \
-		source/opt/set_spec_constant_default_value_pass.cpp \
-		source/opt/strip_debug_info_pass.cpp \
-		source/opt/type_manager.cpp \
-		source/opt/types.cpp \
-		source/opt/unify_const_pass.cpp
+LOCAL_SRC_FILES:= $(SPVTOOLS_OPT_SRC_FILES)
 include $(BUILD_STATIC_LIBRARY)


### PR DESCRIPTION
Before the first build, the Android.mk build system can't see
for itself the transitive dependency via
table.h -> extensions.h -> extension_enum.inc.
Since table.h is so fundamental, make all (non-test) .cpp files
depend on extension_enum.inc.