### PR TITLE
Support setting target environment version, e.g. Vulkan 1.1

### DIFF
--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -217,16 +217,20 @@ follow the version specified by `-std=`.
 ==== `--target-env=`
 
 `--target-env=<value>` lets you specify a target environment on the command line.
-This affects the generation of warnings and errors. ``<value>`` can be one of
+This affects the generation of warnings and errors. The ``<value>`` can be one of
 the following:
 
-* `vulkan`: create SPIR-V under Vulkan semantics.
-* `opengl`: create SPIR-V under OpenGL semantics.
+* `vulkan`: create SPIR-V under Vulkan 1.0 semantics.
+* `vulkan1.0`: create SPIR-V under Vulkan 1.0 semantics.
+* `vulkan1.1`: create SPIR-V under Vulkan 1.1 semantics.
+* `opengl`: create SPIR-V under OpenGL 4.5 semantics.
+* `opengl4.5`: create SPIR-V under OpenGL 4.5 semantics.
 * `opengl_compat`: create SPIR-V under OpenGL semantics, including compatibility
   profile functions.
 
-By default, the ``<value>`` is set to `vulkan` and the compiler creates SPIR-V
-under Vulkan semantics.
+Generated code uses SPIR-V 1.0, except that code compiled for Vulkan 1.1 uses SPIR-V 1.3.
+
+If this option is not specified, a default of `vulkan1.0` is used.
 
 ==== `-x`
 

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -135,9 +135,14 @@ Options:
                     generation.
   -S                Only run preprocess and compilation steps.
   --target-env=<environment>
-                    Set the target shader environment, and the semantics
-                    of warnings and errors. Valid values are 'opengl',
-                    'opengl_compat' and 'vulkan'. The default value is 'vulkan'.
+                    Set the target client environment, and the semantics
+                    of warnings and errors.  An optional suffix can specify
+                    the client version.  Values are:
+                        vulkan1.0       # The default
+                        vulkan1.1
+                        vulkan          # Same as vulkan1.0
+                        opengl4.5
+                        opengl          # Same as opengl4.5
   -w                Suppresses all warning messages.
   -Werror           Treat all warnings as errors.
   -x <language>     Treat subsequent input files as having type <language>.
