### PR TITLE
Add support for NV_EXTENSIONS in #pragma shader_stage()

### DIFF
--- a/libshaderc_util/src/shader_stage.cc
+++ b/libshaderc_util/src/shader_stage.cc
@@ -33,7 +33,18 @@ EShLanguage MapStageNameToLanguage(const string_piece& stage_name) {
       {"tesscontrol", EShLangTessControl},
       {"tesseval", EShLangTessEvaluation},
       {"geometry", EShLangGeometry},
-      {"compute", EShLangCompute}};
+      {"compute", EShLangCompute},
+#ifdef NV_EXTENSIONS
+      {"raygen", EShLangRayGenNV},
+      {"intersect", EShLangIntersectNV},
+      {"anyhit", EShLangAnyHitNV},
+      {"closest", EShLangClosestHitNV},
+      {"miss", EShLangMissNV},
+      {"callable", EShLangCallableNV},
+      {"task", EShLangTaskNV},
+      {"mesh", EShLangMeshNV},
+#endif
+  };
 
   for (const auto& entry : string_to_stage) {
     if (stage_name == entry.id) return entry.language;


### PR DESCRIPTION
This adds missing support for raytracing and task/mesh shaders to
shader_stage() pragma so that you can build these shaders without
specifying the stage via command line arguments.