### PR TITLE
React to Glslang and SPIRV-Tools changes

### DIFF
--- a/glslc/test/include.py
+++ b/glslc/test/include.py
@@ -274,10 +274,11 @@ class TestWrongPoundVersionInIncludingFile(expect.ValidObjectFileWithWarning):
     environment = Directory('.', [
         File('a.vert', '#version 100000000\n#include "b.glsl"\n'),
         File('b.glsl', 'void main() {}\n')])
-    glslc_args = ['-c', 'a.vert']
+    glslc_args = ['-c', '-std=400', 'a.vert']
 
     expected_warning = [
-        'a.vert: warning: version 100000000 is unknown.\n',
+        'a.vert: warning: (version, profile) forced to be (400, none),'
+        ' while in source code it is (100000000, none)\n'
         '1 warning generated.\n'
     ]
 

--- a/glslc/test/messages_tests.py
+++ b/glslc/test/messages_tests.py
@@ -84,10 +84,11 @@ class GlobalWarning(expect.WarningMessage):
     void main() {
     }
     """, '.vert')
-    glslc_args = ['-c', shader]
+    glslc_args = ['-c', '-std=400', shader]
 
     expected_warning = [
-        shader, ': warning: version 550 is unknown.\n1 warning generated.\n']
+            shader, ': warning: (version, profile) forced to be (400, none),'
+            ' while in source code it is (550, none)\n1 warning generated.\n']
 
 @inside_glslc_testsuite('ErrorMessages')
 class SuppressedGlobalWarning(expect.SuccessfulReturn):
@@ -99,7 +100,7 @@ class SuppressedGlobalWarning(expect.SuccessfulReturn):
     void main() {
     }
     """, '.vert')
-    glslc_args = ['-c', shader, '-w']
+    glslc_args = ['-c', '-std=400', shader, '-w']
 
 
 @inside_glslc_testsuite('ErrorMessages')
@@ -112,10 +113,11 @@ class GlobalWarningAsError(expect.ErrorMessage):
     void main() {
     }
     """, '.vert')
-    glslc_args = ['-c', shader, '-Werror']
+    glslc_args = ['-c', '-std=400', shader, '-Werror']
 
     expected_error= [
-        shader, ': error: version 550 is unknown.\n1 error generated.\n']
+            shader, ': error: (version, profile) forced to be (400, none),'
+            ' while in source code it is (550, none)\n1 error generated.\n']
 
 @inside_glslc_testsuite('ErrorMessages')
 class WarningOnLine(expect.WarningMessage):
@@ -255,13 +257,15 @@ class WarningAsErrorMultipleFiles(expect.ErrorMessage):
     }
     """, '.vert')
 
-    glslc_args = ['-c', shader, '-Werror', shader2]
+    glslc_args = ['-c', '-std=400', shader, '-Werror', shader2]
 
     expected_error = [
         shader, ':2: error: attribute deprecated in version 130; ',
         'may be removed in future release\n',
-        shader2, ': error: version 550 is unknown.\n',
+        shader2, ': error: (version, profile) forced to be (400, none),'
+            ' while in source code it is (550, none)\n',
         '2 errors generated.\n']
+
 
 @inside_glslc_testsuite('ErrorMessages')
 class SuppressedWarningAsError(expect.SuccessfulReturn):

--- a/glslc/test/messages_tests.py
+++ b/glslc/test/messages_tests.py
@@ -122,8 +122,8 @@ class WarningOnLine(expect.WarningMessage):
     """Tests that a warning message with a file/line number is emitted."""
 
     shader = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     void main() {
     }
     """, '.vert')
@@ -139,8 +139,8 @@ class SuppressedWarningOnLine(expect.SuccessfulReturn):
     presence of -w."""
 
     shader = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     void main() {
     }
     """, '.vert')
@@ -152,8 +152,8 @@ class WarningOnLineAsError(expect.ErrorMessage):
     number is emitted instead of a warning."""
 
     shader = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     void main() {
     }
     """, '.vert')
@@ -168,8 +168,8 @@ class WarningAndError(expect.ErrorMessage):
     """Tests that both warnings and errors are emitted together."""
 
     shader = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     int main() {
     }
     """, '.vert')
@@ -187,8 +187,8 @@ class SuppressedWarningAndError(expect.ErrorMessage):
     """Tests that only warnings are suppressed in the presence of -w."""
 
     shader = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     int main() {
     }
     """, '.vert')
@@ -204,8 +204,8 @@ class WarningAsErrorAndError(expect.ErrorMessage):
     """Tests that with -Werror an warnings and errors are emitted as errors."""
 
     shader = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     int main() {
     }
     """, '.vert')
