### PR TITLE
Allow SPIRV-Headers to be checked out at third_party/

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ install:
   - git clone https://github.com/google/googletest.git          third_party/googletest
   - git clone https://github.com/google/glslang.git             third_party/glslang
   - git clone https://github.com/KhronosGroup/SPIRV-Tools.git   third_party/spirv-tools
-  - git clone https://github.com/KhronosGroup/SPIRV-Headers.git third_party/spirv-tools/external/spirv-headers
+  - git clone https://github.com/KhronosGroup/SPIRV-Headers.git third_party/spirv-headers
 
 build:
   parallel: true  # enable MSBuild parallel builds

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ cscope.*
 third_party/glslang/
 third_party/googletest/
 third_party/spirv-tools/
+third_party/spirv-headers/
 android_test/libs
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ before_script:
   - git clone --depth=1 https://github.com/google/googletest          third_party/googletest
   - git clone --depth=1 https://github.com/google/glslang             third_party/glslang
   - git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Tools   third_party/spirv-tools
-  - git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Headers third_party/spirv-tools/external/spirv-headers
+  - git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Headers third_party/spirv-headers
 
 script:
   - mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cd $SOURCE_DIR/third_party
 git clone https://github.com/google/googletest.git
 git clone https://github.com/google/glslang.git
 git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
-git clone https://github.com/KhronosGroup/SPIRV-Headers.git spirv-tools/external/spirv-headers
+git clone https://github.com/KhronosGroup/SPIRV-Headers.git spirv-headers
 cd $SOURCE_DIR/
 ```
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -7,6 +7,8 @@ set(SHADERC_GOOGLE_TEST_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/googletest" CACHE S
   "Location of googletest source")
 set(SHADERC_SPIRV_TOOLS_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/spirv-tools" CACHE STRING
   "Location of spirv-tools source")
+set(SHADERC_SPIRV_HEADERS_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/spirv-headers" CACHE STRING
+  "Location of spirv-headers source")
 set(SHADERC_GLSLANG_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/glslang" CACHE STRING
   "Location of glslang source")
 
@@ -25,6 +27,10 @@ if(${SHADERC_ENABLE_TESTS})
 endif()
 
 set(OLD_PLATFORM_TOOLSET ${CMAKE_GENERATOR_TOOLSET})
+
+if (IS_DIRECTORY ${SHADERC_SPIRV_HEADERS_DIR})
+  add_subdirectory(${SHADERC_SPIRV_HEADERS_DIR} spirv-headers)
+endif()
 
 # Check SPIRV-Tools before glslang since it is a dependency of glslang.
 if (IS_DIRECTORY ${SHADERC_SPIRV_TOOLS_DIR})


### PR DESCRIPTION
This makes the directory hierarchy less complicated.