### PR TITLE
Generate source text debug info if requested

### DIFF
--- a/glslc/test/option_dash_cap_O.py
+++ b/glslc/test/option_dash_cap_O.py
@@ -20,6 +20,34 @@ from placeholder import FileShader
 MINIMAL_SHADER = '#version 310 es\nvoid main() {}'
 EMPTY_SHADER_IN_CWD = Directory('.', [File('shader.vert', MINIMAL_SHADER)])
 
+ASSEMBLY_WITH_DEBUG_SOURCE = [
+    '; SPIR-V\n',
+    '; Version: 1.0\n',
+    '; Generator: Google Shaderc over Glslang; 7\n',
+    '; Bound: 7\n',
+    '; Schema: 0\n',
+    '               OpCapability Shader\n',
+    '          %2 = OpExtInstImport "GLSL.std.450"\n',
+    '               OpMemoryModel Logical GLSL450\n',
+    '               OpEntryPoint Vertex %main "main"\n',
+    '          %1 = OpString "shader.vert"\n',
+    '               OpSource ESSL 310 %1 "// OpModuleProcessed entry-point main\n',
+    '// OpModuleProcessed client vulkan100\n',
+    '// OpModuleProcessed target-env vulkan1.0\n',
+    '// OpModuleProcessed entry-point main\n',
+    '#line 1\n',
+    '#version 310 es\n',
+    'void main() {}"\n',
+    '               OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"\n',
+    '               OpSourceExtension "GL_GOOGLE_include_directive"\n',
+    '               OpName %main "main"\n',
+    '       %void = OpTypeVoid\n',
+    '          %4 = OpTypeFunction %void\n',
+    '       %main = OpFunction %void None %4\n',
+    '          %6 = OpLabel\n',
+    '               OpReturn\n',
+    '               OpFunctionEnd\n']
+
 ASSEMBLY_WITH_DEBUG = [
     '; SPIR-V\n',
     '; Version: 1.0\n',
@@ -104,7 +132,7 @@ class TestDashCapOWithDashG(expect.ValidFileContents):
     environment = EMPTY_SHADER_IN_CWD
     glslc_args = ['-S', '-Os', '-g', 'shader.vert']
     target_filename = 'shader.vert.spvasm'
-    expected_file_contents = ASSEMBLY_WITH_DEBUG
+    expected_file_contents = ASSEMBLY_WITH_DEBUG_SOURCE
 
 
 @inside_glslc_testsuite('OptionDashCapO')
@@ -114,7 +142,7 @@ class TestDashGWithDashCapO(expect.ValidFileContents):
     environment = EMPTY_SHADER_IN_CWD
     glslc_args = ['-S', '-g', '-Os', 'shader.vert']
     target_filename = 'shader.vert.spvasm'
-    expected_file_contents = ASSEMBLY_WITH_DEBUG
+    expected_file_contents = ASSEMBLY_WITH_DEBUG_SOURCE
 
 
 @inside_glslc_testsuite('OptionDashCapO')

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -242,6 +242,18 @@ const char* kMinimalShaderDisassemblySubstrings[] = {
     "               OpReturn\n",
     "               OpFunctionEnd\n"};
 
+const char* kMinimalShaderDebugInfoDisassemblySubstrings[] = {
+    "; SPIR-V\n"
+    "; Version: 1.0\n"
+    "; Generator: Google Shaderc over Glslang; 7\n"
+    "; Bound:",
+
+    "               OpCapability Shader\n",
+    "          %2 = OpExtInstImport \"GLSL.std.450\"\n",
+    "               OpMemoryModel Logical GLSL450\n",
+    "               OpReturn\n",
+    "               OpFunctionEnd\n"};
+
 const char kMinimalShaderAssembly[] = R"(
     ; SPIR-V
     ; Version: 1.0

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -458,21 +458,29 @@ TEST_F(CppInterface, ForcedVersionProfileRedundantProfileStd) {
 
 TEST_F(CppInterface, GenerateDebugInfoBinary) {
   options_.SetGenerateDebugInfo();
-  // The output binary should contain the name of the vector: debug_info_sample
-  // as char array.
-  EXPECT_THAT(CompilationOutput(kMinimalDebugInfoShader,
-                                shaderc_glsl_vertex_shader, options_),
-              HasSubstr("debug_info_sample"));
+  const std::string binary_output =
+      CompilationOutput(kMinimalDebugInfoShader,
+                        shaderc_glsl_vertex_shader, options_);
+  // The binary output should contain the name of the vector (debug_info_sample)
+  // null-terminated, as well as the whole original source.
+  std::string vector_name("debug_info_sample");
+  vector_name.resize(vector_name.size() + 1);
+  EXPECT_THAT(binary_output, HasSubstr(vector_name));
+  EXPECT_THAT(binary_output, HasSubstr(kMinimalDebugInfoShader));
 }
 
 TEST_F(CppInterface, GenerateDebugInfoBinaryClonedOptions) {
   options_.SetGenerateDebugInfo();
   CompileOptions cloned_options(options_);
-  // The output binary should contain the name of the vector: debug_info_sample
-  // as char array.
-  EXPECT_THAT(CompilationOutput(kMinimalDebugInfoShader,
-                                shaderc_glsl_vertex_shader, cloned_options),
-              HasSubstr("debug_info_sample"));
+  const std::string binary_output =
+      CompilationOutput(kMinimalDebugInfoShader,
+                        shaderc_glsl_vertex_shader, cloned_options);
+  // The binary output should contain the name of the vector (debug_info_sample)
+  // null-terminated, as well as the whole original source.
+  std::string vector_name("debug_info_sample");
+  vector_name.resize(vector_name.size() + 1);
+  EXPECT_THAT(binary_output, HasSubstr(vector_name));
+  EXPECT_THAT(binary_output, HasSubstr(kMinimalDebugInfoShader));
 }
 
 TEST_F(CppInterface, GenerateDebugInfoDisassembly) {
@@ -571,7 +579,7 @@ TEST_F(CppInterface, GenerateDebugInfoOverridesOptimizationLevel) {
   options_.SetGenerateDebugInfo();
   const std::string disassembly_text =
       AssemblyOutput(kMinimalShader, shaderc_glsl_vertex_shader, options_);
-  for (const auto& substring : kMinimalShaderDisassemblySubstrings) {
+  for (const auto& substring : kMinimalShaderDebugInfoDisassemblySubstrings) {
     EXPECT_THAT(disassembly_text, HasSubstr(substring));
   }
   // Check that we still have debug instructions.
@@ -585,7 +593,7 @@ TEST_F(CppInterface, GenerateDebugInfoProhibitsOptimizationLevel) {
   options_.SetOptimizationLevel(shaderc_optimization_level_size);
   const std::string disassembly_text =
       AssemblyOutput(kMinimalShader, shaderc_glsl_vertex_shader, options_);
-  for (const auto& substring : kMinimalShaderDisassemblySubstrings) {
+  for (const auto& substring : kMinimalShaderDebugInfoDisassemblySubstrings) {
     EXPECT_THAT(disassembly_text, HasSubstr(substring));
   }
   // Check that we still have debug instructions.

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -608,10 +608,15 @@ TEST_F(CompileStringWithOptionsTest, ForcedVersionProfileRedundantProfileStd) {
 TEST_F(CompileStringWithOptionsTest, GenerateDebugInfoBinary) {
   shaderc_compile_options_set_generate_debug_info(options_.get());
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
-  // The binary output should contain the name of the vector: debug_info_sample.
-  EXPECT_THAT(CompilationOutput(kMinimalDebugInfoShader,
-                                shaderc_glsl_vertex_shader, options_.get()),
-              HasSubstr("debug_info_sample"));
+  const std::string binary_output =
+      CompilationOutput(kMinimalDebugInfoShader,
+                        shaderc_glsl_vertex_shader, options_.get());
+  // The binary output should contain the name of the vector (debug_info_sample)
+  // null-terminated, as well as the whole original source.
+  std::string vector_name("debug_info_sample");
+  vector_name.resize(vector_name.size() + 1);
+  EXPECT_THAT(binary_output, HasSubstr(vector_name));
+  EXPECT_THAT(binary_output, HasSubstr(kMinimalDebugInfoShader));
 }
 
 TEST_F(CompileStringWithOptionsTest, GenerateDebugInfoBinaryClonedOptions) {
@@ -619,11 +624,15 @@ TEST_F(CompileStringWithOptionsTest, GenerateDebugInfoBinaryClonedOptions) {
   compile_options_ptr cloned_options(
       shaderc_compile_options_clone(options_.get()));
   ASSERT_NE(nullptr, compiler_.get_compiler_handle());
-  // The binary output should contain the name of the vector: debug_info_sample.
-  EXPECT_THAT(
-      CompilationOutput(kMinimalDebugInfoShader, shaderc_glsl_vertex_shader,
-                        cloned_options.get()),
-      HasSubstr("debug_info_sample"));
+  const std::string binary_output =
+      CompilationOutput(kMinimalDebugInfoShader,
+                        shaderc_glsl_vertex_shader, cloned_options.get());
+  // The binary output should contain the name of the vector (debug_info_sample)
+  // null-terminated, as well as the whole original source.
+  std::string vector_name("debug_info_sample");
+  vector_name.resize(vector_name.size() + 1);
+  EXPECT_THAT(binary_output, HasSubstr(vector_name));
+  EXPECT_THAT(binary_output, HasSubstr(kMinimalDebugInfoShader));
 }
 
 TEST_F(CompileStringWithOptionsTest, GenerateDebugInfoDisassembly) {
@@ -730,7 +739,7 @@ TEST_F(CompileStringWithOptionsTest,
   const std::string disassembly_text =
       CompilationOutput(kMinimalShader, shaderc_glsl_vertex_shader,
                         options_.get(), OutputType::SpirvAssemblyText);
-  for (const auto& substring : kMinimalShaderDisassemblySubstrings) {
+  for (const auto& substring : kMinimalShaderDebugInfoDisassemblySubstrings) {
     EXPECT_THAT(disassembly_text, HasSubstr(substring));
   }
   // Check that we still have debug instructions.
@@ -747,7 +756,7 @@ TEST_F(CompileStringWithOptionsTest,
   const std::string disassembly_text =
       CompilationOutput(kMinimalShader, shaderc_glsl_vertex_shader,
                         options_.get(), OutputType::SpirvAssemblyText);
-  for (const auto& substring : kMinimalShaderDisassemblySubstrings) {
+  for (const auto& substring : kMinimalShaderDebugInfoDisassemblySubstrings) {
     EXPECT_THAT(disassembly_text, HasSubstr(substring));
   }
   // Check that we still have debug instructions.


### PR DESCRIPTION
Pass the necessary flags through to glslang to get it to emit OpSource containing the shader source text if it was requested in the options.

Implements issue #455.