@@ -243,8 +243,8 @@ class WarningAsErrorMultipleFiles(expect.ErrorMessage):
     """
 
     shader = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     void main() {
     }
     """, '.vert')
@@ -268,8 +268,8 @@ class SuppressedWarningAsError(expect.SuccessfulReturn):
     """Tests that nothing is returned in the presence of -w -Werror."""
 
     shader = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     void main() {
     }
     """, '.vert')
@@ -280,8 +280,8 @@ class MultipleSuppressed(expect.SuccessfulReturn):
     """Tests that multiple -w arguments are supported."""
 
     shader = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     void main() {
     }
     """, '.vert')
@@ -292,15 +292,15 @@ class MultipleSuppressedFiles(expect.SuccessfulReturn):
     """Tests that -w suppresses warnings from all files."""
 
     shader = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     void main() {
     }
     """, '.vert')
 
     shader2 = FileShader(
-        """#version 140
-    attribute float x;
+        """#version 400
+    layout(location = 0) attribute float x;
     void main() {
     }
     """, '.vert')

--- a/glslc/test/option_dash_M.py
+++ b/glslc/test/option_dash_M.py
@@ -381,7 +381,9 @@ class TestDashCapMImpliesDashW(DependencyInfoStdoutMatch,
          <no warning message should be generated>
     """
     environment = Directory('.', [File(
-        'shader.vert', '#version 140\nattribute float x;\nvoid main() {}')])
+            'shader.vert', """#version 400
+               layout(location=0) attribute float x;
+               void main() {}""")])
     glslc_args = ['-M', 'shader.vert']
     dependency_rules_expected = [{'target': 'shader.vert.spv',
                                   'dependency': {'shader.vert'}}]
@@ -412,7 +414,10 @@ class TestDashCapMMImpliesDashW(DependencyInfoStdoutMatch,
          <no warning message should be generated>
     """
     environment = Directory('.', [File(
-        'shader.vert', '#version 140\nattribute float x;\nvoid main() {}')])
+        'shader.vert', """
+           #version 400
+           layout(location = 0) attribute float x;
+           void main() {}""")])
     glslc_args = ['-MM', 'shader.vert']
     dependency_rules_expected = [{'target': 'shader.vert.spv',
                                   'dependency': {'shader.vert'}}]

--- a/glslc/test/option_target_env.py
+++ b/glslc/test/option_target_env.py
@@ -51,7 +51,8 @@ class TestTargetEnvEqOpenglWithOpenGlCompatShader(expect.ErrorMessageSubstr):
     glslc_args = ['--target-env=opengl', shader]
     expected_error_substr = [shader, ":4: error: 'assign' :  ",
                              "cannot convert from ' const float' to ",
-                             "' fragColor"]
+                             "'layout( location=0) out 4-component ",
+                             "vector of float"]
 
 
 @inside_glslc_testsuite('OptionTargetEnv')

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -47,8 +47,8 @@ const char kValuelessPredefinitionShader[] =
 // because some versions of glslang will error out for a too-low version
 // when generating SPIR-V.
 const char kDeprecatedAttributeShader[] =
-    "#version 140\n"
-    "attribute float x;\n"
+    "#version 400\n"
+    "layout(location = 0) attribute float x;\n"
     "void main() {}\n";
 
 // By default the compiler will emit a warning as version 550 is an unknown
@@ -80,9 +80,9 @@ const char kTwoErrorsShader[] =
 
 // Compiler should generate two warnings.
 const char kTwoWarningsShader[] =
