### PR TITLE
Don't suppress stderr of subprocesses

### DIFF
--- a/update_shaderc_sources.py
+++ b/update_shaderc_sources.py
@@ -45,8 +45,7 @@ def command_output(cmd, directory):
         print('In {d}: {cmd}'.format(d=directory, cmd=cmd))
     p = subprocess.Popen(cmd,
                          cwd=directory,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
+                         stdout=subprocess.PIPE)
     (stdout, _) = p.communicate()
     if p.returncode != 0:
         raise RuntimeError('Failed to run {} in {}'.format(cmd, directory))


### PR DESCRIPTION
When a subprocess failed in update_shaderc_sources.py, it was impossible
to know the failure's reason without hacking the script, because the
script suppressed the stderr of all subprocesses.

For example, when `git fetch` failed on the shaderc repo, the script
printed only this error message:

    Failed to run ['git', 'fetch', 'known-good'] in .

Is there no network connection? Did ssh authentication fail? Is the
repository corrupt? Who knows what happened?!?!?! Answer: stderr knows
what happened.