### PR TITLE
Deploy Appveyor build artifacts to GitHub Releases

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,6 +49,51 @@ build_script:
 test_script:
   - ctest -C %CONFIGURATION% --output-on-failure
 
+after_test:
+  # For debug build, the generated dll has a postfix "d" in its name.
+  - ps: >-
+      If ($env:configuration -Match "Debug") {
+        $env:SHADERC_DLL="shaderc_sharedd.dll"
+      } Else {
+        $env:SHADERC_DLL="shaderc_shared.dll"
+      }
+  - cp libshaderc\%CONFIGURATION%\%SHADERC_DLL% install\lib\
+  - cd install
+  - 7z a artifacts.zip bin\glslc.exe include\shaderc\* lib\shaderc_combined.lib lib\%SHADERC_DLL%
+
+artifacts:
+  - path: build\install\artifacts.zip
+    name: shaderc-artifacts
+  - path: build\install\bin\glslc.exe
+
+deploy:
+  - provider: GitHub
+    auth_token:
+      secure: 2eLsMUFD0NxGTFpcl627vYDiwTM41ZEolu9mYBIsvAzNscyh0X1SrLmH0EVfNLi/
+    release: master-tot-release
+    description: "Continuous release build of the top of the tree (ToT) of the master branch by Appveyor.\n\nartifacts.zip contains the build artifacts for Windows x64 platform:\n- glslc.exe\n- shaderc C/C++ headers\n- shaderc_combined.lib\n- shaderc_shared.dll"
+    artifact: shaderc-artifacts
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+      branch: master
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Release
+  - provider: GitHub
+    auth_token:
+      secure: 2eLsMUFD0NxGTFpcl627vYDiwTM41ZEolu9mYBIsvAzNscyh0X1SrLmH0EVfNLi/
+    release: master-tot-debug
+    description: "Continuous debug build of the top of the tree (ToT) of the master branch by Appveyor.\n\nartifacts.zip contains the build artifacts for Windows x64 platform:\n- glslc.exe\n- shaderc C/C++ headers\n- shaderc_combined.lib\n- shaderc_sharedd.dll"
+    artifact: shaderc-artifacts
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+      branch: master
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      configuration: Debug
+
 notifications:
   - provider: Email
     to:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ Shaderc into.
 
 ## Getting and building Shaderc
 
+On Windows, instead of building from source, you can get the artifacts for
+the top of the tree of the master branch deployed by the Appveyor continuous
+integration service at the [Release][ci-release] page.
+
 1) Check out the source code:
 
 ```sh
@@ -237,4 +241,5 @@ older versions of Shaderc and its dependencies.
 [google-glslang]: https://github.com/google/glslang
 [spirv-tools]: https://github.com/KhronosGroup/SPIRV-Tools
 [pyshaderc]: https://github.com/realitix/pyshaderc
+[ci-release]: https://github.com/google/shaderc/releases
 [shaderc-rs]: https://github.com/google/shaderc-rs


### PR DESCRIPTION
This pull request added configuration for uploading Appveyor
build artifacts of master top of the tree to the GitHub
"Releases" page. The following are published:
* glslc.exe
* shaderc headers
* shaderc_combined.lib
* shaderc_shared.dll