### PR TITLE
Avoid -fPIC for MinGW builds

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -9,7 +9,10 @@ endfunction(shaderc_use_gmock)
 
 function(shaderc_default_c_compile_options TARGET)
   if (NOT "${MSVC}")
-    target_compile_options(${TARGET} PRIVATE -Wall -Werror -fPIC -fvisibility=hidden)
+    target_compile_options(${TARGET} PRIVATE -Wall -Werror -fvisibility=hidden)
+    if (NOT "${MINGW}")
+      target_compile_options(${TARGET} PRIVATE -fPIC)
+    endif()
     if (ENABLE_CODE_COVERAGE)
       # The --coverage option is a synonym for -fprofile-arcs -ftest-coverage
       # when compiling.


### PR DESCRIPTION
Android NDK build uses a MinGW build that warns if -fPIC is specified
because PIC is always turned on anyway.  That causes an error since
we have warnings as errors.