### PR TITLE
WIP:  Force SPIR-V 1.0 binaries

### DIFF
--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -221,6 +221,11 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   shader.setResourceSetBinding(
       hlsl_explicit_bindings_[static_cast<int>(used_shader_stage)]);
 
+  // Vulkan and OpenGL only support SPIR-V 1.0.
+  // TODO(dneto): Extensions or future versions of those APIs might permit
+  // other versions of SPIR-V.
+  shader.setEnvTarget(glslang::EshTargetSpv, 100);
+
   // TODO(dneto): Generate source-level debug info if requested.
   bool success = shader.parse(
       &limits_, default_version_, default_profile_, force_version_profile_,


### PR DESCRIPTION
That's the only version of SPIR-V accepted by Vulkan 1.0 and OpenGL 4.6
client APIS.