### PR TITLE
Add git clone of re2 and effcee to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN git clone https://github.com/google/googletest.git          third_party/goog
 RUN git clone https://github.com/google/glslang.git             third_party/glslang
 RUN git clone https://github.com/KhronosGroup/SPIRV-Tools.git   third_party/spirv-tools
 RUN git clone https://github.com/KhronosGroup/SPIRV-Headers.git third_party/spirv-tools/external/spirv-headers
+RUN git clone https://github.com/google/re2.git                 third_party/re2
+RUN git clone https://github.com/google/effcee.git              third_party/effcee
 
 WORKDIR build
 RUN cmake -GNinja \


### PR DESCRIPTION
Currently, building the docker container fails with:
```
CMake Error at third_party/CMakeLists.txt:49 (add_subdirectory):
  add_subdirectory given source "/root/shaderc/third_party/re2" which is not
  an existing directory.


CMake Error at third_party/CMakeLists.txt:50 (add_subdirectory):
  add_subdirectory given source "/root/shaderc/third_party/effcee" which is
  not an existing directory.
```
It looks like the CMake file has been changed without updating the Dockerfile. This just adds a git clone of the two projects.