### PR TITLE
Glslang generator version 6

### DIFF
--- a/glslc/test/assembly.py
+++ b/glslc/test/assembly.py
@@ -21,7 +21,7 @@ def assembly_comments():
     return """
     ; SPIR-V
     ; Version: 1.0
-    ; Generator: Google Shaderc over Glslang; 5
+    ; Generator: Google Shaderc over Glslang; 6
     ; Bound: 6
     ; Schema: 0"""
 

--- a/glslc/test/expect.py
+++ b/glslc/test/expect.py
@@ -170,7 +170,7 @@ class CorrectObjectFilePreamble(GlslCTest):
                 return False, 'Incorrect SPV binary: wrong version number'
             # Shaderc-over-Glslang (0x000d....) or
             # SPIRV-Tools (0x0007....) generator number
-            if read_word(preamble, 2, little_endian) != 0x000d0005 and \
+            if read_word(preamble, 2, little_endian) != 0x000d0006 and \
                     read_word(preamble, 2, little_endian) != 0x00070000:
                 return False, ('Incorrect SPV binary: wrong generator magic '
                                'number')

--- a/glslc/test/option_dash_cap_O.py
+++ b/glslc/test/option_dash_cap_O.py
@@ -23,7 +23,7 @@ EMPTY_SHADER_IN_CWD = Directory('.', [File('shader.vert', MINIMAL_SHADER)])
 ASSEMBLY_WITH_DEBUG = [
     '; SPIR-V\n',
     '; Version: 1.0\n',
-    '; Generator: Google Shaderc over Glslang; 5\n',
+    '; Generator: Google Shaderc over Glslang; 6\n',
     '; Bound: 6\n',
     '; Schema: 0\n',
     '               OpCapability Shader\n',
@@ -44,7 +44,7 @@ ASSEMBLY_WITH_DEBUG = [
 ASSEMBLY_WITHOUT_DEBUG = [
     '; SPIR-V\n',
     '; Version: 1.0\n',
-    '; Generator: Google Shaderc over Glslang; 5\n',
+    '; Generator: Google Shaderc over Glslang; 6\n',
     '; Bound: 6\n',
     '; Schema: 0\n',
     '               OpCapability Shader\n',

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -189,7 +189,7 @@ const char kVertexOnlyShaderWithInvalidPragma[] =
 const char* kMinimalShaderDisassemblySubstrings[] = {
     "; SPIR-V\n"
     "; Version: 1.0\n"
-    "; Generator: Google Shaderc over Glslang; 5\n"
+    "; Generator: Google Shaderc over Glslang; 6\n"
     "; Bound:",
 
     "               OpCapability Shader\n",
@@ -201,7 +201,7 @@ const char* kMinimalShaderDisassemblySubstrings[] = {
 const char kMinimalShaderAssembly[] = R"(
     ; SPIR-V
     ; Version: 1.0
-    ; Generator: Google Shaderc over Glslang; 5
+    ; Generator: Google Shaderc over Glslang; 6
     ; Bound: 6
     ; Schema: 0
 


### PR DESCRIPTION
Reverses previous change.

React to today's update to Glslang.
https://github.com/KhronosGroup/glslang/commit/ac3707921ed313eaba1c206e8113b85fef054c34

This is required to update google/glslang