### PR TITLE
Only include third_party directories if needed.

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -32,31 +32,35 @@ if (IS_DIRECTORY ${SHADERC_SPIRV_HEADERS_DIR})
   add_subdirectory(${SHADERC_SPIRV_HEADERS_DIR} spirv-headers)
 endif()
 
-# Check SPIRV-Tools before glslang so that it is linked into glslang.
-# we control optimizations via glslang API calls directly.
-if (IS_DIRECTORY ${SHADERC_SPIRV_TOOLS_DIR})
-  if ("${SHADERC_SKIP_TESTS}")
-    # Also skip building tests in SPIRV-Tools.
-    set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
-  endif()
-  add_subdirectory(${SHADERC_SPIRV_TOOLS_DIR} spirv-tools)
-endif()
 if (NOT TARGET SPIRV-Tools)
-  message(FATAL_ERROR "SPIRV-Tools was not found - required for compilation")
+  # Check SPIRV-Tools before glslang so that it is linked into glslang.
+  # we control optimizations via glslang API calls directly.
+  if (IS_DIRECTORY ${SHADERC_SPIRV_TOOLS_DIR})
+    if ("${SHADERC_SKIP_TESTS}")
+      # Also skip building tests in SPIRV-Tools.
+      set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
+    endif()
+    add_subdirectory(${SHADERC_SPIRV_TOOLS_DIR} spirv-tools)
+  endif()
+  if (NOT TARGET SPIRV-Tools)
+    message(FATAL_ERROR "SPIRV-Tools was not found - required for compilation")
+  endif()
 endif()
 
-if (IS_DIRECTORY ${SHADERC_GLSLANG_DIR})
-  add_subdirectory(${SHADERC_GLSLANG_DIR} glslang)
-endif()
 if (NOT TARGET glslang)
-  message(FATAL_ERROR "glslang was not found - required for compilation")
-endif()
-if(WIN32)
-    # This is unfortunate but glslang forces our
-    # platform toolset to be v110, which we may not even have
-    # installed, undo anything glslang has done to it.
-    set(CMAKE_GENERATOR_TOOLSET "${OLD_PLATFORM_TOOLSET}" CACHE STRING
-      "Platform Toolset" FORCE)
+  if (IS_DIRECTORY ${SHADERC_GLSLANG_DIR})
+    add_subdirectory(${SHADERC_GLSLANG_DIR} glslang)
+  endif()
+  if (NOT TARGET glslang)
+    message(FATAL_ERROR "glslang was not found - required for compilation")
+  endif()
+  if(WIN32)
+      # This is unfortunate but glslang forces our
+      # platform toolset to be v110, which we may not even have
+      # installed, undo anything glslang has done to it.
+      set(CMAKE_GENERATOR_TOOLSET "${OLD_PLATFORM_TOOLSET}" CACHE STRING
+        "Platform Toolset" FORCE)
+  endif()
 endif()
 
 if(${SHADERC_ENABLE_TESTS})


### PR DESCRIPTION
Currently the third_party directories are always added in the cmake
file. This CL changes the including to only happen if the target that
will be included is not already defined.