### PR TITLE
Add a virtual destructor to CompileOptions::IncluderInterface

### DIFF
--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -180,6 +180,8 @@ class CompileOptions {
 
     // Handles shaderc_include_result_release_fn callbacks.
     virtual void ReleaseInclude(shaderc_include_result* data) = 0;
+
+    virtual ~IncluderInterface() = default;
   };
 
   // Sets the includer instance for libshaderc to call during compilation, as


### PR DESCRIPTION
We need a virtual destructor on `CompileOptions::IncluderInterface` otherwise Clang 6.0 complains about delete being called on an abstract class.

See the error below before that caused this addition:

```
FAILED: /usr/bin/c++   -DSHADERC_SHAREDLIB -I../libshaderc/include -I../libshaderc_util/include -I../third_party/glslang -I../third_party/spirv-tools/include -isystem ../third_party/googletest/googlemock/include -isystem ../third_party/googletest/googletest/include -O2 -g -DNDEBUG   -Wall -Werror -fvisibility=hidden -fPIC -std=c++11 -MMD -MT libshaderc/CMakeFiles/shaderc_shared_shaderc_cpp_test.dir/src/shaderc_cpp_test.cc.o -MF libshaderc/CMakeFiles/shaderc_shared_shaderc_cpp_test.dir/src/shaderc_cpp_test.cc.o.d -o libshaderc/CMakeFiles/shaderc_shared_shaderc_cpp_test.dir/src/shaderc_cpp_test.cc.o -c ../libshaderc/src/shaderc_cpp_test.cc
In file included from ../libshaderc/src/shaderc_cpp_test.cc:15:
In file included from ../third_party/googletest/googlemock/include/gmock/gmock.h:58:
In file included from ../third_party/googletest/googlemock/include/gmock/gmock-actions.h:46:
In file included from ../third_party/googletest/googlemock/include/gmock/internal/gmock-internal-utils.h:46:
In file included from ../third_party/googletest/googletest/include/gtest/gtest.h:58:
In file included from ../third_party/googletest/googletest/include/gtest/internal/gtest-internal.h:55:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/iomanip:43:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/locale:43:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/locale_conv.h:41:
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unique_ptr.h:76:2: error: delete called on 'shaderc::CompileOptions::IncluderInterface' that is abstract but has non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
        delete __ptr;
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unique_ptr.h:236:4: note: in instantiation of member function 'std::default_delete<shaderc::CompileOptions::IncluderInterface>::operator()' requested here
          get_deleter()(__ptr);
          ^
../libshaderc/include/shaderc/shaderc.hpp:133:3: note: in instantiation of member function 'std::unique_ptr<shaderc::CompileOptions::IncluderInterface, std::default_delete<shaderc::CompileOptions::IncluderInterface> >::~unique_ptr' requested here
  CompileOptions() { options_ = shaderc_compile_options_initialize(); }
  ^
In file included from ../libshaderc/src/shaderc_cpp_test.cc:15:
In file included from ../third_party/googletest/googlemock/include/gmock/gmock.h:58:
In file included from ../third_party/googletest/googlemock/include/gmock/gmock-actions.h:46:
In file included from ../third_party/googletest/googlemock/include/gmock/internal/gmock-internal-utils.h:46:
In file included from ../third_party/googletest/googletest/include/gtest/gtest.h:58:
In file included from ../third_party/googletest/googletest/include/gtest/internal/gtest-internal.h:55:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/iomanip:43:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/locale:43:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/locale_conv.h:41:
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unique_ptr.h:76:2: error: delete called on non-final '(anonymous namespace)::TestIncluder' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
        delete __ptr;
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unique_ptr.h:236:4: note: in instantiation of member function 'std::default_delete<(anonymous namespace)::TestIncluder>::operator()' requested here
          get_deleter()(__ptr);
          ^
../libshaderc/src/shaderc_cpp_test.cc:781:23: note: in instantiation of member function 'std::unique_ptr<(anonymous namespace)::TestIncluder, std::default_delete<(anonymous namespace)::TestIncluder> >::~unique_ptr' requested here
  options.SetIncluder(std::unique_ptr<TestIncluder>(new TestIncluder(fs)));
                      ^
2 errors generated.
[627/658] Building CXX object libshade...cpp_test.dir/src/shaderc_cpp_test.cc.o
FAILED: /usr/bin/c++    -I../libshaderc/include -I../libshaderc_util/include -I../third_party/glslang -I../third_party/spirv-tools/include -isystem ../third_party/googletest/googlemock/include -isystem ../third_party/googletest/googletest/include -O2 -g -DNDEBUG   -Wall -Werror -fvisibility=hidden -fPIC -std=c++11 -MMD -MT libshaderc/CMakeFiles/shaderc_shaderc_cpp_test.dir/src/shaderc_cpp_test.cc.o -MF libshaderc/CMakeFiles/shaderc_shaderc_cpp_test.dir/src/shaderc_cpp_test.cc.o.d -o libshaderc/CMakeFiles/shaderc_shaderc_cpp_test.dir/src/shaderc_cpp_test.cc.o -c ../libshaderc/src/shaderc_cpp_test.cc
In file included from ../libshaderc/src/shaderc_cpp_test.cc:15:
In file included from ../third_party/googletest/googlemock/include/gmock/gmock.h:58:
In file included from ../third_party/googletest/googlemock/include/gmock/gmock-actions.h:46:
In file included from ../third_party/googletest/googlemock/include/gmock/internal/gmock-internal-utils.h:46:
In file included from ../third_party/googletest/googletest/include/gtest/gtest.h:58:
In file included from ../third_party/googletest/googletest/include/gtest/internal/gtest-internal.h:55:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/iomanip:43:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/locale:43:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/locale_conv.h:41:
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unique_ptr.h:76:2: error: delete called on 'shaderc::CompileOptions::IncluderInterface' that is abstract but has non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
        delete __ptr;
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unique_ptr.h:236:4: note: in instantiation of member function 'std::default_delete<shaderc::CompileOptions::IncluderInterface>::operator()' requested here
          get_deleter()(__ptr);
          ^
../libshaderc/include/shaderc/shaderc.hpp:133:3: note: in instantiation of member function 'std::unique_ptr<shaderc::CompileOptions::IncluderInterface, std::default_delete<shaderc::CompileOptions::IncluderInterface> >::~unique_ptr' requested here
  CompileOptions() { options_ = shaderc_compile_options_initialize(); }
  ^
In file included from ../libshaderc/src/shaderc_cpp_test.cc:15:
In file included from ../third_party/googletest/googlemock/include/gmock/gmock.h:58:
In file included from ../third_party/googletest/googlemock/include/gmock/gmock-actions.h:46:
In file included from ../third_party/googletest/googlemock/include/gmock/internal/gmock-internal-utils.h:46:
In file included from ../third_party/googletest/googletest/include/gtest/gtest.h:58:
In file included from ../third_party/googletest/googletest/include/gtest/internal/gtest-internal.h:55:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/iomanip:43:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/locale:43:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/locale_conv.h:41:
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unique_ptr.h:76:2: error: delete called on non-final '(anonymous namespace)::TestIncluder' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
        delete __ptr;
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/5.4.0/../../../../include/c++/5.4.0/bits/unique_ptr.h:236:4: note: in instantiation of member function 'std::default_delete<(anonymous namespace)::TestIncluder>::operator()' requested here
          get_deleter()(__ptr);
          ^
../libshaderc/src/shaderc_cpp_test.cc:781:23: note: in instantiation of member function 'std::unique_ptr<(anonymous namespace)::TestIncluder, std::default_delete<(anonymous namespace)::TestIncluder> >::~unique_ptr' requested here
  options.SetIncluder(std::unique_ptr<TestIncluder>(new TestIncluder(fs)));
                      ^
2 errors generated.
[627/658] Building CXX object libshaderc/CMakeFiles/shaderc_shared_shaderc_test.dir/src/shaderc_test.cc.o
ninja: build stopped: subcommand failed.
```