### PR TITLE
Fix the link order of libglslang and libHLSL

### DIFF
--- a/glslc/CMakeLists.txt
+++ b/glslc/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(glslc STATIC
 shaderc_default_compile_options(glslc)
 target_include_directories(glslc PUBLIC ${glslang_SOURCE_DIR})
 target_link_libraries(glslc PRIVATE glslang OSDependent OGLCompiler
-  HLSL glslang SPIRV ${CMAKE_THREAD_LIBS_INIT})
+  glslang SPIRV HLSL ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(glslc PRIVATE shaderc_util shaderc)
 
 add_executable(glslc_exe src/main.cc)

--- a/libshaderc_util/CMakeLists.txt
+++ b/libshaderc_util/CMakeLists.txt
@@ -34,8 +34,8 @@ endif(SHADERC_ENABLE_INSTALL)
 
 find_package(Threads)
 target_link_libraries(shaderc_util PRIVATE
-  glslang OSDependent OGLCompiler HLSL glslang SPIRV
-  SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
+  glslang OSDependent OGLCompiler glslang HLSL SPIRV
+  SPIRV-Tools-opt SPIRV-Tools ${CMAKE_THREAD_LIBS_INIT})
 
 shaderc_add_tests(
   TEST_PREFIX shaderc_util


### PR DESCRIPTION
libglslang depends on libHLSL, so the latter needs to be specified last.
This fixes an issue when trying to build shaderc against system-wide
versions of libglslang/libHLSL, rather than the in-tree versions from
third_party.