### PR TITLE
Use standard SPIRV-Tools transformation recipes

### DIFF
--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -312,6 +312,7 @@ glslang support for generating debug info.
 `-O` specifies which optimization level to use:
 
 * `-O0` means "no optimization". This level generates the most debuggable code.
+* `-O` means the default optimization level for better performance.
 * `-Os` enables optimizations to reduce code size.
 
 ==== `-mfmt=<format>`

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -592,7 +592,10 @@ int main(int argc, char** argv) {
     } else if (arg == "-g") {
       compiler.options().SetGenerateDebugInfo();
     } else if (arg.starts_with("-O")) {
-      if (arg == "-Os") {
+      if (arg == "-O") {
+        compiler.options().SetOptimizationLevel(
+            shaderc_optimization_level_performance);
+      } else if (arg == "-Os") {
         compiler.options().SetOptimizationLevel(
             shaderc_optimization_level_size);
       } else if (arg == "-O0") {

--- a/glslc/test/option_dash_cap_O.py
+++ b/glslc/test/option_dash_cap_O.py
@@ -68,6 +68,14 @@ class TestDashCapO0(expect.ValidFileContents):
     target_filename = 'shader.vert.spvasm'
     expected_file_contents = ASSEMBLY_WITH_DEBUG
 
+@inside_glslc_testsuite('OptionDashCapO')
+class TestDashCapOPerformance(expect.ValidFileContents):
+    """Tests -O works."""
+
+    environment = EMPTY_SHADER_IN_CWD
+    glslc_args = ['-S', '-O', 'shader.vert']
+    target_filename = 'shader.vert.spvasm'
+    expected_file_contents = ASSEMBLY_WITH_DEBUG
 
 @inside_glslc_testsuite('OptionDashCapO')
 class TestDashCapOs(expect.ValidFileContents):

--- a/glslc/test/option_dash_cap_O.py
+++ b/glslc/test/option_dash_cap_O.py
@@ -75,7 +75,7 @@ class TestDashCapOPerformance(expect.ValidFileContents):
     environment = EMPTY_SHADER_IN_CWD
     glslc_args = ['-S', '-O', 'shader.vert']
     target_filename = 'shader.vert.spvasm'
-    expected_file_contents = ASSEMBLY_WITH_DEBUG
+    expected_file_contents = ASSEMBLY_WITHOUT_DEBUG
 
 @inside_glslc_testsuite('OptionDashCapO')
 class TestDashCapOs(expect.ValidFileContents):

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -122,9 +122,9 @@ typedef enum {
 
 // Optimization level.
 typedef enum {
-  shaderc_optimization_level_zero,         // no optimization
-  shaderc_optimization_level_performance,  // optimize towards performance
+  shaderc_optimization_level_zero,  // no optimization
   shaderc_optimization_level_size,  // optimize towards reducing code size
+  shaderc_optimization_level_performance,  // optimize towards performance
 } shaderc_optimization_level;
 
 // Resource limits.

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -122,7 +122,8 @@ typedef enum {
 
 // Optimization level.
 typedef enum {
-  shaderc_optimization_level_zero,  // no optimization
+  shaderc_optimization_level_zero,         // no optimization
+  shaderc_optimization_level_performance,  // optimize towards performance
   shaderc_optimization_level_size,  // optimize towards reducing code size
 } shaderc_optimization_level;
 

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -258,9 +258,13 @@ const char kGlslShaderComputeSubgroupBarrier[] =
     R"(#version 450
        #extension GL_KHR_shader_subgroup_basic : enable
        void main() { subgroupBarrier(); })";
-const char kHlslMultipleFnShader[] =
-    R"(int foo(int param) { return param; }
-       int main(int input : A) : B { return foo(input); })";
+
+const char kGlslMultipleFnShader[] =
+    R"(#version 450
+       layout(location=0) flat in  int inVal;
+       layout(location=0)      out int outVal;
+       int foo(int a) { return a; }
+       void main() { outVal = foo(inVal); })";
 
 #ifdef __cplusplus
 }

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -258,6 +258,9 @@ const char kGlslShaderComputeSubgroupBarrier[] =
     R"(#version 450
        #extension GL_KHR_shader_subgroup_basic : enable
        void main() { subgroupBarrier(); })";