-    "#version 140\n"
-    "attribute float x;\n"
-    "attribute float y;\n"
+    "#version 400\n"
+    "layout(location = 0) attribute float x;\n"
+    "layout(location = 1) attribute float y;\n"
     "void main(){}\n";
 
 // A shader that compiles under OpenGL compatibility profile rules,

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -432,7 +432,8 @@ TEST_F(CppInterface, ForcedVersionProfileUnknownVersionStd) {
                                    shaderc_profile_core);
   EXPECT_THAT(
       CompilationWarnings(kMinimalShader, shaderc_glsl_vertex_shader, options_),
-      HasSubstr("warning: version 4242 is unknown.\n"));
+      HasSubstr("warning: (version, profile) forced to be (4242, core),"
+                " while in source code it is (140, none)\n"));
 }
 
 TEST_F(CppInterface, ForcedVersionProfileVersionsBefore150) {
@@ -891,15 +892,18 @@ TEST_F(CppInterface, WarningsOnLineAsErrorsClonedOptions) {
 TEST_F(CppInterface, GlobalWarnings) {
   // By default the compiler will emit a warning as version 550 is an unknown
   // version.
+  options_.SetForcedVersionProfile(400, shaderc_profile_core);
   EXPECT_THAT(CompilationWarnings(kMinimalUnknownVersionShader,
                                   shaderc_glsl_vertex_shader, options_),
-              HasSubstr("warning: version 550 is unknown.\n"));
+              HasSubstr("(version, profile) forced to be (400, core),"
+                        " while in source code it is (550, none)\n"));
 }
 
 TEST_F(CppInterface, SuppressGlobalWarnings) {
   // Sets the compiler to suppress warnings, so that the unknown version warning
   // won't be emitted.
   options_.SetSuppressWarnings();
+  options_.SetForcedVersionProfile(400, shaderc_profile_core);
   EXPECT_EQ("", CompilationWarnings(kMinimalUnknownVersionShader,
                                     shaderc_glsl_vertex_shader, options_));
 }
@@ -919,19 +923,23 @@ TEST_F(CppInterface, GlobalWarningsAsErrors) {
   // Sets the compiler to make warnings into errors. So that the unknown
   // version warning will be emitted as an error and compilation should fail.
   options_.SetWarningsAsErrors();
+  options_.SetForcedVersionProfile(400, shaderc_profile_core);
   EXPECT_THAT(CompilationErrors(kMinimalUnknownVersionShader,
                                 shaderc_glsl_vertex_shader, options_),
-              HasSubstr("error: version 550 is unknown.\n"));
+              HasSubstr("(version, profile) forced to be (400, core),"
+                        " while in source code it is (550, none)\n"));
 }
 
 TEST_F(CppInterface, GlobalWarningsAsErrorsClonedOptions) {
   // Sets the compiler to make warnings into errors. This mode should be carried
   // into any clone of the original option object.
   options_.SetWarningsAsErrors();
+  options_.SetForcedVersionProfile(400, shaderc_profile_core);
   CompileOptions cloned_options(options_);
   EXPECT_THAT(CompilationErrors(kMinimalUnknownVersionShader,
                                 shaderc_glsl_vertex_shader, cloned_options),
-              HasSubstr("error: version 550 is unknown.\n"));
+              HasSubstr("(version, profile) forced to be (400, core),"
+                        " while in source code it is (550, none)\n"));
 }
 
 TEST_F(CppInterface, SuppressWarningsModeFirstOverridesWarningsAsErrorsMode) {

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -571,7 +571,8 @@ TEST_F(CompileStringWithOptionsTest, ForcedVersionProfileUnknownVersionStd) {
   // Warning message should complain about the unknown version.
   EXPECT_THAT(CompilationWarnings(kMinimalShader, shaderc_glsl_vertex_shader,
                                   options_.get()),
-              HasSubstr("warning: version 4242 is unknown.\n"));
+              HasSubstr("warning: (version, profile) forced to be (4242, core),"
+                        " while in source code it is (140, none)\n"));
 }
 
 TEST_F(CompileStringWithOptionsTest, ForcedVersionProfileVersionsBefore150) {
@@ -984,22 +985,30 @@ TEST_F(CompileStringWithOptionsTest, SuppressWarningsOnLine) {
 
 TEST_F(CompileStringWithOptionsTest, GlobalWarnings) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
+  shaderc_compile_options_set_forced_version_profile(options_.get(), 400,
+                                                     shaderc_profile_core);
   EXPECT_THAT(CompilationWarnings(kMinimalUnknownVersionShader,
                                   shaderc_glsl_vertex_shader, options_.get()),
-              HasSubstr("version 550 is unknown.\n"));
+              HasSubstr("(version, profile) forced to be (400, core),"
+                        " while in source code it is (550, none)\n"));
 }
 
 TEST_F(CompileStringWithOptionsTest, GlobalWarningsAsErrors) {
   shaderc_compile_options_set_warnings_as_errors(options_.get());
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
+  shaderc_compile_options_set_forced_version_profile(options_.get(), 400,
+                                                     shaderc_profile_core);
   EXPECT_THAT(CompilationErrors(kMinimalUnknownVersionShader,
                                 shaderc_glsl_vertex_shader, options_.get()),
-              HasSubstr("error: version 550 is unknown.\n"));
+              HasSubstr("(version, profile) forced to be (400, core),"
+                        " while in source code it is (550, none)\n"));
 }
 
 TEST_F(CompileStringWithOptionsTest, SuppressGlobalWarnings) {
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
   shaderc_compile_options_set_suppress_warnings(options_.get());
+  shaderc_compile_options_set_forced_version_profile(options_.get(), 400,
+                                                     shaderc_profile_core);
   EXPECT_EQ("",
             CompilationWarnings(kMinimalUnknownVersionShader,
                                 shaderc_glsl_vertex_shader, options_.get()));

--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -162,6 +162,8 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/inline_pass.cpp \
 		source/opt/instruction.cpp \
 		source/opt/ir_loader.cpp \
+		source/opt/local_access_chain_convert_pass.cpp \
+		source/opt/local_single_block_elim_pass.cpp \
 		source/opt/module.cpp \
 		source/opt/optimizer.cpp \
 		source/opt/pass_manager.cpp \

--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -95,9 +95,7 @@ LOCAL_SRC_FILES:= \
 		glslang/MachineIndependent/preprocessor/PpAtom.cpp \
 		glslang/MachineIndependent/preprocessor/PpContext.cpp \
 		glslang/MachineIndependent/preprocessor/Pp.cpp \
-		glslang/MachineIndependent/preprocessor/PpMemory.cpp \
 		glslang/MachineIndependent/preprocessor/PpScanner.cpp \
-		glslang/MachineIndependent/preprocessor/PpSymbols.cpp \
 		glslang/MachineIndependent/preprocessor/PpTokens.cpp
 
 LOCAL_C_INCLUDES:=$(GLSLANG_LOCAL_PATH) \

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -53,9 +53,11 @@ if(${SHADERC_ENABLE_TESTS})
   # The runtests script assumes the glslangValidator executable exists in
   # a location inside the source tree, but we build it elsewhere.
   # We need to copy the test files, fix the path references, and then run tests.
+  # Use test directory named "Test" to match Glslangs Test directory, so
+  # that we get the right relative path names in the "include" test output.
   set(GLSLANG_TEST_SRC_DIR ${SHADERC_GLSLANG_DIR}/Test)
   set(GLSLANG_TEST_BIN_DIR
-        ${CMAKE_CURRENT_BINARY_DIR}/test-glslang/${CMAKE_CFG_INTDIR})
+        ${CMAKE_CURRENT_BINARY_DIR}/Test/${CMAKE_CFG_INTDIR})
 
   # If we are building in a multi-configuration setting we have
   # to put the glslang tests into their respective subdirectories.
