### PR TITLE
Add virtual dtor to classes with virtual functions

### DIFF
--- a/glslc/src/file_includer.cc
+++ b/glslc/src/file_includer.cc
@@ -25,6 +25,9 @@ shaderc_include_result* MakeErrorIncludeResult(const char* message) {
   return new shaderc_include_result{"", 0, message, strlen(message)};
 }
 
+FileIncluder::~FileIncluder() {
+}
+
 shaderc_include_result* FileIncluder::GetInclude(
     const char* requested_source, shaderc_include_type include_type,
     const char* requesting_source, size_t) {

--- a/glslc/src/file_includer.cc
+++ b/glslc/src/file_includer.cc
@@ -25,8 +25,7 @@ shaderc_include_result* MakeErrorIncludeResult(const char* message) {
   return new shaderc_include_result{"", 0, message, strlen(message)};
 }
 
-FileIncluder::~FileIncluder() {
-}
+FileIncluder::~FileIncluder() = default;
 
 shaderc_include_result* FileIncluder::GetInclude(
     const char* requested_source, shaderc_include_type include_type,

--- a/glslc/src/file_includer.h
+++ b/glslc/src/file_includer.h
@@ -38,6 +38,9 @@ class FileIncluder : public shaderc::CompileOptions::IncluderInterface {
  public:
   explicit FileIncluder(const shaderc_util::FileFinder* file_finder)
       : file_finder_(*file_finder) {}
+
+  ~FileIncluder() override;
+
   // Resolves a requested source file of a given type from a requesting
   // source into a shaderc_include_result whose contents will remain valid
   // until it's released.

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -172,8 +172,6 @@ class CompileOptions {
   // A C++ version of the libshaderc includer interface.
   class IncluderInterface {
    public:
-    virtual ~IncluderInterface() {}
-
     // Handles shaderc_include_resolver_fn callbacks.
     virtual shaderc_include_result* GetInclude(const char* requested_source,
                                                shaderc_include_type type,

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -172,6 +172,8 @@ class CompileOptions {
   // A C++ version of the libshaderc includer interface.
   class IncluderInterface {
    public:
+    virtual ~IncluderInterface() {}
+
     // Handles shaderc_include_resolver_fn callbacks.
     virtual shaderc_include_result* GetInclude(const char* requested_source,
                                                shaderc_include_type type,


### PR DESCRIPTION
IncluderInterface has virtual functions but does not have a virtual
destructor. This class is derived from by FileIncluder w hich overrides
those functions.

Because there is an interface in use here, it is safe to assume some
container is storing IncluderInterface*. If the container instead held
FileIncluder* then the virtual functions wouldn't be needed.

This causes a problem since FileIncluder has member variables. The
destructor of FileIncluder knows to also destruct those member variables
(including deallocating their dynamically allocated memory).

But when IncluderInterface's destructor is called, it is not virtual and
will not call FileIncluder's destructor. So these member variables are
never destroyed and their dynamically allocated memory will be leaked.

In this case, FileIncluder stores a std::unordered_set<std::string>
which will be leaked.

This patch adds a virtual destructor to IncluderInterface to make sure
FileIncluder's destructor is called and this memory isn't leaked.