+const char kHlslMultipleFnShader[] =
+    R"(int foo(int param) { return param; }
+       int main(int input : A) : B { return foo(input); })";
 
 #ifdef __cplusplus
 }

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -240,8 +240,9 @@ shaderc_util::Compiler::TargetEnv GetCompilerTargetEnv(shaderc_target_env env) {
 // Returns the Compiler::Limit enum for the given shaderc_limit enum.
 shaderc_util::Compiler::Limit CompilerLimit(shaderc_limit limit) {
   switch (limit) {
-#define RESOURCE(NAME,FIELD,CNAME) \
-     case shaderc_limit_##CNAME: return shaderc_util::Compiler::Limit::NAME;
+#define RESOURCE(NAME, FIELD, CNAME) \
+  case shaderc_limit_##CNAME:        \
+    return shaderc_util::Compiler::Limit::NAME;
 #include "libshaderc_util/resources.inc"
 #undef RESOURCE
     default:
@@ -293,7 +294,6 @@ shaderc_util::Compiler::Stage GetStage(shaderc_shader_kind kind) {
   return static_cast<shaderc_util::Compiler::Stage>(0);
 }
 
-
 }  // anonymous namespace
 
 struct shaderc_compile_options {
@@ -328,8 +328,7 @@ void shaderc_compile_options_add_macro_definition(
 }
 
 void shaderc_compile_options_set_source_language(
-    shaderc_compile_options_t options,
-    shaderc_source_language set_lang) {
+    shaderc_compile_options_t options, shaderc_source_language set_lang) {
   auto lang = shaderc_util::Compiler::SourceLanguage::GLSL;
   if (set_lang == shaderc_source_language_hlsl)
     lang = shaderc_util::Compiler::SourceLanguage::HLSL;
@@ -347,6 +346,9 @@ void shaderc_compile_options_set_optimization_level(
   switch (level) {
     case shaderc_optimization_level_size:
       opt_level = shaderc_util::Compiler::OptimizationLevel::Size;
+      break;
+    case shaderc_optimization_level_performance:
+      opt_level = shaderc_util::Compiler::OptimizationLevel::Performance;
       break;
     default:
       break;
@@ -401,8 +403,8 @@ void shaderc_compile_options_set_warnings_as_errors(
   options->compiler.SetWarningsAsErrors();
 }
 
-void shaderc_compile_options_set_limit(
-    shaderc_compile_options_t options, shaderc_limit limit, int value) {
+void shaderc_compile_options_set_limit(shaderc_compile_options_t options,
+                                       shaderc_limit limit, int value) {
   options->compiler.SetLimit(CompilerLimit(limit), value);
 }
 
@@ -416,8 +418,8 @@ void shaderc_compile_options_set_hlsl_io_mapping(
   options->compiler.SetHlslIoMapping(hlsl_iomap);
 }
 
-void shaderc_compile_options_set_hlsl_offsets(
-    shaderc_compile_options_t options, bool hlsl_offsets) {
+void shaderc_compile_options_set_hlsl_offsets(shaderc_compile_options_t options,
+                                              bool hlsl_offsets) {
   options->compiler.SetHlslOffsets(hlsl_offsets);
 }
 

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -27,9 +27,9 @@
 namespace {
 
 using shaderc::AssemblyCompilationResult;
+using shaderc::CompileOptions;
 using shaderc::PreprocessedSourceCompilationResult;
 using shaderc::SpvCompilationResult;
-using shaderc::CompileOptions;
 using testing::Each;
 using testing::Eq;
 using testing::HasSubstr;
@@ -504,6 +504,15 @@ TEST_F(CppInterface, CompileAndOptimizeWithLevelZero) {
   // Check that we still have debug instructions.
   EXPECT_THAT(disassembly_text, HasSubstr("OpName"));
   EXPECT_THAT(disassembly_text, HasSubstr("OpSource"));
+}
+
+TEST_F(CppInterface, CompileAndOptimizeWithLevelPerformance) {
+  options_.SetOptimizationLevel(shaderc_optimization_level_performance);
+  options_.SetSourceLanguage(shaderc_source_language_hlsl);
+  const std::string disassembly_text =
+      AssemblyOutput(kHlslMultipleFnShader, shaderc_vertex_shader, options_);
+  // Check that we do not have function definition for foo() anymore.
+  EXPECT_THAT(disassembly_text, Not(HasSubstr("%foo = OpFunction")));
 }
 
 TEST_F(CppInterface, CompileAndOptimizeWithLevelSize) {
@@ -1178,10 +1187,10 @@ TEST(
 // offset.
 std::string ShaderWithTexOffset(int offset) {
   std::ostringstream oss;
-  oss <<
-    "#version 450\n"
-    "layout (binding=0) uniform sampler1D tex;\n"
-    "void main() { vec4 x = textureOffset(tex, 1.0, " << offset << "); }\n";
+  oss << "#version 450\n"
+         "layout (binding=0) uniform sampler1D tex;\n"
+         "void main() { vec4 x = textureOffset(tex, 1.0, "
+      << offset << "); }\n";
   return oss.str();
 }
 
@@ -1317,8 +1326,7 @@ TEST_F(CppInterface, GlslDefaultPackingUsed) {
   CompileOptions options;
   const std::string disassembly_text = AssemblyOutput(
       kGlslShaderWeirdPacking, shaderc_glsl_vertex_shader, options);
-  EXPECT_THAT(disassembly_text,
-              HasSubstr("OpMemberDecorate %B 1 Offset 16"));
+  EXPECT_THAT(disassembly_text, HasSubstr("OpMemberDecorate %B 1 Offset 16"));
 }
 
 TEST_F(CppInterface, HlslOffsetsOptionDisableRespected) {
@@ -1326,8 +1334,7 @@ TEST_F(CppInterface, HlslOffsetsOptionDisableRespected) {
   options.SetHlslOffsets(false);
   const std::string disassembly_text = AssemblyOutput(
       kGlslShaderWeirdPacking, shaderc_glsl_vertex_shader, options);
-  EXPECT_THAT(disassembly_text,
-              HasSubstr("OpMemberDecorate %B 1 Offset 16"));
+  EXPECT_THAT(disassembly_text, HasSubstr("OpMemberDecorate %B 1 Offset 16"));
 }
 
 TEST_F(CppInterface, HlslOffsetsOptionEnableRespected) {
@@ -1335,8 +1342,7 @@ TEST_F(CppInterface, HlslOffsetsOptionEnableRespected) {
   options.SetHlslOffsets(true);
   const std::string disassembly_text = AssemblyOutput(
       kGlslShaderWeirdPacking, shaderc_glsl_vertex_shader, options);
-  EXPECT_THAT(disassembly_text,
-              HasSubstr("OpMemberDecorate %B 1 Offset 4"));
+  EXPECT_THAT(disassembly_text, HasSubstr("OpMemberDecorate %B 1 Offset 4"));
 }
 
 TEST_F(CppInterface, HlslRegSetBindingForFragmentRespected) {

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -508,11 +508,10 @@ TEST_F(CppInterface, CompileAndOptimizeWithLevelZero) {
 
 TEST_F(CppInterface, CompileAndOptimizeWithLevelPerformance) {
   options_.SetOptimizationLevel(shaderc_optimization_level_performance);
-  options_.SetSourceLanguage(shaderc_source_language_hlsl);
-  const std::string disassembly_text =
-      AssemblyOutput(kHlslMultipleFnShader, shaderc_vertex_shader, options_);
-  // Check that we do not have function definition for foo() anymore.
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("%foo = OpFunction")));
+  const std::string disassembly_text = AssemblyOutput(
+      kGlslMultipleFnShader, shaderc_glsl_fragment_shader, options_);
+  // Check that we do not have function calls anymore.
+  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpFunctionCall")));
 }
 
 TEST_F(CppInterface, CompileAndOptimizeWithLevelSize) {

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -652,13 +652,11 @@ TEST_F(CompileStringWithOptionsTest, CompileAndOptimizeWithLevelZero) {
 TEST_F(CompileStringWithOptionsTest, CompileAndOptimizeWithLevelPerformance) {
   shaderc_compile_options_set_optimization_level(
       options_.get(), shaderc_optimization_level_performance);
-  shaderc_compile_options_set_source_language(options_.get(),
-                                              shaderc_source_language_hlsl);
   const std::string disassembly_text =
-      CompilationOutput(kHlslMultipleFnShader, shaderc_vertex_shader,
+      CompilationOutput(kGlslMultipleFnShader, shaderc_glsl_fragment_shader,
                         options_.get(), OutputType::SpirvAssemblyText);
-  // Check that we do not have function definition for foo() anymore.
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("%foo = OpFunction")));
+  // Check that we do not have function calls anymore.
+  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpFunctionCall")));
 }
 
 TEST_F(CompileStringWithOptionsTest, CompileAndOptimizeWithLevelSize) {

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -649,6 +649,18 @@ TEST_F(CompileStringWithOptionsTest, CompileAndOptimizeWithLevelZero) {
   EXPECT_THAT(disassembly_text, HasSubstr("OpSource"));
 }
 
+TEST_F(CompileStringWithOptionsTest, CompileAndOptimizeWithLevelPerformance) {
+  shaderc_compile_options_set_optimization_level(
+      options_.get(), shaderc_optimization_level_performance);
+  shaderc_compile_options_set_source_language(options_.get(),
+                                              shaderc_source_language_hlsl);
+  const std::string disassembly_text =
+      CompilationOutput(kHlslMultipleFnShader, shaderc_vertex_shader,
+                        options_.get(), OutputType::SpirvAssemblyText);
+  // Check that we do not have function definition for foo() anymore.
+  EXPECT_THAT(disassembly_text, Not(HasSubstr("%foo = OpFunction")));
+}
+
 TEST_F(CompileStringWithOptionsTest, CompileAndOptimizeWithLevelSize) {
   shaderc_compile_options_set_optimization_level(
       options_.get(), shaderc_optimization_level_size);
@@ -1427,10 +1439,10 @@ TEST(EntryPointTest, LangHlslOnHlslVertexSucceedsWithGivenEntryPointName) {
 // offset.
 std::string ShaderWithTexOffset(int offset) {
   std::ostringstream oss;
-  oss <<
-    "#version 450\n"
-    "layout (binding=0) uniform sampler1D tex;\n"
-    "void main() { vec4 x = textureOffset(tex, 1.0, " << offset << "); }\n";
+  oss << "#version 450\n"
+         "layout (binding=0) uniform sampler1D tex;\n"
+         "void main() { vec4 x = textureOffset(tex, 1.0, "
+      << offset << "); }\n";
   return oss.str();
 }
 
@@ -1617,18 +1629,18 @@ TEST_F(
   const std::string disassembly_text = CompilationOutput(
       kShaderWithUniformsWithoutBindings, shaderc_vertex_shader, options_.get(),
       OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text, HasSubstr("OpDecorate %my_tex Binding 100")) << disassembly_text;
+  EXPECT_THAT(disassembly_text, HasSubstr("OpDecorate %my_tex Binding 100"))
+      << disassembly_text;
   EXPECT_THAT(disassembly_text, HasSubstr("OpDecorate %my_sam Binding 0"));
   EXPECT_THAT(disassembly_text, HasSubstr("OpDecorate %my_img Binding 1"));
   EXPECT_THAT(disassembly_text, HasSubstr("OpDecorate %my_imbuf Binding 2"));
   EXPECT_THAT(disassembly_text, HasSubstr("OpDecorate %my_ubo Binding 3"));
 }
 
-TEST_F(
-    CompileStringWithOptionsTest,
-    SetBindingBaseForTextureForVertexIgnoredWhenCompilingAsFragment) {
+TEST_F(CompileStringWithOptionsTest,
+       SetBindingBaseForTextureForVertexIgnoredWhenCompilingAsFragment) {
   shaderc_compile_options_set_auto_bind_uniforms(options_.get(), true);
-// This is ignored since we're compiling as a different stage.
+  // This is ignored since we're compiling as a different stage.
   shaderc_compile_options_set_binding_base_for_stage(
       options_.get(), shaderc_vertex_shader, shaderc_uniform_kind_texture, 100);
   const std::string disassembly_text = CompilationOutput(
@@ -1645,8 +1657,7 @@ TEST_F(CompileStringWithOptionsTest, GlslDefaultPackingUsed) {
   const std::string disassembly_text =
       CompilationOutput(kGlslShaderWeirdPacking, shaderc_vertex_shader,
                         options_.get(), OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text,
-              HasSubstr("OpMemberDecorate %B 1 Offset 16"));
+  EXPECT_THAT(disassembly_text, HasSubstr("OpMemberDecorate %B 1 Offset 16"));
 }
 
 TEST_F(CompileStringWithOptionsTest, HlslOffsetsOptionDisableRespected) {
@@ -1654,8 +1665,7 @@ TEST_F(CompileStringWithOptionsTest, HlslOffsetsOptionDisableRespected) {
   const std::string disassembly_text =
       CompilationOutput(kGlslShaderWeirdPacking, shaderc_vertex_shader,
                         options_.get(), OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text,
-              HasSubstr("OpMemberDecorate %B 1 Offset 16"));
+  EXPECT_THAT(disassembly_text, HasSubstr("OpMemberDecorate %B 1 Offset 16"));
 }
 
 TEST_F(CompileStringWithOptionsTest, HlslOffsetsOptionEnableRespected) {
@@ -1663,8 +1673,7 @@ TEST_F(CompileStringWithOptionsTest, HlslOffsetsOptionEnableRespected) {
   const std::string disassembly_text =
       CompilationOutput(kGlslShaderWeirdPacking, shaderc_vertex_shader,
                         options_.get(), OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text,
-              HasSubstr("OpMemberDecorate %B 1 Offset 4"));
+  EXPECT_THAT(disassembly_text, HasSubstr("OpMemberDecorate %B 1 Offset 4"));
 }
 
 }  // anonymous namespace

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -128,8 +128,9 @@ class Compiler {
 
   // Supported optimization levels.
   enum class OptimizationLevel {
-    Zero,  // No optimization.
-    Size,  // Optimization towards reducing code size.
+    Zero,         // No optimization.
+    Performance,  // Optimization towards better performance.
+    Size,         // Optimization towards reducing code size.
   };
 
   // Resource limits.  These map to the "max*" fields in glslang::TBuiltInResource.

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -129,8 +129,8 @@ class Compiler {
   // Supported optimization levels.
   enum class OptimizationLevel {
     Zero,         // No optimization.
-    Performance,  // Optimization towards better performance.
     Size,         // Optimization towards reducing code size.
+    Performance,  // Optimization towards better performance.
   };
 
   // Resource limits.  These map to the "max*" fields in glslang::TBuiltInResource.

--- a/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
+++ b/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
@@ -39,6 +39,7 @@ bool SpirvToolsDisassemble(Compiler::TargetEnv env,
 
 // The ids of a list of supported optimization passes.
 enum class PassId {
+  kLegalizationPasses,
   kNullPass,
   kStripDebugInfo,
   kEliminateDeadFunctions,

--- a/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
+++ b/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
@@ -39,27 +39,14 @@ bool SpirvToolsDisassemble(Compiler::TargetEnv env,
 
 // The ids of a list of supported optimization passes.
 enum class PassId {
+  // SPIRV-Tools standard recipes
   kLegalizationPasses,
+  kPerformancePasses,
+  kSizePasses,
+
+  // SPIRV-Tools specific passes
   kNullPass,
   kStripDebugInfo,
-  kEliminateDeadFunctions,
-  kFlattenDecoration,
-  kFreezeSpecConstantValue,
-  kFoldSpecConstantOpAndComposite,
-  kUnifyConstant,
-  kEliminateDeadConstant,
-  kStrengthReduction,
-  kBlockMerge,
-  kInlineExhaustive,
-  kInlineOpaque,
-  kLocalSingleBlockLoadStoreElim,
-  kDeadBranchElim,
-  kLocalMultiStoreElim,
-  kLocalAccessChainConvert,
-  kLocalSingleStoreElim,
-  kInsertExtractElim,
-  kCommonUniformElim,
-  kAggressiveDCE,
   kCompactIds,
 };
 

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -417,6 +417,12 @@ void Compiler::SetOptimizationLevel(Compiler::OptimizationLevel level) {
       }
       enabled_opt_passes_.push_back(PassId::kSizePasses);
       break;
+    case OptimizationLevel::Performance:
+      if (!generate_debug_info_) {
+        enabled_opt_passes_.push_back(PassId::kStripDebugInfo);
+      }
+      enabled_opt_passes_.push_back(PassId::kPerformancePasses);
+      break;
     default:
       break;
   }

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -415,7 +415,7 @@ void Compiler::SetOptimizationLevel(Compiler::OptimizationLevel level) {
       if (!generate_debug_info_) {
         enabled_opt_passes_.push_back(PassId::kStripDebugInfo);
       }
-      enabled_opt_passes_.push_back(PassId::kUnifyConstant);
+      enabled_opt_passes_.push_back(PassId::kSizePasses);
       break;
     default:
       break;

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -282,8 +282,10 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   shader.setShiftSamplerBinding(bases[static_cast<int>(UniformKind::Sampler)]);
   shader.setShiftTextureBinding(bases[static_cast<int>(UniformKind::Texture)]);
   shader.setShiftUboBinding(bases[static_cast<int>(UniformKind::Buffer)]);
-  shader.setShiftSsboBinding(bases[static_cast<int>(UniformKind::StorageBuffer)]);
-  shader.setShiftUavBinding(bases[static_cast<int>(UniformKind::UnorderedAccessView)]);
+  shader.setShiftSsboBinding(
+      bases[static_cast<int>(UniformKind::StorageBuffer)]);
+  shader.setShiftUavBinding(
+      bases[static_cast<int>(UniformKind::UnorderedAccessView)]);
   shader.setHlslIoMapping(hlsl_iomap_);
   shader.setResourceSetBinding(
       hlsl_explicit_bindings_[static_cast<int>(used_shader_stage)]);
@@ -320,12 +322,12 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   options.optimizeSize = false;
   // Note the call to GlslangToSpv also populates compilation_output_data.
   glslang::GlslangToSpv(*program.getIntermediate(used_shader_stage), spirv,
-			&options);
+                        &options);
 
   // Set the tool field (the top 16-bits) in the generator word to
   // 'Shaderc over Glslang'.
-  const uint32_t shaderc_generator_word = 13; // From SPIR-V XML Registry
-  const uint32_t generator_word_index = 2; // SPIR-V 2.3: Physical layout
+  const uint32_t shaderc_generator_word = 13;  // From SPIR-V XML Registry
+  const uint32_t generator_word_index = 2;     // SPIR-V 2.3: Physical layout
   assert(spirv.size() > generator_word_index);
   spirv[generator_word_index] =
       (spirv[generator_word_index] & 0xffff) | (shaderc_generator_word << 16);
@@ -335,27 +337,11 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   if (hlsl_legalization_enabled_ && source_language_ == SourceLanguage::HLSL) {
     // If from HLSL, run this passes to "legalize" the SPIR-V for Vulkan
     // eg. forward and remove memory writes of opaque types.
-    opt_passes.push_back(PassId::kInlineExhaustive);
-    opt_passes.push_back(PassId::kLocalAccessChainConvert);
-    opt_passes.push_back(PassId::kLocalSingleBlockLoadStoreElim);
-    opt_passes.push_back(PassId::kLocalSingleStoreElim);
-    opt_passes.push_back(PassId::kInsertExtractElim);
-    opt_passes.push_back(PassId::kAggressiveDCE);
-    opt_passes.push_back(PassId::kDeadBranchElim);
-    opt_passes.push_back(PassId::kBlockMerge);
-    opt_passes.push_back(PassId::kLocalMultiStoreElim);
-    opt_passes.push_back(PassId::kInsertExtractElim);
-    opt_passes.push_back(PassId::kAggressiveDCE);
-    opt_passes.push_back(PassId::kEliminateDeadConstant);
-    opt_passes.push_back(PassId::kEliminateDeadFunctions);
-
-    // TODO(atgoo, dneto0, greg-lunarg):
-    // Add PassId::kCommonUniformElim when AMD driver issues are resolved.
-    // Add dead var/type elimination passes when available.
+    opt_passes.push_back(PassId::kLegalizationPasses);
   }
 
-  opt_passes.insert(
-      opt_passes.end(), enabled_opt_passes_.begin(), enabled_opt_passes_.end());
+  opt_passes.insert(opt_passes.end(), enabled_opt_passes_.begin(),
+                    enabled_opt_passes_.end());
 
   if (!opt_passes.empty()) {
     std::string opt_errors;
@@ -693,4 +679,4 @@ std::vector<uint32_t> ConvertStringToVector(const std::string& str) {
   return result_vec;
 }
 
-}  // namesapce shaderc_util
+}  // namespace shaderc_util

--- a/libshaderc_util/src/spirv_tools_wrapper.cc
+++ b/libshaderc_util/src/spirv_tools_wrapper.cc
@@ -105,67 +105,17 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
       case PassId::kLegalizationPasses:
         optimizer.RegisterLegalizationPasses();
         break;
+      case PassId::kPerformancePasses:
+        optimizer.RegisterPerformancePasses();
+        break;
+      case PassId::kSizePasses:
+        optimizer.RegisterSizePasses();
+        break;
       case PassId::kNullPass:
         // We actually don't need to do anything for null pass.
         break;
       case PassId::kStripDebugInfo:
         optimizer.RegisterPass(spvtools::CreateStripDebugInfoPass());
-        break;
-      case PassId::kEliminateDeadFunctions:
-        optimizer.RegisterPass(spvtools::CreateEliminateDeadFunctionsPass());
-        break;
-      case PassId::kFlattenDecoration:
-        optimizer.RegisterPass(spvtools::CreateFlattenDecorationPass());
-        break;
-      case PassId::kFreezeSpecConstantValue:
-        optimizer.RegisterPass(spvtools::CreateFreezeSpecConstantValuePass());
-        break;
-      case PassId::kFoldSpecConstantOpAndComposite:
-        optimizer.RegisterPass(
-            spvtools::CreateFoldSpecConstantOpAndCompositePass());
-        break;
-      case PassId::kUnifyConstant:
-        optimizer.RegisterPass(spvtools::CreateUnifyConstantPass());
-        break;
-      case PassId::kEliminateDeadConstant:
-        optimizer.RegisterPass(spvtools::CreateEliminateDeadConstantPass());
-        break;
-      case PassId::kStrengthReduction:
-        optimizer.RegisterPass(spvtools::CreateStrengthReductionPass());
-        break;
-      case PassId::kBlockMerge:
-        optimizer.RegisterPass(spvtools::CreateBlockMergePass());
-        break;
-      case PassId::kInlineExhaustive:
-        optimizer.RegisterPass(spvtools::CreateInlineExhaustivePass());
-        break;
-      case PassId::kInlineOpaque:
-        optimizer.RegisterPass(spvtools::CreateInlineOpaquePass());
-        break;
-      case PassId::kLocalSingleBlockLoadStoreElim:
-        optimizer.RegisterPass(
-            spvtools::CreateLocalSingleBlockLoadStoreElimPass());
-        break;
-      case PassId::kDeadBranchElim:
-        optimizer.RegisterPass(spvtools::CreateDeadBranchElimPass());
-        break;
-      case PassId::kLocalMultiStoreElim:
-        optimizer.RegisterPass(spvtools::CreateLocalMultiStoreElimPass());
-        break;
-      case PassId::kLocalAccessChainConvert:
-        optimizer.RegisterPass(spvtools::CreateLocalAccessChainConvertPass());
-        break;
-      case PassId::kLocalSingleStoreElim:
-        optimizer.RegisterPass(spvtools::CreateLocalSingleStoreElimPass());
-        break;
-      case PassId::kInsertExtractElim:
-        optimizer.RegisterPass(spvtools::CreateInsertExtractElimPass());
-        break;
-      case PassId::kCommonUniformElim:
-        optimizer.RegisterPass(spvtools::CreateCommonUniformElimPass());
-        break;
-      case PassId::kAggressiveDCE:
-        optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());
         break;
       case PassId::kCompactIds:
         optimizer.RegisterPass(spvtools::CreateCompactIdsPass());

--- a/libshaderc_util/src/spirv_tools_wrapper.cc
+++ b/libshaderc_util/src/spirv_tools_wrapper.cc
@@ -43,12 +43,15 @@ bool SpirvToolsDisassemble(Compiler::TargetEnv env,
                            std::string* text_or_error) {
   spvtools::SpirvTools tools(SPV_ENV_VULKAN_1_0);
   std::ostringstream oss;
-  tools.SetMessageConsumer([&oss](
-      spv_message_level_t, const char*, const spv_position_t& position,
-      const char* message) { oss << position.index << ": " << message; });
-  const bool success = tools.Disassemble(
-      binary, text_or_error, SPV_BINARY_TO_TEXT_OPTION_INDENT |
-                                 SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
+  tools.SetMessageConsumer([&oss](spv_message_level_t, const char*,
+                                  const spv_position_t& position,
+                                  const char* message) {
+    oss << position.index << ": " << message;
+  });
+  const bool success =
+      tools.Disassemble(binary, text_or_error,
+                        SPV_BINARY_TO_TEXT_OPTION_INDENT |
+                            SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES);
   if (!success) {
     *text_or_error = oss.str();
   }
@@ -99,6 +102,9 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
 
   for (const auto& pass : enabled_passes) {
     switch (pass) {
+      case PassId::kLegalizationPasses:
+        optimizer.RegisterLegalizationPasses();
+        break;
       case PassId::kNullPass:
         // We actually don't need to do anything for null pass.
         break;
@@ -115,7 +121,8 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
         optimizer.RegisterPass(spvtools::CreateFreezeSpecConstantValuePass());
         break;
       case PassId::kFoldSpecConstantOpAndComposite:
-        optimizer.RegisterPass(spvtools::CreateFoldSpecConstantOpAndCompositePass());
+        optimizer.RegisterPass(
+            spvtools::CreateFoldSpecConstantOpAndCompositePass());
         break;
       case PassId::kUnifyConstant:
         optimizer.RegisterPass(spvtools::CreateUnifyConstantPass());
@@ -136,7 +143,8 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
         optimizer.RegisterPass(spvtools::CreateInlineOpaquePass());
         break;
       case PassId::kLocalSingleBlockLoadStoreElim:
-        optimizer.RegisterPass(spvtools::CreateLocalSingleBlockLoadStoreElimPass());
+        optimizer.RegisterPass(
+            spvtools::CreateLocalSingleBlockLoadStoreElimPass());
         break;
       case PassId::kDeadBranchElim:
         optimizer.RegisterPass(spvtools::CreateDeadBranchElimPass());

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -32,18 +32,6 @@ if (IS_DIRECTORY ${SHADERC_SPIRV_HEADERS_DIR})
   add_subdirectory(${SHADERC_SPIRV_HEADERS_DIR} spirv-headers)
 endif()
 
-# Check SPIRV-Tools before glslang since it is a dependency of glslang.
-if (IS_DIRECTORY ${SHADERC_SPIRV_TOOLS_DIR})
-  if ("${SHADERC_SKIP_TESTS}")
-    # Also skip building tests in SPIRV-Tools.
-    set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
-  endif()
-  add_subdirectory(${SHADERC_SPIRV_TOOLS_DIR} spirv-tools)
-endif()
-if (NOT TARGET SPIRV-Tools)
-  message(FATAL_ERROR "SPIRV-Tools was not found - required for compilation")
-endif()
-
 if (IS_DIRECTORY ${SHADERC_GLSLANG_DIR})
   add_subdirectory(${SHADERC_GLSLANG_DIR} glslang)
 endif()
@@ -56,6 +44,19 @@ if(WIN32)
     # installed, undo anything glslang has done to it.
     set(CMAKE_GENERATOR_TOOLSET "${OLD_PLATFORM_TOOLSET}" CACHE STRING
       "Platform Toolset" FORCE)
+endif()
+
+# Check SPIRV-Tools after glslang so that it is not linked into glslang and
+# we can control optimizations.
+if (IS_DIRECTORY ${SHADERC_SPIRV_TOOLS_DIR})
+  if ("${SHADERC_SKIP_TESTS}")
+    # Also skip building tests in SPIRV-Tools.
+    set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
+  endif()
+  add_subdirectory(${SHADERC_SPIRV_TOOLS_DIR} spirv-tools)
+endif()
+if (NOT TARGET SPIRV-Tools)
+  message(FATAL_ERROR "SPIRV-Tools was not found - required for compilation")
 endif()
 
 if(${SHADERC_ENABLE_TESTS})


### PR DESCRIPTION
Previously we manually manage the list of passes.
This commit converts to use the SPIRV-Tools standard
ones.