### PR TITLE
Specify NV_EXTENSIONS for Android build

### DIFF
--- a/libshaderc/Android.mk
+++ b/libshaderc/Android.mk
@@ -7,7 +7,7 @@ LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)/include
 LOCAL_SRC_FILES:=src/shaderc.cc
 LOCAL_C_INCLUDES:=$(LOCAL_PATH)/include
 LOCAL_STATIC_LIBRARIES:=shaderc_util SPIRV-Tools-opt
-LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti -DNV_EXTENSIONS
 LOCAL_EXPORT_CPPFLAGS:=-std=c++11
 LOCAL_EXPORT_LDFLAGS:=-latomic
 include $(BUILD_STATIC_LIBRARY)

--- a/libshaderc_util/Android.mk
+++ b/libshaderc_util/Android.mk
@@ -2,7 +2,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE:=shaderc_util
-LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti
+LOCAL_CXXFLAGS:=-std=c++11 -fno-exceptions -fno-rtti -DNV_EXTENSIONS
 LOCAL_EXPORT_C_INCLUDES:=$(LOCAL_PATH)/include
 LOCAL_SRC_FILES:=src/compiler.cc \
 		src/file_finder.cc \


### PR DESCRIPTION
This is a fix for problems we ran into using shaderc for Vulkan validation layer tests on Android with the latest changes:

https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/342

Normally we would have waited for a known_good update, but things moved fast.  I didn't make it optional like the cmake flag, but I'm hearing the #ifdefs may change soon anyway.