### PR TITLE
Update third_party/Android.mk

### DIFF
--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -162,6 +162,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 		source/opt/dead_branch_elim_pass.cpp \
 		source/opt/def_use_manager.cpp \
 		source/opt/eliminate_dead_constant_pass.cpp \
+		source/opt/eliminate_dead_functions_pass.cpp \
 		source/opt/flatten_decoration_pass.cpp \
 		source/opt/fold_spec_constant_op_and_composite_pass.cpp \
 		source/opt/freeze_spec_constant_value_pass.cpp \

--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -149,6 +149,7 @@ SPVTOOLS_SRC_FILES := \
 		source/validate_id.cpp \
 		source/validate_instruction.cpp \
 		source/validate_layout.cpp \
+		source/validate_logicals.cpp \
 		source/validate_type_unique.cpp
 
 SPVTOOLS_OPT_SRC_FILES := \

--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -190,6 +190,7 @@ SPVTOOLS_OPT_SRC_FILES := \
 # Locations of grammar files.
 SPV_CORE10_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.0/spirv.core.grammar.json
 SPV_CORE11_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.1/spirv.core.grammar.json
+SPV_CORE12_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.2/spirv.core.grammar.json
 SPV_GLSL_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.0/extinst.glsl.std.450.grammar.json
 SPV_OPENCL_GRAMMAR=$(SPVHEADERS_LOCAL_PATH)/include/spirv/1.0/extinst.opencl.std.100.grammar.json
 
@@ -219,9 +220,9 @@ $(1)/core.insts-1.1.inc $(1)/operand.kinds-1.1.inc: \
 		@echo "[$(TARGET_ARCH_ABI)] Grammar v1.1   : instructions & operands <= grammar JSON files"
 $(1)/core.insts-1.2.inc $(1)/operand.kinds-1.2.inc: \
         $(SPVTOOLS_LOCAL_PATH)/utils/generate_grammar_tables.py \
-        $(SPV_CORE11_GRAMMAR)
+        $(SPV_CORE12_GRAMMAR)
 		@$(HOST_PYTHON) $(SPVTOOLS_LOCAL_PATH)/utils/generate_grammar_tables.py \
-		                --spirv-core-grammar=$(SPV_CORE11_GRAMMAR) \
+		                --spirv-core-grammar=$(SPV_CORE12_GRAMMAR) \
 		                --core-insts-output=$(1)/core.insts-1.2.inc \
 		                --operand-kinds-output=$(1)/operand.kinds-1.2.inc
 		@echo "[$(TARGET_ARCH_ABI)] Grammar v1.2   : instructions & operands <= grammar JSON files"

--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -142,6 +142,7 @@ SPVTOOLS_SRC_FILES := \
 		source/val/validation_state.cpp \
 		source/validate.cpp \
 		source/validate_arithmetics.cpp \
+		source/validate_bitwise.cpp \
 		source/validate_cfg.cpp \
 		source/validate_capability.cpp \
 		source/validate_datarules.cpp \


### PR DESCRIPTION
Fix generation of 1.2 grammar tables
SPIRV-Tools added source files.

Goes along with https://github.com/KhronosGroup/SPIRV-Tools/pull/831