### PR TITLE
Glslang now requires bindings on resources

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ Revision history for Shaderc
 v2017.2-dev 2017-03-10
  - Add a shared library version of libshaderc
  - Support GLSL 4.6 and ESSL 3.2
+ - Fail compilation if a resource does not have a binding.
  - Add options for automatically set bindings for (uniform) resources that
    don't have bindings set in shader source.
  - Add option for using HLSL IO mappings as expressed in source.

--- a/glslc/test/option_fauto_bind_uniforms.py
+++ b/glslc/test/option_fauto_bind_uniforms.py
@@ -81,13 +81,12 @@ float4 main() : SV_Target0 {
 """
 
 @inside_glslc_testsuite('OptionFAutoBindUniforms')
-class UniformBindingsNotCreatedByDefault(expect.ValidAssemblyFileWithoutSubstr):
-    """Tests that the compiler does not generate bindings for uniforms by default."""
+class UniformBindingsNotCreatedByDefault(expect.ErrorMessageSubstr):
+    """Tests that compilation fails when uniforms have no binding."""
 
     shader = FileShader(GLSL_SHADER_WITH_UNIFORMS_WITHOUT_BINDINGS, '.vert')
     glslc_args = ['-S', shader]
-    # Sufficient to just check one of the uniforms.
-    unexpected_assembly_substr = "OpDecorate %my_sam Binding"
+    expected_error_substr = "sampler/texture/image requires layout(binding=X)"
 
 
 @inside_glslc_testsuite('OptionFAutoBindUniforms')

--- a/glslc/test/option_flimit.py
+++ b/glslc/test/option_flimit.py
@@ -21,8 +21,8 @@ from placeholder import FileShader
 def shader_source_with_tex_offset(offset):
     """Returns a vertex shader using a texture access with the given offset."""
 
-    return """#version 150
-              uniform sampler1D tex;
+    return """#version 450
+              layout (binding=0) uniform sampler1D tex;
               void main() { vec4 x = textureOffset(tex, 1.0, """ + str(offset) + "); }"
 
 

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -1393,8 +1393,8 @@ TEST(EntryPointTest, LangHlslOnHlslVertexSucceedsWithGivenEntryPointName) {
 std::string ShaderWithTexOffset(int offset) {
   std::ostringstream oss;
   oss <<
-    "#version 150\n"
-    "uniform sampler1D tex;\n"
+    "#version 450\n"
+    "layout (binding=0) uniform sampler1D tex;\n"
     "void main() { vec4 x = textureOffset(tex, 1.0, " << offset << "); }\n";
   return oss.str();
 }
@@ -1440,29 +1440,12 @@ TEST_F(CompileStringTest, LimitsTexelOffsetHigherMaximum) {
                                   options_.get()));
 }
 
-TEST_F(CompileStringWithOptionsTest,
-       UniformsWithoutBindingsHaveNoBindingsByDefault) {
-  const std::string disassembly_text = CompilationOutput(
-      kShaderWithUniformsWithoutBindings, shaderc_glsl_vertex_shader,
-      options_.get(), OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_tex Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_sam Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_img Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_imbuf Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_ubo Binding")));
-}
-
-TEST_F(CompileStringWithOptionsTest,
-       UniformsWithoutBindingsOptionSetNoBindingsHaveNoBindings) {
-  shaderc_compile_options_set_auto_bind_uniforms(options_.get(), false);
-  const std::string disassembly_text = CompilationOutput(
-      kShaderWithUniformsWithoutBindings, shaderc_glsl_vertex_shader,
-      options_.get(), OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_tex Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_sam Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_img Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_imbuf Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_ubo Binding")));
+TEST_F(CompileStringWithOptionsTest, UniformsWithoutBindingsFailCompilation) {
+  const std::string errors =
+      CompilationErrors(kShaderWithUniformsWithoutBindings,
+                        shaderc_glsl_vertex_shader, options_.get());
+  EXPECT_THAT(errors,
+              HasSubstr("sampler/texture/image requires layout(binding=X)"));
 }
 
 TEST_F(CompileStringWithOptionsTest,
@@ -1572,26 +1555,6 @@ TEST_F(CompileStringWithOptionsTest, SetBindingBaseSurvivesCloning) {
   EXPECT_THAT(disassembly_text, HasSubstr("OpDecorate %my_img Binding 60"));
   EXPECT_THAT(disassembly_text, HasSubstr("OpDecorate %my_imbuf Binding 61"));
   EXPECT_THAT(disassembly_text, HasSubstr("OpDecorate %my_ubo Binding 70"));
-}
-
-TEST_F(CompileStringWithOptionsTest, SetBindingBaseIgnoredWhenNotAutoBinding) {
-  shaderc_compile_options_set_auto_bind_uniforms(options_.get(), false);
-  shaderc_compile_options_set_binding_base(options_.get(),
-                                           shaderc_uniform_kind_texture, 40);
-  shaderc_compile_options_set_binding_base(options_.get(),
-                                           shaderc_uniform_kind_sampler, 50);
-  shaderc_compile_options_set_binding_base(options_.get(),
-                                           shaderc_uniform_kind_image, 60);
-  shaderc_compile_options_set_binding_base(options_.get(),
-                                           shaderc_uniform_kind_buffer, 70);
-  const std::string disassembly_text = CompilationOutput(
-      kShaderWithUniformsWithoutBindings, shaderc_glsl_vertex_shader,
-      options_.get(), OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_tex Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_sam Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_img Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_imbuf Binding")));
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorate %my_ubo Binding")));
 }
 
 TEST(Compiler, IncludeWithoutOptionsReturnsValidError) {


### PR DESCRIPTION
Either supply a binding via layout annotation in the shader,
or use the auto-map-uniforms option.

This goes along with a refresh of google/glslang from upstream.  Bots will fail on this PR since they won't pick up the Glslang changes in https://github.com/KhronosGroup/glslang/pull/1256