### PR TITLE
Support repos where .git is a file, not a dir

### DIFF
--- a/update_shaderc_sources.py
+++ b/update_shaderc_sources.py
@@ -90,7 +90,7 @@ class GoodCommit(object):
         command_output(['git', 'fetch', 'known-good'], self.subdir)
 
     def Checkout(self):
-        if not os.path.isdir(os.path.join(self.subdir,'.git')):
+        if not os.path.exists(os.path.join(self.subdir,'.git')):
             self.Clone()
         self.Fetch()
         command_output(['git', 'checkout', self.commit], self.subdir)


### PR DESCRIPTION
In repos created with the git-worktree and git-submodule
commands, '.git' is a text file that points to the real git directory.

update_shaderc_sources.py fails on such repos. The fix is an easy
one-liner.