### PR TITLE
Increase default maxDrawBuffers

### DIFF
--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -254,7 +254,7 @@ MaxVertexTextureImageUnits 16
 MaxCombinedTextureImageUnits 80
 MaxTextureImageUnits 16
 MaxFragmentUniformComponents 1024
-MaxDrawBuffers 4
+MaxDrawBuffers 8
 MaxVertexUniformVectors 256
 MaxVaryingVectors 15
 MaxFragmentUniformVectors 256

--- a/libshaderc_util/src/resources.cc
+++ b/libshaderc_util/src/resources.cc
@@ -32,7 +32,12 @@ const TBuiltInResource kDefaultTBuiltInResource = {
     /*.maxCombinedTextureImageUnits = */ 80,
     /*.maxTextureImageUnits = */ 16,
     /*.maxFragmentUniformComponents = */ 1024,
-    /*.maxDrawBuffers = */ 4,
+
+    // glslang has 32 maxDrawBuffers.
+    // Pixel phone Vulkan driver in Android N has 8
+    // maxFragmentOutputAttachments.
+    /*.maxDrawBuffers = */ 8, 
+
     /*.maxVertexUniformVectors = */ 256,
     /*.maxVaryingVectors = */ 15,  // From OpenGLES 3.1 table 6.44.
     /*.maxFragmentUniformVectors = */ 256,


### PR DESCRIPTION
Glslang has default of 32.
Vulkan driver on Pixel in Android N has maxFragmentOutputAttachments of 8.