### PR TITLE
Make tests resilient to better SPIR-V optimizations

### DIFF
--- a/glslc/test/option_fauto_bind_uniforms.py
+++ b/glslc/test/option_fauto_bind_uniforms.py
@@ -40,8 +40,8 @@ HLSL_SHADER_WITHOUT_BINDINGS = """
 SamplerState s1 : register(s1);
 SamplerComparisonState s2 : register(s2);
 
-Texture1D <float2> t1 : register(t11);
-Texture2D <float2> t2 : register(t12);
+Texture1D t1 : register(t11);
+Texture2D <float4> t2 : register(t12);
 Texture3D <float2> t3 : register(t13);
 StructuredBuffer<float4> t4 : register(t14);
 ByteAddressBuffer t5 : register(t15);
@@ -75,7 +75,8 @@ float4 main() : SV_Target0 {
    u6[2];
    u7;
    u8;
-   return float4(1.0);
+   return float4(u8.Consume() + t2.SampleCmp(s2, 1.0, 2.0)) + t1.Sample(s1, 1.0)
+    + t6.Load(1);
 }
 """
 

--- a/glslc/test/option_fresource_set_binding.py
+++ b/glslc/test/option_fresource_set_binding.py
@@ -22,9 +22,7 @@ Buffer<float4> t4 : register(t4);
 Buffer<float4> t5 : register(t5);
 
 float4 main() : SV_Target0 {
-   t4[2];
-   t5[7];
-   return float4(1.0);
+   return float4(t4.Load(0) + t5.Load(1));
 }
 """
 

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -245,9 +245,7 @@ const char kHlslFragShaderWithRegisters[] =
     R"(Buffer<float> t4 : register(t4);
        Buffer<float> t5 : register(t5);
        float4 main() : SV_Target0 {
-         t4;
-         t5;
-         return float4(1.0);
+         return float4(t4.Load(0) + t5.Load(1));
        })";
 
 #ifdef __cplusplus


### PR DESCRIPTION
A test shader should use the resources or samplers whose
bindings are being checked.