### PR TITLE
Force binary mode when writing a binary to stdout

### DIFF
--- a/glslc/src/file_compiler.cc
+++ b/glslc/src/file_compiler.cc
@@ -214,7 +214,13 @@ bool FileCompiler::EmitCompiledResult(
       case SpirvBinaryEmissionFormat::Unspecified:
       case SpirvBinaryEmissionFormat::Binary:
         // The output format is unspecified or specified as binary output.
+        // On Windows, the output stream must be set to binary mode.  By
+        // default the standard output stream is set to text mode, which
+        // translates newlines (\n) to carriage-return newline pairs
+        // (\r\n).
+        if (out == &std::cout) shaderc_util::FlushAndSetBinaryModeOnStdout();
         out->write(compilation_output.data(), compilation_output.size());
+        if (out == &std::cout) shaderc_util::FlushAndSetTextModeOnStdout();
         break;
       case SpirvBinaryEmissionFormat::Numbers:
         // The output format is specified to be a list of hex numbers, the

--- a/libshaderc_util/include/libshaderc_util/io.h
+++ b/libshaderc_util/include/libshaderc_util/io.h
@@ -57,6 +57,13 @@ std::ostream* GetOutputStream(const string_piece& output_filename,
 // is "-", writes to std::cout.
 bool WriteFile(std::ostream* output_stream, const string_piece& output_data);
 
+// Flush the standard output stream and set it to binary mode.  Subsequent
+// output will not translate newlines to carriage-return newline pairs.
+void FlushAndSetBinaryModeOnStdout();
+// Flush the standard output stream and set it to text mode.  Subsequent
+// output will translate newlines to carriage-return newline pairs.
+void FlushAndSetTextModeOnStdout();
+
 }  // namespace shaderc_util
 
 #endif  // LIBSHADERC_UTIL_IO_H_

--- a/libshaderc_util/src/io.cc
+++ b/libshaderc_util/src/io.cc
@@ -16,7 +16,15 @@
 
 #include "libshaderc_util/universal_unistd.h"
 
+#if _WIN32
+// Need _fileno from stdio.h
+// Need _O_BINARY and _O_TEXT from fcntl.h
+#include <fcntl.h>
+#include <stdio.h>
+#endif
+
 #include <errno.h>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -118,6 +126,20 @@ bool WriteFile(std::ostream* stream, const string_piece& output_data) {
   }
   stream->flush();
   return true;
+}
+
+void FlushAndSetBinaryModeOnStdout() {
+  std::fflush(stdout);
+#if _WIN32
+  _setmode(_fileno(stdout), _O_BINARY);
+#endif
+}
+
+void FlushAndSetTextModeOnStdout() {
+  std::fflush(stdout);
+#if _WIN32
+  _setmode(_fileno(stdout), _O_TEXT);
+#endif
 }
 
 }  // namespace shaderc_util


### PR DESCRIPTION
For the test: also refactor the glslc test expectation code to
be able to check the length and header of a binary residing in a
Python "bytes" object, not just in a file.

Fixes https://github.com/google/shaderc/issues/457