### PR TITLE
Fixed leaking compiler->initializer

### DIFF
--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -449,14 +449,17 @@ void shaderc_compile_options_set_hlsl_register_set_and_binding(
 }
 
 shaderc_compiler_t shaderc_compiler_initialize() {
-  static shaderc_util::GlslangInitializer* initializer =
+  shaderc_util::GlslangInitializer* initializer =
       new shaderc_util::GlslangInitializer;
   shaderc_compiler_t compiler = new (std::nothrow) shaderc_compiler;
   compiler->initializer = initializer;
   return compiler;
 }
 
-void shaderc_compiler_release(shaderc_compiler_t compiler) { delete compiler; }
+void shaderc_compiler_release(shaderc_compiler_t compiler) {
+  delete compiler->initializer;
+  delete compiler;
+}
 
 namespace {
 shaderc_compilation_result_t CompileToSpecifiedOutputType(


### PR DESCRIPTION
https://github.com/google/shaderc/issues/356

Fixes a big part of that issue. 

Someone still needs to fix the leak for InitializeMemoryPools().
