### PR TITLE
Deprecate OpenGL compatibility profile for SPIR-V compilation

### DIFF
--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -82,9 +82,15 @@ typedef enum {
 typedef enum {
   shaderc_target_env_vulkan,         // create SPIR-V under Vulkan semantics
   shaderc_target_env_opengl,         // create SPIR-V under OpenGL semantics
+
+  // OpenGL Compatibility mode is no longer supported, and may result in
+  // unexpected compilation failures since the underlying Glslang compiler
+  // no longer supports OpenGL compatibility profile when generating SPIR-V.
+  // The OpenGL GL_ARB_gl_spirv extension removes all OpenGL compatibility
+  // mode features.
   shaderc_target_env_opengl_compat,  // create SPIR-V under OpenGL semantics,
                                      // including compatibility profile
-                                     // functions
+                                     // functions.
   shaderc_target_env_default = shaderc_target_env_vulkan
 } shaderc_target_env;
 

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -980,7 +980,8 @@ TEST_F(CppInterface, SuppressWarningsModeSecondOverridesWarningsAsErrorsMode) {
               Eq("shader: error: version not supported\n"));
 }
 
-TEST_F(CppInterface, TargetEnvCompileOptions) {
+// OpenGL compatibility profile is not supported.
+TEST_F(CppInterface, DISABLED_TargetEnvCompileOptions) {
   // Test shader compilation which requires opengl compatibility environment
   options_.SetTargetEnvironment(shaderc_target_env_opengl_compat, 0);
   const std::string kGlslShader =

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -1076,8 +1076,10 @@ TEST_F(CompileStringWithOptionsTest, IfDefCompileOption) {
                                  shaderc_glsl_vertex_shader, options_.get()));
 }
 
-TEST_F(CompileStringWithOptionsTest,
-       TargetEnvRespectedWhenCompilingOpenGLCompatibilityShaderToBinary) {
+// OpenGL compatibility profile is no longer supported.
+TEST_F(
+    CompileStringWithOptionsTest,
+    DISABLED_TargetEnvRespectedWhenCompilingOpenGLCompatibilityShaderToBinary) {
   // Confirm that kOpenGLCompatibilityFragmentShader compiles with
   // shaderc_target_env_opengl_compat.  When targeting OpenGL core profile
   // or Vulkan, it should fail to compile.

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -221,6 +221,12 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   shader.setResourceSetBinding(
       hlsl_explicit_bindings_[static_cast<int>(used_shader_stage)]);
 
+  // Vulkan and OpenGL only support SPIR-V 1.0, which has binary version word
+  // 0x10000.
+  // TODO(dneto): Extensions or future versions of those APIs might permit
+  // other versions of SPIR-V.
+  shader.setEnvTarget(glslang::EShTargetSpv, 0x10000);
+
   // TODO(dneto): Generate source-level debug info if requested.
   bool success = shader.parse(
       &limits_, default_version_, default_profile_, force_version_profile_,

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -235,7 +235,9 @@ TEST_F(CompilerTest, SimpleVulkanShaderCompilesWithDefaultCompilerSettings) {
   EXPECT_TRUE(SimpleCompilationSucceeds(kVulkanVertexShader, EShLangVertex));
 }
 
-TEST_F(CompilerTest, RespectTargetEnvOnOpenGLCompatibilityShader) {
+// OpenGL compatibility profile is no longer supported for SPIR-V code
+// generation by Glslan.
+TEST_F(CompilerTest, DISABLED_RespectTargetEnvOnOpenGLCompatibilityShader) {
   const EShLanguage stage = EShLangFragment;
 
   compiler_.SetTargetEnv(Compiler::TargetEnv::OpenGLCompat);


### PR DESCRIPTION
    
    Disable its tests.
    
    Glslang doesn't support SPIR-V code generation for OpenGL
    compatibility mode.  GL_ARB_gl_spirv disables OpenGL compatibility
    mode, since SPIR-V doesn't support certain features.
    
    Shaderc still offers this as a mode, but it will likely cause
    compilation failure.
