### PR TITLE
glsl: Don't write dependency info when compilation output is stdout

### DIFF
--- a/glslc/src/file_compiler.cc
+++ b/glslc/src/file_compiler.cc
@@ -321,6 +321,15 @@ bool FileCompiler::ValidateOptions(size_t num_files) {
                 << std::endl;
       return false;
     }
+
+    if (output_file_name_ == "-") {
+        std::cerr << "glslc: error: options -M* and '-o -' are incompatible"
+                  << std::endl;
+        std::cerr << "glslc: error: cannot generate dependency info when"
+                     " compilation is written stdout"
+                  << std::endl;
+        return false;
+    }
   }
 
   // If the output format is specified to be a binary, a list of hex numbers or


### PR DESCRIPTION
If glslc is given option '-o -' and one of the -M* dependency
options, then it wrote an incorrect dependency file. For example:

    $ glslc -MD -S -o - a.glsl | sed ...
    $ ls
    -.d a.glsl
    $ cat ./-.d
    -: a.glsl

It doesn't make sense to write a dependency file when the compilation
output is stdout. So catch the error while validating command line
flags, emit a helpful error message, and fail.

Fixes: https://github.com/google/shaderc/issues/327