### PR TITLE
Pass environment version into SPIRV-Tools properly

### DIFF
--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -310,6 +310,16 @@ const char kHlslShaderWithCounterBuffer[] =
          return float4(Ainc.IncrementCounter(), 0, 0, 0);
        })";
 
+const char kHlslWaveActiveSumeComputeShader[] =
+  R"(struct S { uint val; uint result; };
+
+     RWStructuredBuffer<S> MyBuffer;
+
+     [numthreads(32, 1, 1)]
+     void main(uint3 id : SV_DispatchThreadID) {
+       MyBuffer[id.x].result = WaveActiveSum(MyBuffer[id.x].val);
+     })";
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -294,6 +294,26 @@ shaderc_util::Compiler::TargetEnv GetCompilerTargetEnv(shaderc_target_env env) {
   return shaderc_util::Compiler::TargetEnv::Vulkan;
 }
 
+shaderc_util::Compiler::TargetEnvVersion GetCompilerTargetEnvVersion(
+    uint32_t version_number) {
+  using namespace shaderc_util;
+
+  if (static_cast<uint32_t>(Compiler::TargetEnvVersion::Vulkan_1_0) ==
+      version_number) {
+    return Compiler::TargetEnvVersion::Vulkan_1_0;
+  }
+  if (static_cast<uint32_t>(Compiler::TargetEnvVersion::Vulkan_1_1) ==
+      version_number) {
+    return Compiler::TargetEnvVersion::Vulkan_1_1;
+  }
+  if (static_cast<uint32_t>(Compiler::TargetEnvVersion::OpenGL_4_5) ==
+      version_number) {
+    return Compiler::TargetEnvVersion::OpenGL_4_5;
+  }
+
+  return Compiler::TargetEnvVersion::Default;
+}
+
 // Returns the Compiler::Limit enum for the given shaderc_limit enum.
 shaderc_util::Compiler::Limit CompilerLimit(shaderc_limit limit) {
   switch (limit) {
@@ -452,7 +472,8 @@ void shaderc_compile_options_set_target_env(shaderc_compile_options_t options,
                                             shaderc_target_env target,
                                             uint32_t version) {
   options->target_env = target;
-  options->compiler.SetTargetEnv(GetCompilerTargetEnv(target), version);
+  options->compiler.SetTargetEnv(GetCompilerTargetEnv(target),
+                                 GetCompilerTargetEnvVersion(version));
 }
 
 void shaderc_compile_options_set_warnings_as_errors(
@@ -652,8 +673,11 @@ shaderc_compilation_result_t shaderc_assemble_into_spv(
     std::string errors;
     const auto target_env = additional_options ? additional_options->target_env
                                                : shaderc_target_env_default;
+    const uint32_t target_env_version =
+        additional_options ? additional_options->target_env_version : 0;
     const bool assembling_succeeded = shaderc_util::SpirvToolsAssemble(
         GetCompilerTargetEnv(target_env),
+        GetCompilerTargetEnvVersion(target_env_version),
         {source_assembly, source_assembly + source_assembly_size},
         &assembling_output_data, &errors);
     result->num_errors = !assembling_succeeded;

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -106,16 +106,17 @@ class Compiler {
 
   // Target environment.
   enum class TargetEnv {
-    Vulkan,  // Default to Vulkan 1.0
-    OpenGL,  // Default to OpenGL 4.5
-    OpenGLCompat, // Deprecated.
+    Vulkan,        // Default to Vulkan 1.0
+    OpenGL,        // Default to OpenGL 4.5
+    OpenGLCompat,  // Deprecated.
   };
 
   // Target environment versions.  These numbers match those used by Glslang.
   enum class TargetEnvVersion : uint32_t {
+    Default = 0,  // Default for the corresponding target environment
     // For Vulkan, use numbering scheme from vulkan.h
-    Vulkan_1_0 = ((1 << 22)),              // Default to Vulkan 1.0
-    Vulkan_1_1 = ((1 << 22) | (1 << 12)),  // Default to Vulkan 1.0
+    Vulkan_1_0 = ((1 << 22)),              // Vulkan 1.0
+    Vulkan_1_1 = ((1 << 22) | (1 << 12)),  // Vulkan 1.1
     // For OpenGL, use the numbering from #version in shaders.
     OpenGL_4_5 = 450,
   };
@@ -133,9 +134,10 @@ class Compiler {
     Performance,  // Optimization towards better performance.
   };
 
-  // Resource limits.  These map to the "max*" fields in glslang::TBuiltInResource.
+  // Resource limits.  These map to the "max*" fields in
+  // glslang::TBuiltInResource.
   enum class Limit {
-#define RESOURCE(NAME,FIELD,CNAME) NAME,
+#define RESOURCE(NAME, FIELD, CNAME) NAME,
 #include "resources.inc"
 #undef RESOURCE
   };
@@ -185,20 +187,24 @@ class Compiler {
 
   // Returns a std::array of all the Stage values.
   const std::array<Stage, kNumStages>& stages() const {
-    static std::array<Stage, kNumStages> values{
-        {Stage::Vertex, Stage::TessEval, Stage::TessControl, Stage::Geometry,
-         Stage::Fragment, Stage::Compute,
+    static std::array<Stage, kNumStages> values{{
+        Stage::Vertex,
+        Stage::TessEval,
+        Stage::TessControl,
+        Stage::Geometry,
+        Stage::Fragment,
+        Stage::Compute,
 #ifdef NV_EXTENSIONS
-          Stage::RayGenNV,
-          Stage::IntersectNV,
-          Stage::AnyHitNV,
-          Stage::ClosestHitNV,
-          Stage::MissNV,
-          Stage::CallableNV,
-          Stage::TaskNV,
-          Stage::MeshNV,
+        Stage::RayGenNV,
+        Stage::IntersectNV,
+        Stage::AnyHitNV,
+        Stage::ClosestHitNV,
+        Stage::MissNV,
+        Stage::CallableNV,
+        Stage::TaskNV,
+        Stage::MeshNV,
 #endif
-        }};
+    }};
     return values;
   }
 
@@ -215,7 +221,7 @@ class Compiler {
         generate_debug_info_(false),
         enabled_opt_passes_(),
         target_env_(TargetEnv::Vulkan),
-        target_env_version_(0),  // Resolve default later.
+        target_env_version_(TargetEnvVersion::Default),
         source_language_(SourceLanguage::GLSL),
         limits_(kDefaultTBuiltInResource),
         auto_bind_uniforms_(false),
@@ -255,10 +261,11 @@ class Compiler {
                           const char* definition, size_t definition_length);
 
   // Sets the target environment, including version.  The version value should
-  // be 0 or one of the values from TargetEnvVersion.  The 0 version value maps
+  // be 0 or one of the values from TargetEnvVersion.  The default value maps
   // to Vulkan 1.0 if the target environment is Vulkan, and it maps to OpenGL
   // 4.5 if the target environment is OpenGL.
-  void SetTargetEnv(TargetEnv env, uint32_t version = 0);
+  void SetTargetEnv(TargetEnv env,
+                    TargetEnvVersion version = TargetEnvVersion::Default);
 
   // Sets the souce language.
   void SetSourceLanguage(SourceLanguage lang);
@@ -476,7 +483,7 @@ class Compiler {
   // particular to each target environment.  If this is 0, then use a default
   // for that particular target environment. See libshaders/shaderc/shaderc.h
   // for those defaults.
-  uint32_t target_env_version_;
+  TargetEnvVersion target_env_version_;
 
   // The source language.  Defaults to GLSL.
   SourceLanguage source_language_;

--- a/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
+++ b/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
@@ -27,13 +27,16 @@ namespace shaderc_util {
 // Assembles the given assembly. On success, returns true, writes the assembled
 // binary to *binary, and clears *errors. Otherwise, writes the error message
 // into *errors.
-bool SpirvToolsAssemble(Compiler::TargetEnv env, const string_piece assembly,
-                        spv_binary* binary, std::string* errors);
+bool SpirvToolsAssemble(Compiler::TargetEnv env,
+                        Compiler::TargetEnvVersion version,
+                        const string_piece assembly, spv_binary* binary,
+                        std::string* errors);
 
 // Disassembles the given binary. Returns true and writes the disassembled text
 // to *text_or_error if successful. Otherwise, writes the error message to
 // *text_or_error.
 bool SpirvToolsDisassemble(Compiler::TargetEnv env,
+                           Compiler::TargetEnvVersion version,
                            const std::vector<uint32_t>& binary,
                            std::string* text_or_error);
 
@@ -55,6 +58,7 @@ enum class PassId {
 // optimized binary back to *binary if successful. Otherwise, writes errors to
 // *errors and the content of binary may be in an invalid state.
 bool SpirvToolsOptimize(Compiler::TargetEnv env,
+                        Compiler::TargetEnvVersion version,
                         const std::vector<PassId>& enabled_passes,
                         std::vector<uint32_t>* binary, std::string* errors);
 

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -25,8 +25,8 @@
 namespace {
 
 using shaderc_util::Compiler;
-using ::testing::HasSubstr;
 using ::testing::Eq;
+using ::testing::HasSubstr;
 using ::testing::Not;
 
 // A trivial vertex shader
@@ -149,13 +149,13 @@ float4 main() : SV_Target0 {
 }
 )";
 
-
 // Returns the disassembly of the given SPIR-V binary, as a string.
 // Assumes the disassembly will be successful when targeting Vulkan.
 std::string Disassemble(const std::vector<uint32_t> binary) {
   std::string result;
-  shaderc_util::SpirvToolsDisassemble(Compiler::TargetEnv::Vulkan, binary,
-                                      &result);
+  shaderc_util::SpirvToolsDisassemble(Compiler::TargetEnv::Vulkan,
+                                      Compiler::TargetEnvVersion::Vulkan_1_1,
+                                      binary, &result);
   return result;
 }
 
@@ -319,7 +319,8 @@ TEST_F(CompilerTest, BadTargetEnvFails) {
 }
 
 TEST_F(CompilerTest, BadTargetEnvVersionFails) {
-  compiler_.SetTargetEnv(Compiler::TargetEnv::Vulkan, 123);
+  compiler_.SetTargetEnv(Compiler::TargetEnv::Vulkan,
+                         static_cast<Compiler::TargetEnvVersion>(123));
   EXPECT_FALSE(SimpleCompilationSucceeds(kVulkanVertexShader, EShLangVertex));
   EXPECT_THAT(errors_,
               HasSubstr("Invalid target client version 123 for environment 0"));
@@ -499,8 +500,8 @@ TEST_F(CompilerTest, TexelOffsetRaiseTheMaximum) {
 
 TEST_F(CompilerTest, GeneratorWordIsShadercOverGlslang) {
   const auto words = SimpleCompilationBinary(kVertexShader, EShLangVertex);
-  const uint32_t shaderc_over_glslang = 13; // From SPIR-V XML Registry
-  const uint32_t generator_word_index = 2; // From SPIR-V binary layout
+  const uint32_t shaderc_over_glslang = 13;  // From SPIR-V XML Registry
+  const uint32_t generator_word_index = 2;   // From SPIR-V binary layout
   EXPECT_EQ(shaderc_over_glslang, words[generator_word_index] >> 16u);
 }
 


### PR DESCRIPTION
Otherwise the assembling/disassembling/optimizing may error out
because of target environment version mismatch.

Fixes https://github.com/google/shaderc/issues/475