### PR TITLE
AppVeyor packaging: debug DLL name no longer has extra "d"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,13 +55,11 @@ test_script:
   - ctest -C %CONFIGURATION% --output-on-failure
 
 after_test:
-  # For debug build, the generated dll has a postfix "d" in its name.
   - ps: >-
+      $env:SHADERC_DLL="shaderc_shared.dll"
       If ($env:configuration -Match "Debug") {
-        $env:SHADERC_DLL="shaderc_sharedd.dll"
         $env:ZIP_FILENAME="shaderc-tot-windows-x64-debug.zip"
       } Else {
-        $env:SHADERC_DLL="shaderc_shared.dll"
         $env:ZIP_FILENAME="shaderc-tot-windows-x64-release.zip"
       }
   - cp libshaderc\%CONFIGURATION%\%SHADERC_DLL% install\lib\


### PR DESCRIPTION
Upstream googletest has fixed its
https://github.com/google/googletest/issues/1268
so it no longer "pollutes" the cmake environment of surrounding
projects (like Shaderc) to add that extra "d".