### PR TITLE
Check _WIN32 instead of WIN32 for building shared library

### DIFF
--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -25,7 +25,7 @@ extern "C" {
 
 // SHADERC_EXPORT tags symbol that will be exposed by the shared library.
 #if defined(SHADERC_SHAREDLIB)
-    #if defined(WIN32)
+    #if defined(_WIN32)
         #if defined(SHADERC_IMPLEMENTATION)
             #define SHADERC_EXPORT __declspec(dllexport)
         #else


### PR DESCRIPTION
_WIN32 is defined by MSVC compilers on Windows platform, not
WIN32.

See https://msdn.microsoft.com/en-us/library/b0084kay.aspx

Addresses https://github.com/google/shaderc/issues/383