### PR TITLE
Appveyor: deploy to BinTray instead of GitHub Release page

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,47 +54,35 @@ after_test:
   - ps: >-
       If ($env:configuration -Match "Debug") {
         $env:SHADERC_DLL="shaderc_sharedd.dll"
+        $env:ZIP_FILENAME="shaderc-tot-windows-x64-debug.zip"
       } Else {
         $env:SHADERC_DLL="shaderc_shared.dll"
+        $env:ZIP_FILENAME="shaderc-tot-windows-x64-release.zip"
       }
   - cp libshaderc\%CONFIGURATION%\%SHADERC_DLL% install\lib\
   - cd install
-  - 7z a artifacts.zip bin\glslc.exe include\shaderc\* lib\shaderc_combined.lib lib\%SHADERC_DLL%
+  - 7z a %ZIP_FILENAME% bin\glslc.exe include\shaderc\* lib\shaderc_combined.lib lib\%SHADERC_DLL%
 
 artifacts:
-  - path: build\install\artifacts.zip
+  - path: build\install\$(ZIP_FILENAME)
     name: shaderc-artifacts
   - path: build\install\bin\glslc.exe
 
 deploy:
-  - provider: GitHub
-    auth_token:
-      secure: 2eLsMUFD0NxGTFpcl627vYDiwTM41ZEolu9mYBIsvAzNscyh0X1SrLmH0EVfNLi/
-    release: master-tot-release
-    description: "Continuous release build of the top of the tree (ToT) of the master branch by Appveyor.\n\nartifacts.zip contains the build artifacts for Windows x64 platform:\n- glslc.exe\n- shaderc C/C++ headers\n- shaderc_combined.lib\n- shaderc_shared.dll"
+  - provider: BinTray
+    username: antiagainst
+    api_key:
+      secure: SwJ06SwKnaNsS5MbChuka51mR9I2YDCXR1itJYZ9khZkNfWZqIwyOZoRvvgAbG8n
+    subject: antiagainst
+    repo: spirv-toolchain
+    package: shaderc
+    version: master-tot
     artifact: shaderc-artifacts
-    repository: antiagainst/shaderc
-    draft: false
-    prerelease: false
-    force_update: true
+    publish: true
+    override: true
     on:
       branch: master
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      configuration: Release
-  - provider: GitHub
-    auth_token:
-      secure: 2eLsMUFD0NxGTFpcl627vYDiwTM41ZEolu9mYBIsvAzNscyh0X1SrLmH0EVfNLi/
-    release: master-tot-debug
-    description: "Continuous debug build of the top of the tree (ToT) of the master branch by Appveyor.\n\nartifacts.zip contains the build artifacts for Windows x64 platform:\n- glslc.exe\n- shaderc C/C++ headers\n- shaderc_combined.lib\n- shaderc_sharedd.dll"
-    artifact: shaderc-artifacts
-    repository: antiagainst/shaderc
-    draft: false
-    prerelease: false
-    force_update: true
-    on:
-      branch: master
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      configuration: Debug
 
 notifications:
   - provider: Email

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ Shaderc into.
 
 ## Getting and building Shaderc
 
-On Windows, instead of building from source, you can get the artifacts for
-the top of the tree of the master branch deployed by the Appveyor continuous
-integration service from [BinTray][bintray].
+**Experimental:** On Windows, instead of building from source, you can get the
+artifacts from a third-party service [BinTray][bintray] (not hosted by Google
+or GitHub). Appveyor continuously deploys the build artifacts for the top of
+the tree of the master branch there.
 
 1) Check out the source code:
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Shaderc into.
 
 On Windows, instead of building from source, you can get the artifacts for
 the top of the tree of the master branch deployed by the Appveyor continuous
-integration service at the [Release][ci-release] page.
+integration service from [BinTray][bintray].
 
 1) Check out the source code:
 
@@ -241,5 +241,5 @@ older versions of Shaderc and its dependencies.
 [google-glslang]: https://github.com/google/glslang
 [spirv-tools]: https://github.com/KhronosGroup/SPIRV-Tools
 [pyshaderc]: https://github.com/realitix/pyshaderc
-[ci-release]: https://github.com/antiagainst/shaderc/releases
 [shaderc-rs]: https://github.com/google/shaderc-rs
+[bintray]: https://bintray.com/antiagainst/spirv-toolchain/shaderc#files


### PR DESCRIPTION
This should fix the current deploy failure.