### PR TITLE
Adapt to Glslang generator version number change

### DIFF
--- a/glslc/test/assembly.py
+++ b/glslc/test/assembly.py
@@ -21,7 +21,7 @@ def assembly_comments():
     return """
     ; SPIR-V
     ; Version: 1.0
-    ; Generator: Google Shaderc over Glslang; 1
+    ; Generator: Google Shaderc over Glslang; 2
     ; Bound: 6
     ; Schema: 0"""
 

--- a/glslc/test/expect.py
+++ b/glslc/test/expect.py
@@ -167,7 +167,7 @@ class CorrectObjectFilePreamble(GlslCTest):
                 return False, 'Incorrect SPV binary: wrong version number'
             # Shaderc-over-Glslang (0x000d....) or
             # SPIRV-Tools (0x0007....) generator number
-            if read_word(preamble, 2, little_endian) != 0x000d0001 and \
+            if read_word(preamble, 2, little_endian) != 0x000d0002 and \
                     read_word(preamble, 2, little_endian) != 0x00070000:
                 return False, ('Incorrect SPV binary: wrong generator magic '
                                'number')
@@ -193,7 +193,7 @@ class CorrectAssemblyFilePreamble(GlslCTest):
 
         if (line1 != '; SPIR-V\n' or
             line2 != '; Version: 1.0\n' or
-            line3 != '; Generator: Google Shaderc over Glslang; 1\n'):
+            line3 != '; Generator: Google Shaderc over Glslang; 2\n'):
             return False, 'Incorrect SPV assembly'
 
         return True, ''

--- a/glslc/test/option_dash_cap_O.py
+++ b/glslc/test/option_dash_cap_O.py
@@ -23,7 +23,7 @@ EMPTY_SHADER_IN_CWD = Directory('.', [File('shader.vert', MINIMAL_SHADER)])
 ASSEMBLY_WITH_DEBUG = [
     '; SPIR-V\n',
     '; Version: 1.0\n',
-    '; Generator: Google Shaderc over Glslang; 1\n',
+    '; Generator: Google Shaderc over Glslang; 2\n',
     '; Bound: 6\n',
     '; Schema: 0\n',
     '               OpCapability Shader\n',
@@ -44,7 +44,7 @@ ASSEMBLY_WITH_DEBUG = [
 ASSEMBLY_WITHOUT_DEBUG = [
     '; SPIR-V\n',
     '; Version: 1.0\n',
-    '; Generator: Google Shaderc over Glslang; 1\n',
+    '; Generator: Google Shaderc over Glslang; 2\n',
     '; Bound: 6\n',
     '; Schema: 0\n',
     '               OpCapability Shader\n',

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -189,7 +189,7 @@ const char kVertexOnlyShaderWithInvalidPragma[] =
 const char* kMinimalShaderDisassemblySubstrings[] = {
     "; SPIR-V\n"
     "; Version: 1.0\n"
-    "; Generator: Google Shaderc over Glslang; 1\n"
+    "; Generator: Google Shaderc over Glslang; 2\n"
     "; Bound:",
 
     "               OpCapability Shader\n",
@@ -201,7 +201,7 @@ const char* kMinimalShaderDisassemblySubstrings[] = {
 const char kMinimalShaderAssembly[] = R"(
     ; SPIR-V
     ; Version: 1.0
-    ; Generator: Google Shaderc over Glslang; 1
+    ; Generator: Google Shaderc over Glslang; 2
     ; Bound: 6
     ; Schema: 0
 


### PR DESCRIPTION
The lower 16bits of the generator number is now 2, up from 1.

See Glslang commit.
https://github.com/KhronosGroup/glslang/commit/07ed11f9a08820505eef1e128bd758b8b9b5ed5b

Glslang updated its generator version number to highlight
a behaviour fix related to atomic decrement, in commit
https://github.com/KhronosGroup/glslang/commit/48d6e798bc76b8e58be844a8cef8bc6f843a909e


(Requires a correponding refresh of google/glslang from KhronosGroup/glslang)