@@ -71,15 +73,15 @@ if(${SHADERC_ENABLE_TESTS})
 
   if (CMAKE_CONFIGURATION_TYPES)
     # If we are running a multi-configuration project,
-    # the tests will be in test-glslang/${Configuration}
+    # the tests will be in Test/${Configuration}
     add_test(NAME glslang-testsuite
       COMMAND bash runtests
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test-glslang/$<CONFIGURATION>
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Test/$<CONFIGURATION>
     )
   else()
     add_test(NAME glslang-testsuite
       COMMAND bash runtests
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test-glslang/
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Test/
     )
   endif()
 endif()

--- a/utils/copy-tests-if-necessary.py
+++ b/utils/copy-tests-if-necessary.py
@@ -109,10 +109,19 @@ def main():
     if intermediate_directory:
         target_location = "../" + target_location + intermediate_directory + "/"
     target_location = "EXE=" + target_location
+
+    include_test_file = "../Test/"
+    if intermediate_directory:
+        include_test_file = "../" + target_location + intermediate_directory + "/"
+    include_test_file = include_test_file + "hlsl.include.vert"
+
     if src_glsl_stamp != old_glsl_stamp:
         setup_directory(glsl_src_dir, glsl_bin_dir)
-        substitute_file(os.path.join(glsl_bin_dir, "runtests"),
+        runtests_script = os.path.join(glsl_bin_dir, "runtests")
+        substitute_file(runtests_script,
                         ("EXE=../build/install/bin/", target_location))
+        substitute_file(runtests_script,
+                        ("../Test/hlsl.include.vert", include_test_file))
         write_file(glsl_list_file, src_glsl_stamp)
 
 


### PR DESCRIPTION
- glslang added an #include facility; adjust test copying to accomodate
- glslang requires location annotation on shader inputs and outputs
- glslang global warnings changed; use forced version/profile instead of unknown version
- glslang removed two .cpp files with empty contents (Affects Android.mk)
- SPIRV-Tools added two new optimization passes. (Affects Android.mk)

These changes are required to be able to refresh google/glslang