### PR TITLE
Update tests for Glslang message changes

### DIFF
--- a/glslc/test/line.py
+++ b/glslc/test/line.py
@@ -257,8 +257,8 @@ int no_return() {}
         "error.glsl:1: error: 'return' : type does not match, or is not "
         "convertible to, the function's return type\n",
         "a.vert:3: error: '' : function does not return a value: no_return\n",
-        "main.glsl:2: error: '=' :  cannot convert from 'const float' to "
-        "'temp highp int'\n",
+        "main.glsl:2: error: '=' :  cannot convert from ' const float' to "
+        "' temp highp int'\n",
         "4 errors generated.\n"]
 
 

--- a/glslc/test/option_target_env.py
+++ b/glslc/test/option_target_env.py
@@ -50,8 +50,8 @@ class TestTargetEnvEqOpenglWithOpenGlCompatShader(expect.ErrorMessageSubstr):
     shader = FileShader(opengl_compat_fragment_shader(), '.frag')
     glslc_args = ['--target-env=opengl', shader]
     expected_error_substr = [shader, ":4: error: 'assign' :  ",
-                             "cannot convert from 'const float' to ",
-                             "'fragColor"]
+                             "cannot convert from ' const float' to ",
+                             "' fragColor"]
 
 
 @inside_glslc_testsuite('OptionTargetEnv')


### PR DESCRIPTION
An extra space now appears at the front of the type listed
in an invalid conversion error message.