### PR TITLE
Use SHADERC_BUILD_SHARED to control static/shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,15 @@ cmake_minimum_required(VERSION 2.8.12)
 project(shaderc)
 enable_testing()
 
+set (CMAKE_CXX_STANDARD 11)
+
 message(STATUS "Shaderc: build type is \"${CMAKE_BUILD_TYPE}\".")
+
+# Note that we are not using or setting CMake BUILD_SHARED_LIBS here since that
+# also affects external projects and makes libshaderc.so to depend on shared
+# libraries compiled from external projects. We want libshaderc.so to depend
+# on only standard system libraries.
+option(SHADERC_BUILD_SHARED "Build Shaderc as shared library" OFF)
 
 option(SHADERC_SKIP_INSTALL "Skip installation" ${SHADERC_SKIP_INSTALL})
 if(NOT ${SHADERC_SKIP_INSTALL})
@@ -18,8 +26,6 @@ if(${SHADERC_ENABLE_TESTS})
 else()
   message(STATUS "Configuring Shaderc to avoid building tests.")
 endif()
-
-set (CMAKE_CXX_STANDARD 11)
 
 option(SHADERC_ENABLE_NV_EXTENSIONS "Enables support of Nvidia-specific extensions" ON)
 

--- a/libshaderc/CMakeLists.txt
+++ b/libshaderc/CMakeLists.txt
@@ -10,18 +10,19 @@ set(SHADERC_SOURCES
   src/shaderc_private.h
 )
 
-add_library(shaderc STATIC ${SHADERC_SOURCES})
+if (${SHADERC_BUILD_SHARED})
+  add_library(shaderc SHARED ${SHADERC_SOURCES})
+  target_compile_definitions(shaderc
+      PRIVATE SHADERC_IMPLEMENTATION
+      PUBLIC SHADERC_SHAREDLIB
+  )
+  set_target_properties(shaderc PROPERTIES SOVERSION 1)
+else()
+  add_library(shaderc STATIC ${SHADERC_SOURCES})
+endif (${SHADERC_BUILD_SHARED})
+
 shaderc_default_compile_options(shaderc)
 target_include_directories(shaderc PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
-
-add_library(shaderc_shared SHARED ${SHADERC_SOURCES})
-shaderc_default_compile_options(shaderc_shared)
-target_include_directories(shaderc_shared PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
-target_compile_definitions(shaderc_shared
-    PRIVATE SHADERC_IMPLEMENTATION
-    PUBLIC SHADERC_SHAREDLIB
-)
-set_target_properties(shaderc_shared PROPERTIES SOVERSION 1)
 
 if(SHADERC_ENABLE_INSTALL)
   install(
@@ -31,7 +32,7 @@ if(SHADERC_ENABLE_INSTALL)
     DESTINATION
       ${CMAKE_INSTALL_INCLUDEDIR}/shaderc)
 
-  install(TARGETS shaderc shaderc_shared
+  install(TARGETS shaderc
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -46,7 +47,6 @@ set(SHADERC_LIBS
 )
 
 target_link_libraries(shaderc PRIVATE ${SHADERC_LIBS})
-target_link_libraries(shaderc_shared PRIVATE ${SHADERC_LIBS})
 
 shaderc_add_tests(
   TEST_PREFIX shaderc
@@ -58,42 +58,34 @@ shaderc_add_tests(
     shaderc_cpp
     shaderc_private)
 
-shaderc_add_tests(
-  TEST_PREFIX shaderc_shared
-  LINK_LIBS shaderc_shared SPIRV-Tools
-  INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc_util/include ${glslang_SOURCE_DIR}
-               ${spirv-tools_SOURCE_DIR}/include
-  TEST_NAMES
-    shaderc
-    shaderc_cpp
-    shaderc_private)
+if (NOT ${SHADERC_BUILD_SHARED})
+  shaderc_combine_static_lib(shaderc_combined shaderc)
 
-shaderc_combine_static_lib(shaderc_combined shaderc)
+  if(SHADERC_ENABLE_INSTALL)
+    # Since shaderc_combined is defined as an imported library, we cannot use the
+    # install() directive to install it. Install it like a normal file.
+    get_target_property(generated_location shaderc_combined LOCATION)
+    string(REGEX MATCH "Visual Studio .*" vs_generator "${CMAKE_GENERATOR}")
+    if (NOT "${vs_generator}" STREQUAL "")
+      # With Visual Studio generators, the LOCATION property is not properly
+      # expanded according to the current build configuration. We need to work
+      # around this problem by manually substitution.
+      string(REPLACE "$(Configuration)" "\${CMAKE_INSTALL_CONFIG_NAME}"
+        install_location "${generated_location}")
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    else()
+      install(FILES ${generated_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    endif()
+  endif(SHADERC_ENABLE_INSTALL)
 
-if(SHADERC_ENABLE_INSTALL)
-  # Since shaderc_combined is defined as an imported library, we cannot use the
-  # install() directive to install it. Install it like a normal file.
-  get_target_property(generated_location shaderc_combined LOCATION)
-  string(REGEX MATCH "Visual Studio .*" vs_generator "${CMAKE_GENERATOR}")
-  if (NOT "${vs_generator}" STREQUAL "")
-    # With Visual Studio generators, the LOCATION property is not properly
-    # expanded according to the current build configuration. We need to work
-    # around this problem by manually substitution.
-    string(REPLACE "$(Configuration)" "\${CMAKE_INSTALL_CONFIG_NAME}"
-      install_location "${generated_location}")
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  else()
-    install(FILES ${generated_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  endif()
-endif(SHADERC_ENABLE_INSTALL)
-
-shaderc_add_tests(
-  TEST_PREFIX shaderc_combined
-  LINK_LIBS shaderc_combined ${CMAKE_THREAD_LIBS_INIT}
-  INCLUDE_DIRS include ${glslang_SOURCE_DIR} ${spirv-tools_SOURCE_DIR}/include
-  TEST_NAMES
-    shaderc
-    shaderc_cpp)
+  shaderc_add_tests(
+    TEST_PREFIX shaderc_combined
+    LINK_LIBS shaderc_combined ${CMAKE_THREAD_LIBS_INIT}
+    INCLUDE_DIRS include ${glslang_SOURCE_DIR} ${spirv-tools_SOURCE_DIR}/include
+    TEST_NAMES
+      shaderc
+      shaderc_cpp)
+endif(NOT ${SHADERC_BUILD_SHARED})
 
 if(${SHADERC_ENABLE_TESTS})
   add_executable(shaderc_c_smoke_test ./src/shaderc_c_smoke_test.c)


### PR DESCRIPTION
Previously we build both static and shared library at the same
time. Because of that, we cannot name both the static and shared
library as shaderc.

This commit stops compiling both static and shared library.
Instead we let the user choose now.