### PR TITLE
Add effcee and re2 when building spirv-tools tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,10 @@ build-*/
 compile_commands.json
 .ycm_extra_conf.py
 cscope.*
+third_party/effcee/
 third_party/glslang/
 third_party/googletest/
+third_party/re2/
 third_party/spirv-tools/
 third_party/spirv-headers/
 android_test/libs

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ git clone https://github.com/google/googletest.git
 git clone https://github.com/google/glslang.git
 git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
 git clone https://github.com/KhronosGroup/SPIRV-Headers.git spirv-headers
+git clone https://github.com/google/re2.git
+git clone https://github.com/google/effcee.git
 cd $SOURCE_DIR/
 ```
 

--- a/kokoro/android-release/build.sh
+++ b/kokoro/android-release/build.sh
@@ -41,8 +41,8 @@ git clone https://github.com/google/googletest.git
 git clone https://github.com/google/glslang.git
 git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
 git clone https://github.com/KhronosGroup/SPIRV-Headers.git spirv-headers
-git clone https://github.com/google/re2 spirv-tools/external/re2
-git clone https://github.com/google/effcee spirv-tools/external/effcee
+git clone https://github.com/google/re2
+git clone https://github.com/google/effcee
 
 cd $SRC/
 mkdir build

--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -74,8 +74,8 @@ git clone https://github.com/google/googletest.git
 git clone https://github.com/google/glslang.git
 git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
 git clone https://github.com/KhronosGroup/SPIRV-Headers.git spirv-headers
-git clone https://github.com/google/re2 spirv-tools/external/re2
-git clone https://github.com/google/effcee spirv-tools/external/effcee
+git clone https://github.com/google/re2
+git clone https://github.com/google/effcee
 
 cd $SRC/
 mkdir build

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -36,8 +36,8 @@ git clone https://github.com/google/googletest.git
 git clone https://github.com/google/glslang.git
 git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
 git clone https://github.com/KhronosGroup/SPIRV-Headers.git spirv-headers
-git clone https://github.com/google/re2 spirv-tools/external/re2
-git clone https://github.com/google/effcee spirv-tools/external/effcee
+git clone https://github.com/google/re2
+git clone https://github.com/google/effcee
 
 cd $SRC/
 mkdir build

--- a/kokoro/ndk-build/build.sh
+++ b/kokoro/ndk-build/build.sh
@@ -45,9 +45,9 @@ cd $SRC/third_party
 git clone $GLSLANG_REPO_URL
 git clone https://github.com/google/googletest.git
 git clone https://github.com/KhronosGroup/SPIRV-Tools.git   spirv-tools
-git clone https://github.com/KhronosGroup/SPIRV-Headers.git spirv-tools/external/spirv-headers
-git clone https://github.com/google/re2                     spirv-tools/external/re2
-git clone https://github.com/google/effcee                  spirv-tools/external/effcee
+git clone https://github.com/KhronosGroup/SPIRV-Headers.git spirv-headers
+git clone https://github.com/google/re2
+git clone https://github.com/google/effcee
 
 cd $SRC/
 mkdir build

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -29,8 +29,8 @@ git clone https://github.com/google/googletest.git
 git clone https://github.com/google/glslang.git
 git clone https://github.com/KhronosGroup/SPIRV-Tools.git spirv-tools
 git clone https://github.com/KhronosGroup/SPIRV-Headers.git spirv-headers
-git clone https://github.com/google/re2 spirv-tools/external/re2
-git clone https://github.com/google/effcee spirv-tools/external/effcee
+git clone https://github.com/google/re2
+git clone https://github.com/google/effcee
 
 cmake --version
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -44,7 +44,7 @@ if (NOT TARGET SPIRV-Tools)
       # Also skip building tests in SPIRV-Tools.
       set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
     elseif(NOT "${SPIRV_SKIP_TESTS}")
-      # SPIRV-Tools requires re2 and effcee to build tests.
+      # SPIRV-Tools requires effcee and re2 to build tests.
       add_subdirectory(${SHADERC_RE2_DIR} re2)
       add_subdirectory(${SHADERC_EFFCEE_DIR} effcee)
     endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -44,7 +44,7 @@ if (NOT TARGET SPIRV-Tools)
       # Also skip building tests in SPIRV-Tools.
       set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
     else()
-      # SPIRV-Tools requires re2 and effcee to build tests
+      # SPIRV-Tools requires re2 and effcee to build tests.
       add_subdirectory(${SHADERC_RE2_DIR} re2)
       add_subdirectory(${SHADERC_EFFCEE_DIR} effcee)
     endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -43,7 +43,7 @@ if (NOT TARGET SPIRV-Tools)
     if ("${SHADERC_SKIP_TESTS}")
       # Also skip building tests in SPIRV-Tools.
       set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
-    else if(NOT "${SPIRV_SKIP_TESTS}")
+    elseif(NOT "${SPIRV_SKIP_TESTS}")
       # SPIRV-Tools requires re2 and effcee to build tests.
       add_subdirectory(${SHADERC_RE2_DIR} re2)
       add_subdirectory(${SHADERC_EFFCEE_DIR} effcee)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -43,7 +43,7 @@ if (NOT TARGET SPIRV-Tools)
     if ("${SHADERC_SKIP_TESTS}")
       # Also skip building tests in SPIRV-Tools.
       set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
-    else()
+    else if(NOT "${SPIRV_SKIP_TESTS}")
       # SPIRV-Tools requires re2 and effcee to build tests.
       add_subdirectory(${SHADERC_RE2_DIR} re2)
       add_subdirectory(${SHADERC_EFFCEE_DIR} effcee)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -11,6 +11,10 @@ set(SHADERC_SPIRV_HEADERS_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/spirv-headers" CA
   "Location of spirv-headers source")
 set(SHADERC_GLSLANG_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/glslang" CACHE STRING
   "Location of glslang source")
+set(SHADERC_EFFCEE_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/effcee" CACHE STRING
+  "Location of effcee source")
+set(SHADERC_RE2_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/re2" CACHE STRING
+  "Location of re2 source")
 
 set( SKIP_GLSLANG_INSTALL ${SHADERC_SKIP_INSTALL} )
 set( SKIP_SPIRV_TOOLS_INSTALL ${SHADERC_SKIP_INSTALL} )
@@ -39,6 +43,10 @@ if (NOT TARGET SPIRV-Tools)
     if ("${SHADERC_SKIP_TESTS}")
       # Also skip building tests in SPIRV-Tools.
       set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
+    else()
+      # SPIRV-Tools requires re2 and effcee to build tests
+      add_subdirectory(${SHADERC_RE2_DIR} re2)
+      add_subdirectory(${SHADERC_EFFCEE_DIR} effcee)
     endif()
     add_subdirectory(${SHADERC_SPIRV_TOOLS_DIR} spirv-tools)
   endif()


### PR DESCRIPTION
The effcee library was made a requirement for building the SPIRV-Tools test suite. When building that suite through shaderc we need to make sure the required dependencies are available.