### PR TITLE
Add BUILD.gn rules.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,95 @@
+# Copyright 2018 The Shaderc Authors. All rights reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/shaderc.gni")
+
+glslang_dir = shaderc_glslang_dir
+spirv_tools_dir = shaderc_spirv_tools_dir
+
+config("shaderc_util_public") {
+  include_dirs = [ "libshaderc_util/include" ]
+}
+
+static_library("shaderc_util") {
+  public_configs = [ ":shaderc_util_public" ]
+  deps = [
+    "${glslang_dir}:glslang_static",
+    "${spirv_tools_dir}:spvtools",
+  ]
+
+  sources = [
+    "libshaderc_util/include/libshaderc_util/counting_includer.h",
+    "libshaderc_util/include/libshaderc_util/file_finder.h",
+    "libshaderc_util/include/libshaderc_util/format.h",
+    "libshaderc_util/include/libshaderc_util/io.h",
+    "libshaderc_util/include/libshaderc_util/message.h",
+    "libshaderc_util/include/libshaderc_util/mutex.h",
+    "libshaderc_util/include/libshaderc_util/resources.h",
+    "libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h",
+    "libshaderc_util/include/libshaderc_util/string_piece.h",
+    "libshaderc_util/include/libshaderc_util/universal_unistd.h",
+    "libshaderc_util/include/libshaderc_util/version_profile.h",
+    "libshaderc_util/src/compiler.cc",
+    "libshaderc_util/src/file_finder.cc",
+    "libshaderc_util/src/io.cc",
+    "libshaderc_util/src/message.cc",
+    "libshaderc_util/src/resources.cc",
+    "libshaderc_util/src/shader_stage.cc",
+    "libshaderc_util/src/spirv_tools_wrapper.cc",
+    "libshaderc_util/src/version_profile.cc",
+  ]
+}
+
+config("shaderc_public") {
+  include_dirs = [ "libshaderc/include" ]
+  defines = [ "SHADERC_SHAREDLIB" ]
+
+  # Executable needs an rpath to find our shared libraries on OSX
+  if (is_mac) {
+    ldflags = [
+      "-rpath",
+      "@executable_path/",
+    ]
+  }
+}
+
+shared_library("libshaderc") {
+  public_configs = [ ":shaderc_public" ]
+  deps = [
+    "${glslang_dir}:glslang_static",
+    ":shaderc_util",
+    "${spirv_tools_dir}:spvtools",
+    "${spirv_tools_dir}:spvtools_val",
+  ]
+  defines = [ "SHADERC_IMPLEMENTATION" ]
+
+  sources = [
+    "libshaderc/include/shaderc/shaderc.h",
+    "libshaderc/include/shaderc/shaderc.hpp",
+    "libshaderc/src/shaderc.cc",
+    "libshaderc/src/shaderc_private.h",
+  ]
+
+  # Tell dependents where to find this shared library
+  if (is_mac) {
+    ldflags = [
+      "-install_name",
+      "@rpath/${target_name}.dylib",
+    ]
+  }
+
+  configs -= [ "//build/config/compiler:chromium_code" ]
+  configs += [ "//build/config/compiler:no_chromium_code" ]
+}
+

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -21,13 +21,7 @@ config("shaderc_util_public") {
   include_dirs = [ "libshaderc_util/include" ]
 }
 
-static_library("shaderc_util") {
-  public_configs = [ ":shaderc_util_public" ]
-  deps = [
-    "${glslang_dir}:glslang_static",
-    "${spirv_tools_dir}:spvtools",
-  ]
-
+source_set("shaderc_util_sources") {
   sources = [
     "libshaderc_util/include/libshaderc_util/counting_includer.h",
     "libshaderc_util/include/libshaderc_util/file_finder.h",
@@ -49,6 +43,21 @@ static_library("shaderc_util") {
     "libshaderc_util/src/spirv_tools_wrapper.cc",
     "libshaderc_util/src/version_profile.cc",
   ]
+
+  public_configs = [ ":shaderc_util_public" ]
+
+  deps = [
+    "${glslang_dir}:glslang_static",
+    "${spirv_tools_dir}:spvtools",
+  ]
+}
+
+static_library("shaderc_util") {
+  public_configs = [ ":shaderc_util_public" ]
+
+  deps = [
+    ":shaderc_util_sources",
+  ]
 }
 
 config("shaderc_public") {
@@ -64,14 +73,7 @@ config("shaderc_public") {
   }
 }
 
-shared_library("libshaderc") {
-  public_configs = [ ":shaderc_public" ]
-  deps = [
-    "${glslang_dir}:glslang_static",
-    ":shaderc_util",
-    "${spirv_tools_dir}:spvtools",
-    "${spirv_tools_dir}:spvtools_val",
-  ]
+source_set("libshaderc_sources") {
   defines = [ "SHADERC_IMPLEMENTATION" ]
 
   sources = [
@@ -79,6 +81,23 @@ shared_library("libshaderc") {
     "libshaderc/include/shaderc/shaderc.hpp",
     "libshaderc/src/shaderc.cc",
     "libshaderc/src/shaderc_private.h",
+  ]
+
+  public_configs = [ ":shaderc_public" ]
+
+  deps = [
+    ":shaderc_util",
+    "${spirv_tools_dir}:spvtools",
+    "${spirv_tools_dir}:spvtools_val",
+    "${glslang_dir}:glslang_static",
+  ]
+}
+
+shared_library("libshaderc") {
+  public_configs = [ ":shaderc_public" ]
+
+  deps = [
+    ":libshaderc_sources",
   ]
 
   # Tell dependents where to find this shared library

--- a/build_overrides/shaderc.gni
+++ b/build_overrides/shaderc.gni
@@ -1,0 +1,19 @@
+# Copyright 2018 The Shaderc Authors. All rights reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These are variables that are overridable by projects that include shaderc.
+
+# The path to shaderc dependencies.
+shaderc_glslang_dir = "//third_party/glslang"
+shaderc_spirv_tools_dir = "//third_party/spirv-tools"


### PR DESCRIPTION
This CL adds the necessary build configuration to allow building
shaderc within a Chromium checkout.