@@ -432,10 +437,20 @@ int main(int argc, char** argv) {
       shaderc_target_env target_env = shaderc_target_env_default;
       const string_piece target_env_str =
           arg.substr(std::strlen("--target-env="));
+      uint32_t version = 0;  // Will default appropriately.
       if (target_env_str == "vulkan") {
         target_env = shaderc_target_env_vulkan;
+      } else if (target_env_str == "vulkan1.0") {
+        target_env = shaderc_target_env_vulkan;
+        version = shaderc_env_version_vulkan_1_0;
+      } else if (target_env_str == "vulkan1.1") {
+        target_env = shaderc_target_env_vulkan;
+        version = shaderc_env_version_vulkan_1_1;
       } else if (target_env_str == "opengl") {
         target_env = shaderc_target_env_opengl;
+      } else if (target_env_str == "opengl4.5") {
+        target_env = shaderc_target_env_opengl;
+        version = shaderc_env_version_opengl_4_5;
       } else if (target_env_str == "opengl_compat") {
         target_env = shaderc_target_env_opengl_compat;
       } else {
@@ -444,7 +459,7 @@ int main(int argc, char** argv) {
                   << std::endl;
         return 1;
       }
-      compiler.options().SetTargetEnvironment(target_env, 0);
+      compiler.options().SetTargetEnvironment(target_env, version);
     } else if (arg.starts_with("-mfmt=")) {
       const string_piece binary_output_format =
           arg.substr(std::strlen("-mfmt="));

--- a/glslc/test/expect.py
+++ b/glslc/test/expect.py
@@ -116,7 +116,7 @@ class NoGeneratedFiles(GlslCTest):
 class CorrectObjectFilePreamble(GlslCTest):
     """Provides methods for verifying preamble for a SPV object file."""
 
-    def verify_object_file_preamble(self, filename):
+    def verify_object_file_preamble(self, filename, spv_version = 0x10000):
         """Checks that the given SPIR-V binary file has correct preamble."""
 
         def read_word(binary, index, little_endian):
@@ -166,7 +166,8 @@ class CorrectObjectFilePreamble(GlslCTest):
             version = read_word(preamble, 1, little_endian)
             # TODO(dneto): Recent Glslang uses version word 0 for opengl_compat
             # profile
-            if version != 0x00010000 and version != 0:
+
+            if version != spv_version and version != 0:
                 return False, 'Incorrect SPV binary: wrong version number'
             # Shaderc-over-Glslang (0x000d....) or
             # SPIRV-Tools (0x0007....) generator number
@@ -203,8 +204,8 @@ class CorrectAssemblyFilePreamble(GlslCTest):
 
 
 class ValidObjectFile(SuccessfulReturn, CorrectObjectFilePreamble):
-    """Mixin class for checking that every input file generates a valid object
-    file following the object file naming rule, and there is no output on
+    """Mixin class for checking that every input file generates a valid SPIR-V 1.0
+    object file following the object file naming rule, and there is no output on
     stdout/stderr."""
 
     def check_object_file_preamble(self, status):
@@ -212,6 +213,22 @@ class ValidObjectFile(SuccessfulReturn, CorrectObjectFilePreamble):
             object_filename = get_object_filename(input_filename)
             success, message = self.verify_object_file_preamble(
                 os.path.join(status.directory, object_filename))
+            if not success:
+                return False, message
+        return True, ''
+
+
+class ValidObjectFile1_3(SuccessfulReturn, CorrectObjectFilePreamble):
+    """Mixin class for checking that every input file generates a valid SPIR-V 1.3
+    object file following the object file naming rule, and there is no output on
+    stdout/stderr."""
+
+    def check_object_file_preamble(self, status):
+        for input_filename in status.input_filenames:
+            object_filename = get_object_filename(input_filename)
+            success, message = self.verify_object_file_preamble(
+                os.path.join(status.directory, object_filename),
+                0x10300)
             if not success:
                 return False, message
         return True, ''

--- a/glslc/test/option_target_env.py
+++ b/glslc/test/option_target_env.py
@@ -95,13 +95,6 @@ class TestTargetEnvEqVulkanWithVulkan1_0ShaderSucceeds(expect.ValidObjectFile):
 
 
 @inside_glslc_testsuite('OptionTargetEnv')
-class TestTargetEnvEqVulkan1_0WithVulkan1_1ShaderFails(expect.ErrorMessageSubstr):
-    shader = FileShader(vulkan_compute_subgroup_shader(), '.comp')
-    glslc_args = ['--target-env=vulkan1.0', '-c', shader]
-    expected_error_substr = "error: 'subgroup op' : requires SPIR-V 1.3"
-
-
-@inside_glslc_testsuite('OptionTargetEnv')
 class TestTargetEnvEqVulkan1_0WithVulkan1_0ShaderSucceeds(expect.ValidObjectFile):
     """Tests that compiling a Vulkan-specific Vulkan 1.0 shader succeeds with
     --target-env=vulkan1.0"""
@@ -117,9 +110,9 @@ class TestTargetEnvEqVulkan1_0WithVulkan1_1ShaderFails(expect.ErrorMessageSubstr
 
 
 @inside_glslc_testsuite('OptionTargetEnv')
-class TestTargetEnvEqVulkan1_1WithVulkan1_0ShaderSucceeds(expect.ValidObjectFile):
+class TestTargetEnvEqVulkan1_1WithVulkan1_0ShaderSucceeds(expect.ValidObjectFile1_3):
     shader = FileShader(vulkan_vertex_shader(), '.vert')
-    glslc_args = ['--target-env=vulkan1.0', '-c', shader]
+    glslc_args = ['--target-env=vulkan1.1', '-c', shader]
 
 
 @inside_glslc_testsuite('OptionTargetEnv')

--- a/glslc/test/option_target_env.py
+++ b/glslc/test/option_target_env.py
@@ -35,6 +35,13 @@ def vulkan_vertex_shader():
 void main() { int t = gl_VertexIndex; }"""
 
 
+def vulkan_compute_subgroup_shader():
+    """Returns a compute shader that requires Vulkan 1.1"""
+    return """#version 450
+              #extension GL_KHR_shader_subgroup_basic : enable
+              void main() { subgroupBarrier(); }"""
+
+
 @inside_glslc_testsuite('OptionTargetEnv')
 class TestTargetEnvEqOpenglCompatWithOpenGlCompatShader(expect.ValidObjectFile):
     """Tests that compiling OpenGL Compatibility Fragment shader with
@@ -80,11 +87,58 @@ class TestDefaultTargetEnvWithVulkanShader(expect.ValidObjectFile):
 
 
 @inside_glslc_testsuite('OptionTargetEnv')
-class TestTargetEnvEqVulkanWithVulkanShader(expect.ValidObjectFile):
-    """Tests that compiling a Vulkan-specific shader succeeds with
+class TestTargetEnvEqVulkanWithVulkan1_0ShaderSucceeds(expect.ValidObjectFile):
+    """Tests that compiling a Vulkan-specific Vulkan 1.0 shader succeeds with
     --target-env=vulkan"""
     shader = FileShader(vulkan_vertex_shader(), '.vert')
     glslc_args = ['--target-env=vulkan', '-c', shader]
+
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqVulkan1_0WithVulkan1_1ShaderFails(expect.ErrorMessageSubstr):
+    shader = FileShader(vulkan_compute_subgroup_shader(), '.comp')
+    glslc_args = ['--target-env=vulkan1.0', '-c', shader]
+    expected_error_substr = "error: 'subgroup op' : requires SPIR-V 1.3"
+
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqVulkan1_0WithVulkan1_0ShaderSucceeds(expect.ValidObjectFile):
+    """Tests that compiling a Vulkan-specific Vulkan 1.0 shader succeeds with
+    --target-env=vulkan1.0"""
+    shader = FileShader(vulkan_vertex_shader(), '.vert')
+    glslc_args = ['--target-env=vulkan1.0', '-c', shader]
+
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqVulkan1_0WithVulkan1_1ShaderFails(expect.ErrorMessageSubstr):
+    shader = FileShader(vulkan_compute_subgroup_shader(), '.comp')
+    glslc_args = ['--target-env=vulkan1.0', '-c', shader]
+    expected_error_substr = "error: 'subgroup op' : requires SPIR-V 1.3"
+
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqVulkan1_1WithVulkan1_0ShaderSucceeds(expect.ValidObjectFile):
+    shader = FileShader(vulkan_vertex_shader(), '.vert')
+    glslc_args = ['--target-env=vulkan1.0', '-c', shader]
+
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqVulkan1_1WithVulkan1_1ShaderSucceeds(expect.ValidObjectFile1_3):
+    shader = FileShader(vulkan_compute_subgroup_shader(), '.comp')
+    glslc_args = ['--target-env=vulkan1.1', '-c', shader]
+
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqOpenGL4_5WithOpenGLShaderSucceeds(expect.ValidObjectFile):
+    shader = FileShader(opengl_vertex_shader(), '.vert')
+    glslc_args = ['--target-env=opengl4.5', '-c', shader]
+
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqOpenGL4_6WithOpenGLShaderFailsUnsupported(expect.ErrorMessageSubstr):
+    shader = FileShader(opengl_vertex_shader(), '.vert')
+    glslc_args = ['--target-env=opengl4.6', '-c', shader]
+    expected_error_substr = "invalid value 'opengl4.6' in '--target-env=opengl4.6'"
 
 
 # Note: Negative tests are covered in the libshaderc_util unit tests.

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -140,9 +140,14 @@ Options:
                     generation.
   -S                Only run preprocess and compilation steps.
   --target-env=<environment>
-                    Set the target shader environment, and the semantics
-                    of warnings and errors. Valid values are 'opengl',
-                    'opengl_compat' and 'vulkan'. The default value is 'vulkan'.
+                    Set the target client environment, and the semantics
+                    of warnings and errors.  An optional suffix can specify
+                    the client version.  Values are:
+                        vulkan1.0       # The default
+                        vulkan1.1
+                        vulkan          # Same as vulkan1.0
+                        opengl4.5
+                        opengl          # Same as opengl4.5
   -w                Suppresses all warning messages.
   -Werror           Treat all warnings as errors.
   -x <language>     Treat subsequent input files as having type <language>.

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -80,13 +80,27 @@ typedef enum {
 } shaderc_shader_kind;
 
 typedef enum {
-  shaderc_target_env_vulkan,         // create SPIR-V under Vulkan semantics
-  shaderc_target_env_opengl,         // create SPIR-V under OpenGL semantics
+  shaderc_target_env_vulkan,  // create SPIR-V under Vulkan semantics
+  shaderc_target_env_opengl,  // create SPIR-V under OpenGL semantics
+  // NOTE: SPIR-V coide generation is not supported for shaders under OpenGL
+  // compatibility profile.
   shaderc_target_env_opengl_compat,  // create SPIR-V under OpenGL semantics,
                                      // including compatibility profile
                                      // functions
   shaderc_target_env_default = shaderc_target_env_vulkan
 } shaderc_target_env;
+
+typedef enum {
+  // For Vulkan, use Vulkan's mapping of version numbers to integers.
+  // See vulkan.h
+  shaderc_env_version_vulkan_1_0 = (((uint32_t)1 << 22)),
+  shaderc_env_version_vulkan_1_1 = (((uint32_t)1 << 22) | (1 << 12)),
+  // For OpenGL, use the number from #version in shaders.
+  // TODO(dneto): Currently no difference between OpenGL 4.5 andf 4.6.
+  // See glslang/Standalone/Standalone.cpp
+  // TODO(dneto): Glslang doesn't accept a OpenGL client version of 460.
+  shaderc_env_version_opengl_4_5 = 450,
+} shaderc_env_version;
 
 typedef enum {
   shaderc_profile_none,  // Used if and only if GLSL version did not specify

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -82,7 +82,7 @@ typedef enum {
 typedef enum {
   shaderc_target_env_vulkan,  // create SPIR-V under Vulkan semantics
   shaderc_target_env_opengl,  // create SPIR-V under OpenGL semantics
-  // NOTE: SPIR-V coide generation is not supported for shaders under OpenGL
+  // NOTE: SPIR-V code generation is not supported for shaders under OpenGL
   // compatibility profile.
   shaderc_target_env_opengl_compat,  // create SPIR-V under OpenGL semantics,
                                      // including compatibility profile
@@ -96,7 +96,7 @@ typedef enum {
   shaderc_env_version_vulkan_1_0 = (((uint32_t)1 << 22)),
   shaderc_env_version_vulkan_1_1 = (((uint32_t)1 << 22) | (1 << 12)),
   // For OpenGL, use the number from #version in shaders.
-  // TODO(dneto): Currently no difference between OpenGL 4.5 andf 4.6.
+  // TODO(dneto): Currently no difference between OpenGL 4.5 and 4.6.
   // See glslang/Standalone/Standalone.cpp
   // TODO(dneto): Glslang doesn't accept a OpenGL client version of 460.
   shaderc_env_version_opengl_4_5 = 450,
@@ -397,7 +397,9 @@ SHADERC_EXPORT void shaderc_compile_options_set_suppress_warnings(
 
 // Sets the target shader environment, affecting which warnings or errors will
 // be issued.  The version will be for distinguishing between different versions
-// of the target environment.  "0" is the only supported version at this point
+// of the target environment.  The version value should be either 0 or
+// a value listed in shaderc_env_version.  The 0 value maps to Vulkan 1.0 if
+// |target| is Vulkan, and it maps to OpenGL 4.5 if |target| is OpenGL.
 SHADERC_EXPORT void shaderc_compile_options_set_target_env(
     shaderc_compile_options_t options,
     shaderc_target_env target,

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -229,10 +229,10 @@ class CompileOptions {
   }
 
   // Sets the target shader environment, affecting which warnings or errors will
-  // be issued.
-  // The version will be for distinguishing between different versions of the
-  // target environment.
-  // "0" is the only supported version at this point
+  // be issued.  The version will be for distinguishing between different
+  // versions of the target environment.  The version value should be either 0
+  // or a value listed in shaderc_env_version.  The 0 value maps to Vulkan 1.0
+  // if |target| is Vulkan, and it maps to OpenGL 4.5 if |target| is OpenGL.
   void SetTargetEnvironment(shaderc_target_env target, uint32_t version) {
     shaderc_compile_options_set_target_env(options_, target, version);
   }

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -248,6 +248,17 @@ const char kHlslFragShaderWithRegisters[] =
          return float4(t4.Load(0) + t5.Load(1));
        })";
 
+// A GLSL compute shader using a regular barrier.
+const char kGlslShaderComputeBarrier[] =
+    R"(#version 450
+       void main() { barrier(); })";
+
+// A GLSL compute shader using the Subgroups feature.
+const char kGlslShaderComputeSubgroupBarrier[] =
+    R"(#version 450
+       #extension GL_KHR_shader_subgroup_basic : enable
+       void main() { subgroupBarrier(); })";
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -298,6 +298,7 @@ shaderc_util::Compiler::Stage GetStage(shaderc_shader_kind kind) {
 
 struct shaderc_compile_options {
   shaderc_target_env target_env = shaderc_target_env_default;
+  uint32_t target_env_version = 0;
   shaderc_util::Compiler compiler;
   shaderc_include_resolve_fn include_resolver = nullptr;
   shaderc_include_result_release_fn include_result_releaser = nullptr;
@@ -391,10 +392,8 @@ void shaderc_compile_options_set_suppress_warnings(
 void shaderc_compile_options_set_target_env(shaderc_compile_options_t options,
                                             shaderc_target_env target,
                                             uint32_t version) {
-  // "version" reserved for future use, intended to distinguish between
-  // different versions of a target environment
   options->target_env = target;
-  options->compiler.SetTargetEnv(GetCompilerTargetEnv(target));
+  options->compiler.SetTargetEnv(GetCompilerTargetEnv(target), version);
 }
 
 void shaderc_compile_options_set_warnings_as_errors(

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -1076,11 +1076,11 @@ TEST_F(CompileStringWithOptionsTest, IfDefCompileOption) {
                                  shaderc_glsl_vertex_shader, options_.get()));
 }
 
-TEST_F(CompileStringWithOptionsTest,
-       TargetEnvRespectedWhenCompilingOpenGLCompatibilityShaderToBinary) {
-  // Confirm that kOpenGLCompatibilityFragmentShader compiles with
-  // shaderc_target_env_opengl_compat.  When targeting OpenGL core profile
-  // or Vulkan, it should fail to compile.
+TEST_F(
+    CompileStringWithOptionsTest,
+    TargetEnvRespectedWhenCompilingOpenGLCompatibilityShaderToBinaryAndAlwaysFails) {
+  // Glslang does not support generating SPIR-V for compatibility profile
+  // shaders.
 
   EXPECT_FALSE(CompilesToValidSpv(compiler_, kOpenGLCompatibilityFragmentShader,
                                   shaderc_glsl_fragment_shader,
@@ -1088,8 +1088,9 @@ TEST_F(CompileStringWithOptionsTest,
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_opengl_compat, 0);
-  EXPECT_TRUE(CompilesToValidSpv(compiler_, kOpenGLCompatibilityFragmentShader,
-                                 shaderc_glsl_fragment_shader, options_.get()));
+  EXPECT_FALSE(CompilesToValidSpv(compiler_, kOpenGLCompatibilityFragmentShader,
+                                  shaderc_glsl_fragment_shader,
+                                  options_.get()));
 
   shaderc_compile_options_set_target_env(options_.get(),
                                          shaderc_target_env_opengl, 0);
@@ -1118,8 +1119,42 @@ TEST_F(CompileStringWithOptionsTest,
                                          shaderc_target_env_opengl, 0);
   EXPECT_TRUE(CompilesToValidSpv(compiler_, kOpenGLVertexShader,
                                  shaderc_glsl_vertex_shader, options_.get()));
+}
 
-  // TODO(dneto): Check what happens when targeting Vulkan.
+TEST_F(CompileStringWithOptionsTest,
+       TargetEnvRespectedWhenCompilingVulkan1_0ShaderToVulkan1_0Succeeds) {
+  shaderc_compile_options_set_target_env(options_.get(),
+                                         shaderc_target_env_vulkan,
+                                         shaderc_env_version_vulkan_1_0);
+  EXPECT_TRUE(CompilesToValidSpv(compiler_, kGlslShaderComputeBarrier,
+                                 shaderc_glsl_compute_shader, options_.get()));
+}
+
+TEST_F(CompileStringWithOptionsTest,
+       TargetEnvRespectedWhenCompilingVulkan1_0ShaderToVulkan1_1Succeeds) {
+  shaderc_compile_options_set_target_env(options_.get(),
+                                         shaderc_target_env_vulkan,
+                                         shaderc_env_version_vulkan_1_1);
+  EXPECT_TRUE(CompilesToValidSpv(compiler_, kGlslShaderComputeBarrier,
+                                 shaderc_glsl_compute_shader, options_.get()));
+}
+
+TEST_F(CompileStringWithOptionsTest,
+       TargetEnvRespectedWhenCompilingVulkan1_1ShaderToVulkan1_0Fails) {
+  shaderc_compile_options_set_target_env(options_.get(),
+                                         shaderc_target_env_vulkan,
+                                         shaderc_env_version_vulkan_1_0);
+  EXPECT_FALSE(CompilesToValidSpv(compiler_, kGlslShaderComputeSubgroupBarrier,
+                                  shaderc_glsl_compute_shader, options_.get()));
+}
+
+TEST_F(CompileStringWithOptionsTest,
+       TargetEnvRespectedWhenCompilingVulkan1_1ShaderToVulkan1_1Succeeds) {
+  shaderc_compile_options_set_target_env(options_.get(),
+                                         shaderc_target_env_vulkan,
+                                         shaderc_env_version_vulkan_1_1);
+  EXPECT_TRUE(CompilesToValidSpv(compiler_, kGlslShaderComputeSubgroupBarrier,
+                                 shaderc_glsl_compute_shader, options_.get()));
 }
 
 TEST_F(CompileStringWithOptionsTest,

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -31,6 +31,9 @@
 #include "resources.h"
 #include "string_piece.h"
 
+// Fix a typo in glslang/Public/ShaderLang.h
+#define EShTargetClientVersion EshTargetClientVersion
+
 namespace shaderc_util {
 
 // To break recursive including. This header is already included in
@@ -103,9 +106,18 @@ class Compiler {
 
   // Target environment.
   enum class TargetEnv {
-    Vulkan,
-    OpenGL,
+    Vulkan,  // Default to Vuilkan 1.0
+    OpenGL,  // Default to OpenGL
     OpenGLCompat,
+  };
+
+  // Target environment versions.  These bnumbgers match those used by Glslang.
+  enum class TargetEnvVersion : uint32_t {
+    // For Vulkan, use numbering schmee from vulkan.h
+    Vulkan_1_0 = ((1 << 22)),              // Default to Vuilkan 1.0
+    Vulkan_1_1 = ((1 << 22) | (1 << 12)),  // Default to Vuilkan 1.0
+    // For Op[enGL, use the numbering from #version in shaders.
+    OpenGL_4_5 = 450,
   };
 
   enum class OutputType {
@@ -180,6 +192,7 @@ class Compiler {
         generate_debug_info_(false),
         enabled_opt_passes_(),
         target_env_(TargetEnv::Vulkan),
+        target_env_version_(0),  // Resolve default later.
         source_language_(SourceLanguage::GLSL),
         limits_(kDefaultTBuiltInResource),
         auto_bind_uniforms_(false),
@@ -214,8 +227,9 @@ class Compiler {
   void AddMacroDefinition(const char* macro, size_t macro_length,
                           const char* definition, size_t definition_length);
 
-  // Sets the target environment.
-  void SetTargetEnv(TargetEnv env);
+  // Sets the target environment, including version.
+  // 0 means the default version for the
+  void SetTargetEnv(TargetEnv env, uint32_t version = 0);
 
   // Sets the souce language.
   void SetSourceLanguage(SourceLanguage lang);
@@ -428,6 +442,12 @@ class Compiler {
   // messages as well as the set of available builtins, as per the
   // implementation of glslang.
   TargetEnv target_env_;
+
+  // The version number of the target environment.  The numbering scheme is
+  // particular to each target environment.  If this is 0, then use a default
+  // for that particular target environment. See libshaders/shaderc/shaderc.h
+  // for those defaults.
+  uint32_t target_env_version_;
 
   // The source language.  Defaults to GLSL.
   SourceLanguage source_language_;

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -106,17 +106,17 @@ class Compiler {
 
   // Target environment.
   enum class TargetEnv {
-    Vulkan,  // Default to Vuilkan 1.0
-    OpenGL,  // Default to OpenGL
-    OpenGLCompat,
+    Vulkan,  // Default to Vulkan 1.0
+    OpenGL,  // Default to OpenGL 4.5
+    OpenGLCompat, // Deprecated.
   };
 
-  // Target environment versions.  These bnumbgers match those used by Glslang.
+  // Target environment versions.  These numbers match those used by Glslang.
   enum class TargetEnvVersion : uint32_t {
-    // For Vulkan, use numbering schmee from vulkan.h
-    Vulkan_1_0 = ((1 << 22)),              // Default to Vuilkan 1.0
-    Vulkan_1_1 = ((1 << 22) | (1 << 12)),  // Default to Vuilkan 1.0
-    // For Op[enGL, use the numbering from #version in shaders.
+    // For Vulkan, use numbering scheme from vulkan.h
+    Vulkan_1_0 = ((1 << 22)),              // Default to Vulkan 1.0
+    Vulkan_1_1 = ((1 << 22) | (1 << 12)),  // Default to Vulkan 1.0
+    // For OpenGL, use the numbering from #version in shaders.
     OpenGL_4_5 = 450,
   };
 
@@ -227,8 +227,10 @@ class Compiler {
   void AddMacroDefinition(const char* macro, size_t macro_length,
                           const char* definition, size_t definition_length);
 
-  // Sets the target environment, including version.
-  // 0 means the default version for the
+  // Sets the target environment, including version.  The version value should
+  // be 0 or one of the values from TargetEnvVersion.  The 0 version value maps
+  // to Vulkan 1.0 if the target environment is Vulkan, and it maps to OpenGL
+  // 4.5 if the target environment is OpenGL.
   void SetTargetEnv(TargetEnv env, uint32_t version = 0);
 
   // Sets the souce language.

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -186,7 +186,7 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   std::vector<uint32_t>& compilation_output_data = std::get<1>(result_tuple);
   size_t& compilation_output_data_size_in_bytes = std::get<2>(result_tuple);
 
-  // Check target envirohnment.
+  // Check target environment.
   const auto target_client_info =
       GetGlslangClientInfo(target_env_, target_env_version_);
   if (!target_client_info.valid_client) {

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -93,6 +93,53 @@ EShMessages GetMessageRules(shaderc_util::Compiler::TargetEnv env,
   return result;
 }
 
+// A GlslangClientInfo captures target client version and desired SPIR-V
+// version.
+struct GlslangClientInfo {
+  bool valid_client = false;
+  glslang::EShClient client = glslang::EShClientNone;
+  bool valid_client_version = false;
+  glslang::EShTargetClientVersion client_version;
+  glslang::EShTargetLanguage target_language = glslang::EShTargetSpv;
+  glslang::EShTargetLanguageVersion target_language_version =
+      glslang::EShTargetSpv_1_0;
+};
+
+// Returns the mappings to Glslang client, client version, and SPIR-V version.
+// Also indicates whether the input values were valid.
+GlslangClientInfo GetGlslangClientInfo(shaderc_util::Compiler::TargetEnv env,
+                                       uint32_t version) {
+  GlslangClientInfo result;
+
+  using shaderc_util::Compiler;
+  switch (env) {
+    case Compiler::TargetEnv::Vulkan:
+      result.valid_client = true;
+      result.client = glslang::EShClientVulkan;
+      if (version == 0 ||
+          version == uint32_t(Compiler::TargetEnvVersion::Vulkan_1_0)) {
+        result.client_version = glslang::EShTargetVulkan_1_0;
+        result.valid_client_version = true;
+      } else if (version == uint32_t(Compiler::TargetEnvVersion::Vulkan_1_1)) {
+        result.client_version = glslang::EShTargetVulkan_1_1;
+        result.valid_client_version = true;
+        result.target_language_version = glslang::EShTargetSpv_1_3;
+      }
+      break;
+    case Compiler::TargetEnv::OpenGLCompat:  // TODO(dneto): remove this
+    case Compiler::TargetEnv::OpenGL:
+      result.valid_client = true;
+      result.client = glslang::EShClientOpenGL;
+      if (version == 0 ||
+          version == uint32_t(Compiler::TargetEnvVersion::OpenGL_4_5)) {
+        result.client_version = glslang::EShTargetOpenGL_450;
+        result.valid_client_version = true;
+      }
+      break;
+  }
+  return result;
+}
+
 }  // anonymous namespace
 
 namespace shaderc_util {
@@ -138,6 +185,25 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   bool& succeeded = std::get<0>(result_tuple);
   std::vector<uint32_t>& compilation_output_data = std::get<1>(result_tuple);
   size_t& compilation_output_data_size_in_bytes = std::get<2>(result_tuple);
+
+  // Check target envirohnment.
+  const auto target_client_info =
+      GetGlslangClientInfo(target_env_, target_env_version_);
+  if (!target_client_info.valid_client) {
+    *error_stream << "error:" << error_tag
+                  << ": Invalid target client environment " << int(target_env_);
+    *total_warnings = 0;
+    *total_errors = 1;
+    return result_tuple;
+  }
+  if (!target_client_info.valid_client_version) {
+    *error_stream << "error:" << error_tag << ": Invalid target client version "
+                  << target_env_version_ << " for environment "
+                  << int(target_env_);
+    *total_warnings = 0;
+    *total_errors = 1;
+    return result_tuple;
+  }
 
   auto token = initializer->Acquire();
   EShLanguage used_shader_stage = forced_shader_stage;
@@ -221,6 +287,10 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   shader.setHlslIoMapping(hlsl_iomap_);
   shader.setResourceSetBinding(
       hlsl_explicit_bindings_[static_cast<int>(used_shader_stage)]);
+  shader.setEnvClient(target_client_info.client,
+                      target_client_info.client_version);
+  shader.setEnvTarget(target_client_info.target_language,
+                      target_client_info.target_language_version);
 
   // TODO(dneto): Generate source-level debug info if requested.
   bool success = shader.parse(
@@ -324,7 +394,10 @@ void Compiler::AddMacroDefinition(const char* macro, size_t macro_length,
       definition ? std::string(definition, definition_length) : "";
 }
 
-void Compiler::SetTargetEnv(Compiler::TargetEnv env) { target_env_ = env; }
+void Compiler::SetTargetEnv(Compiler::TargetEnv env, uint32_t version) {
+  target_env_ = env;
+  target_env_version_ = version;
+}
 
 void Compiler::SetSourceLanguage(Compiler::SourceLanguage lang) {
   source_language_ = lang;
@@ -380,6 +453,22 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
   shader.setStringsWithLengthsAndNames(&shader_strings, &shader_lengths,
                                        &string_names, 1);
   shader.setPreamble(shader_preamble.data());
+  auto target_client_info =
+      GetGlslangClientInfo(target_env_, target_env_version_);
+  if (!target_client_info.valid_client) {
+    std::ostringstream os;
+    os << "error:" << error_tag << ": Invalid target client "
+       << int(target_env_);
+    return std::make_tuple(false, "", os.str());
+  }
+  if (!target_client_info.valid_client_version) {
+    std::ostringstream os;
+    os << "error:" << error_tag << ": Invalid target client "
+       << int(target_env_version_) << " for environmnent " << int(target_env_);
+    return std::make_tuple(false, "", os.str());
+  }
+  shader.setEnvClient(target_client_info.client,
+                      target_client_info.client_version);
 
   // The preprocessor might be sensitive to the target environment.
   // So combine the existing rules with the just-give-me-preprocessor-output


### PR DESCRIPTION
NOTE: We no longer can compile OpenGL compatibility profile shaders to SPIR-V.
These will error out.

C and C++ API: Set nontrivial target environment version

Glslc --target-env accepts optional version suffix, e.g. vulkan1.1