### PR TITLE
Fixup source matching test

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ vars = {
   'googletest_revision': 'd5932506d6eed73ac80b9bcc47ed723c8c74eb1e',
   're2_revision': 'f620af75bd693f917c684106d26de1b99ffe0e0d',
   'spirv_headers_revision': '4618b86e9e4b027a22040732dfee35e399cd2c47',
-  'spirv_tools_revision': '64f2750e5dc553baa2922b780f15049023689ef9',
+  'spirv_tools_revision': '04cc2b15bcb05e55d0e5627ea916a9fe88cbb235',
 }
 
 deps = {

--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '8f0a61dc95e0df18c18e0ac56d83b3fa9d2fe90b',
-  'glslang_revision': '0fe8a948bee576257eb7661935794d39382c4552',
+  'glslang_revision': '3638a3b4f679f00e9b9a9b6df2df5e0a258ce236',
   'googletest_revision': 'd5932506d6eed73ac80b9bcc47ed723c8c74eb1e',
   're2_revision': 'f620af75bd693f917c684106d26de1b99ffe0e0d',
   'spirv_headers_revision': '4618b86e9e4b027a22040732dfee35e399cd2c47',

--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '8f0a61dc95e0df18c18e0ac56d83b3fa9d2fe90b',
-  'glslang_revision': '3638a3b4f679f00e9b9a9b6df2df5e0a258ce236',
+  'glslang_revision': 'e96fa717d387bff99b9a0fa47f422c863e0f2725',
   'googletest_revision': 'd5932506d6eed73ac80b9bcc47ed723c8c74eb1e',
   're2_revision': 'f620af75bd693f917c684106d26de1b99ffe0e0d',
   'spirv_headers_revision': '4618b86e9e4b027a22040732dfee35e399cd2c47',
@@ -19,7 +19,7 @@ deps = {
   'third_party/googletest': vars['google_git'] + '/googletest.git@' +
       vars['googletest_revision'],
 
-  'third_party/glslang': 'https://github.com/dj2/glslang.git@' +
+  'third_party/glslang': vars['khronos_git'] + '/glslang.git@' +
       vars['glslang_revision'],
 
   'third_party/re2': vars['google_git'] + '/re2.git@' +

--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '8f0a61dc95e0df18c18e0ac56d83b3fa9d2fe90b',
-  'glslang_revision': '83b2647293db3d777e77adbaf04283cf97a18661',
+  'glslang_revision': '0fe8a948bee576257eb7661935794d39382c4552',
   'googletest_revision': 'd5932506d6eed73ac80b9bcc47ed723c8c74eb1e',
   're2_revision': 'f620af75bd693f917c684106d26de1b99ffe0e0d',
   'spirv_headers_revision': '4618b86e9e4b027a22040732dfee35e399cd2c47',
@@ -19,7 +19,7 @@ deps = {
   'third_party/googletest': vars['google_git'] + '/googletest.git@' +
       vars['googletest_revision'],
 
-  'third_party/glslang': vars['khronos_git'] + '/glslang.git@' +
+  'third_party/glslang': 'https://github.com/dj2/glslang.git@' +
       vars['glslang_revision'],
 
   'third_party/re2': vars['google_git'] + '/re2.git@' +

--- a/glslc/test/option_dash_cap_O.py
+++ b/glslc/test/option_dash_cap_O.py
@@ -17,7 +17,7 @@ from environment import File, Directory
 from glslc_test_framework import inside_glslc_testsuite
 from placeholder import FileShader
 
-MINIMAL_SHADER = '#version 310 es\nvoid main() {}\n'
+MINIMAL_SHADER = '#version 310 es\nvoid main() {}'
 EMPTY_SHADER_IN_CWD = Directory('.', [File('shader.vert', MINIMAL_SHADER)])
 
 ASSEMBLY_WITH_DEBUG_SOURCE = [
@@ -37,8 +37,7 @@ ASSEMBLY_WITH_DEBUG_SOURCE = [
     '// OpModuleProcessed entry-point main\n',
     '#line 1\n',
     '#version 310 es\n',
-    'void main() {}\n',
-    '"\n',
+    'void main() {}"\n',
     '               OpSourceExtension "GL_GOOGLE_cpp_style_line_directive"\n',
     '               OpSourceExtension "GL_GOOGLE_include_directive"\n',
     '               OpName %main "main"\n',


### PR DESCRIPTION
This CL rolls GLSLang and reverts the test change made to make MacOS pass as it has
now been fixed upstream in GLSLang.