### PR TITLE
Create intermediate directories for output files

### DIFF
--- a/glslc/src/dependency_info.cc
+++ b/glslc/src/dependency_info.cc
@@ -48,6 +48,10 @@ bool DependencyInfoDumpingHandler::DumpDependencyInfo(
     compilation_output_ptr->assign(dep_string_stream.str());
   } else if (mode_ == dump_as_extra_file) {
     std::ofstream potential_file_stream_for_dep_info_dump;
+    if (!CreateIntermediateDirectories(dep_file_name)) {
+      std::cerr << "glslc: error: cannot create directories" << std::endl;
+      return false;
+    }
     std::ostream* dep_file_stream = shaderc_util::GetOutputStream(
         dep_file_name, &potential_file_stream_for_dep_info_dump, &std::cerr);
     *dep_file_stream << dep_string_stream.str();

--- a/glslc/src/file.cc
+++ b/glslc/src/file.cc
@@ -64,9 +64,16 @@ bool CreateIntermediateDirectories(const std::string &filename)
         }
     }
 
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(_WIN32)
+    bool success = CreateDirectoryA(path, nullptr);
+    if (!success)
+        success = GetLastError() == ERROR_ALREADY_EXISTS;
+#else
     int ret = mkdir(path, 0755);
+    bool success = ret == 0 || errno == EEXIST;
+#endif
     free(path);
-    return ret == 0;
+    return success;
 }
 
 }  // namespace glslc

--- a/glslc/src/file.cc
+++ b/glslc/src/file.cc
@@ -23,4 +23,50 @@ shaderc_util::string_piece GetFileExtension(
   return filename.substr(dot_pos + 1);
 }
 
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(_WIN32)
+#define strdup _strdup
+#define isseparator(c) ((c) == '/' || (c) == '\\')
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRALEAN
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <string.h>
+#define isseparator(c) ((c) == '/')
+#endif
+
+
+bool CreateIntermediateDirectories(const std::string &filename)
+{
+    char *path = strdup(filename.c_str());
+    int len = filename.length();
+
+    /* Find the file. Remove it from the path. */
+    for (int i = len - 1; i >= 0; --i) {
+        if (isseparator(path[i])) {
+            path[i] = 0;
+            break;
+        }
+    }
+
+    /* Create all intermediate directories. */
+    for (int i = 0; i < len; ++i) {
+        if (isseparator(path[i])) {
+            char c = path[i];
+            path[i] = 0;
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(_WIN32)
+            CreateDirectoryA(path, nullptr);
+#else
+            mkdir(path, 0755);
+#endif
+            path[i] = c;
+        }
+    }
+
+    int ret = mkdir(path, 0755);
+    free(path);
+    return ret == 0;
+}
+
 }  // namespace glslc

--- a/glslc/src/file.h
+++ b/glslc/src/file.h
@@ -41,6 +41,8 @@ inline std::string GetGlslOrHlslExtension(
   return "";
 }
 
+bool CreateIntermediateDirectories(const std::string &filename);
+
 }  // namespace glslc
 
 #endif  // GLSLC_FILE_H_

--- a/glslc/src/file_compiler.cc
+++ b/glslc/src/file_compiler.cc
@@ -201,6 +201,9 @@ bool FileCompiler::EmitCompiledResult(
   std::ostream* out = nullptr;
   std::ofstream potential_file_stream;
   if (compilation_success) {
+    if (!CreateIntermediateDirectories(output_file_name)) {
+      return false;
+    }
     out = shaderc_util::GetOutputStream(output_file_name,
                                         &potential_file_stream, &std::cerr);
     if (!out || out->fail()) {


### PR DESCRIPTION
I noticed that `glslc` doesn't create intermediate directories (like other compilers do). I've added a helper function to do exactly that and added it to create the directories for the output & dependency files. 