### PR TITLE
Disable layout and relax logical pointer for optimizer validation

### DIFF
--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -320,6 +320,26 @@ const char kHlslWaveActiveSumeComputeShader[] =
        MyBuffer[id.x].result = WaveActiveSum(MyBuffer[id.x].val);
      })";
 
+const char kHlslMemLayoutResourceSelect[] =
+    R"(cbuffer Foo { float a; float3 b; }
+
+       Texture2D Tex;
+       SamplerState Sampler1;
+       SamplerState Sampler2;
+
+       static const int val = 42;
+
+       float4 main() : SV_Target {
+         SamplerState samp;
+
+         if (val > 5)
+           samp = Sampler1;
+         else
+           samp = Sampler2;
+
+         return Tex.Sample(samp, float2(0.5, 0.5)) + float4(a, b);
+       })";
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -1558,35 +1558,29 @@ TEST_F(CompileStringTest, LimitsTexelOffsetDefault) {
                                   shaderc_glsl_fragment_shader,
                                   options_.get()));
   EXPECT_TRUE(CompilationSuccess(ShaderWithTexOffset(-8).c_str(),
-                                 shaderc_glsl_fragment_shader,
-                                 options_.get()));
+                                 shaderc_glsl_fragment_shader, options_.get()));
   EXPECT_TRUE(CompilationSuccess(ShaderWithTexOffset(7).c_str(),
-                                 shaderc_glsl_fragment_shader,
-                                 options_.get()));
+                                 shaderc_glsl_fragment_shader, options_.get()));
   EXPECT_FALSE(CompilationSuccess(ShaderWithTexOffset(8).c_str(),
                                   shaderc_glsl_fragment_shader,
                                   options_.get()));
 }
 
 TEST_F(CompileStringTest, LimitsTexelOffsetLowerMinimum) {
-  shaderc_compile_options_set_limit(options_.get(),
-                                    shaderc_limit_min_program_texel_offset,
-                                    -99);
+  shaderc_compile_options_set_limit(
+      options_.get(), shaderc_limit_min_program_texel_offset, -99);
   EXPECT_FALSE(CompilationSuccess(ShaderWithTexOffset(-100).c_str(),
                                   shaderc_glsl_fragment_shader,
                                   options_.get()));
   EXPECT_TRUE(CompilationSuccess(ShaderWithTexOffset(-99).c_str(),
-                                 shaderc_glsl_fragment_shader,
-                                 options_.get()));
+                                 shaderc_glsl_fragment_shader, options_.get()));
 }
 
 TEST_F(CompileStringTest, LimitsTexelOffsetHigherMaximum) {
   shaderc_compile_options_set_limit(options_.get(),
-                                    shaderc_limit_max_program_texel_offset,
-                                    10);
+                                    shaderc_limit_max_program_texel_offset, 10);
   EXPECT_TRUE(CompilationSuccess(ShaderWithTexOffset(10).c_str(),
-                                 shaderc_glsl_fragment_shader,
-                                 options_.get()));
+                                 shaderc_glsl_fragment_shader, options_.get()));
   EXPECT_FALSE(CompilationSuccess(ShaderWithTexOffset(11).c_str(),
                                   shaderc_glsl_fragment_shader,
                                   options_.get()));
@@ -1787,7 +1781,8 @@ TEST_F(CompileStringWithOptionsTest, HlslFunctionality1OffByDefault) {
   const std::string disassembly_text =
       CompilationOutput(kHlslShaderWithCounterBuffer, shaderc_fragment_shader,
                         options_.get(), OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorateStringGOOGLE"))) << disassembly_text;
+  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorateStringGOOGLE")))
+      << disassembly_text;
 }
 
 TEST_F(CompileStringWithOptionsTest, HlslFunctionality1Respected) {
@@ -1810,6 +1805,16 @@ TEST_F(CompileStringWithOptionsTest, HlslFunctionality1SurvivesCloning) {
       CompilationOutput(kHlslShaderWithCounterBuffer, shaderc_fragment_shader,
                         cloned_options.get(), OutputType::SpirvAssemblyText);
   EXPECT_THAT(disassembly_text, HasSubstr("OpDecorateStringGOOGLE"));
+}
+
+TEST_F(CompileStringWithOptionsTest, HlslFlexibleMemoryLayoutAllowed) {
+  shaderc_compile_options_set_source_language(options_.get(),
+                                              shaderc_source_language_hlsl);
+  shaderc_compile_options_set_optimization_level(
+      options_.get(), shaderc_optimization_level_performance);
+
+  EXPECT_TRUE(CompilesToValidSpv(compiler_, kHlslMemLayoutResourceSelect,
+                                 shaderc_fragment_shader, options_.get()));
 }
 
 }  // anonymous namespace

--- a/libshaderc_util/src/spirv_tools_wrapper.cc
+++ b/libshaderc_util/src/spirv_tools_wrapper.cc
@@ -111,7 +111,18 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
     return true;
   }
 
+  spvtools::ValidatorOptions val_opts;
+  // This allows flexible memory layout for HLSL.
+  val_opts.SetSkipBlockLayout(true);
+  // This allows HLSL legalization regarding resources.
+  val_opts.SetRelaxLogicalPointer(true);
+
+  spvtools::OptimizerOptions opt_opts;
+  opt_opts.set_validator_options(val_opts);
+  opt_opts.set_run_validator(true);
+
   spvtools::Optimizer optimizer(GetSpirvToolsTargetEnv(env, version));
+
   std::ostringstream oss;
   optimizer.SetMessageConsumer(
       [&oss](spv_message_level_t, const char*, const spv_position_t&,
@@ -140,7 +151,7 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
     }
   }
 
-  if (!optimizer.Run(binary->data(), binary->size(), binary)) {
+  if (!optimizer.Run(binary->data(), binary->size(), binary, opt_opts)) {
     *errors = oss.str();
     return false;
   }


### PR DESCRIPTION
These two validation exceptions are needed for HLSL compilation.

Fixes https://github.com/google/shaderc/issues/499