### PR TITLE
Remove use of deprecated googletest macro

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ vars = {
 
   'effcee_revision' : '8f0a61dc95e0df18c18e0ac56d83b3fa9d2fe90b',
   'glslang_revision': 'e96fa717d387bff99b9a0fa47f422c863e0f2725',
-  'googletest_revision': 'd5932506d6eed73ac80b9bcc47ed723c8c74eb1e',
+  'googletest_revision': '0599a7b8410dc5cfdb477900b280475ae775d7f9',
   're2_revision': '90970542fe952602f42150c6e71d086f5afebcb3',
   'spirv_headers_revision': '4618b86e9e4b027a22040732dfee35e399cd2c47',
   'spirv_tools_revision': '04cc2b15bcb05e55d0e5627ea916a9fe88cbb235',

--- a/glslc/src/resource_parse_test.cc
+++ b/glslc/src/resource_parse_test.cc
@@ -40,7 +40,7 @@ TEST_P(ParseResourceSettingsTest, Sample) {
   EXPECT_THAT(err, Eq(GetParam().message));
 }
 
-INSTANTIATE_TEST_CASE_P(ParseResources, ParseResourceSettingsTest,
+INSTANTIATE_TEST_SUITE_P(ParseResources, ParseResourceSettingsTest,
   ::testing::ValuesIn(std::vector<ResourceSettingsCase>{
     {"", true, {}, ""},
     {"   \t \t \n ", true, {}, ""},

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -706,7 +706,7 @@ TEST_P(ValidShaderKind, ValidSpvCode) {
       CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_kind_));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CompileStringTest, ValidShaderKind,
     testing::ValuesIn(std::vector<ShaderKindTestCase>{
         // Valid default shader kinds.
@@ -743,7 +743,7 @@ TEST_P(InvalidShaderKind, CompilationShouldFail) {
       CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_kind_));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CompileStringTest, InvalidShaderKind,
     testing::ValuesIn(std::vector<ShaderKindTestCase>{
         // Invalid default shader kind.
@@ -844,7 +844,7 @@ TEST_P(IncluderTests, SetIncluderClonedOptions) {
               HasSubstr(test_case.expected_substring()));
 }
 
-INSTANTIATE_TEST_CASE_P(CppInterface, IncluderTests,
+INSTANTIATE_TEST_SUITE_P(CppInterface, IncluderTests,
                         testing::ValuesIn(std::vector<IncluderTestCase>{
                             IncluderTestCase(
                                 // Fake file system.

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -812,7 +812,7 @@ TEST_P(ValidShaderKind, ValidSpvCode) {
       CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_kind_));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CompileStringTest, ValidShaderKind,
     testing::ValuesIn(std::vector<ShaderKindTestCase>{
         // Valid default shader kinds.
@@ -858,7 +858,7 @@ TEST_P(InvalidShaderKind, CompilationShouldFail) {
       CompilesToValidSpv(compiler, test_case.shader_, test_case.shader_kind_));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CompileStringTest, InvalidShaderKind,
     testing::ValuesIn(std::vector<ShaderKindTestCase>{
         // Invalid default shader kind.
@@ -982,7 +982,7 @@ TEST_P(IncluderTests, SetIncluderCallbacksClonedOptions) {
               HasSubstr(test_case.expected_substring()));
 }
 
-INSTANTIATE_TEST_CASE_P(CompileStringTest, IncluderTests,
+INSTANTIATE_TEST_SUITE_P(CompileStringTest, IncluderTests,
                         testing::ValuesIn(std::vector<IncluderTestCase>{
                             IncluderTestCase(
                                 // Fake file system.
@@ -1457,7 +1457,7 @@ TEST_P(ParseVersionProfileTest, FromNullTerminatedString) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     HelperMethods, ParseVersionProfileTest,
     testing::ValuesIn(std::vector<ParseVersionProfileTestCase>{
         // Valid version profiles

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -375,7 +375,7 @@ TEST_P(ConvertStringToVectorTestFixture, VariousStringSize) {
       << "test_case.input_str: " << test_case.input_str << std::endl;
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ConvertStringToVectorTest, ConvertStringToVectorTestFixture,
     testing::ValuesIn(std::vector<ConvertStringToVectorTestCase>{
         {"", {0x00000000}},
@@ -451,7 +451,7 @@ TEST_P(LimitTest, Sample) {
 
 #define CASE(LIMIT, DEFAULT, NEW) \
   { Compiler::Limit::LIMIT, DEFAULT, NEW }
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CompilerTest, LimitTest,
     // See resources.cc for the defaults.
     testing::ValuesIn(std::vector<SetLimitCase>{
@@ -462,7 +462,7 @@ INSTANTIATE_TEST_CASE_P(
         CASE(MaxTessControlAtomicCounters, 0, 72),
         CASE(MaxSamples, 4, 8),
         // clang-format on
-    }), );
+    }));
 #undef CASE
 
 // Returns a fragment shader accessing a texture with the given

--- a/libshaderc_util/src/version_profile_test.cc
+++ b/libshaderc_util/src/version_profile_test.cc
@@ -71,7 +71,7 @@ TEST_P(ParseVersionProfileTest, Sample) {
 // For OpenGL ES GLSL (ESSL) versions, see
 // https://www.khronos.org/registry/OpenGL/index_e.php
 
-INSTANTIATE_TEST_CASE_P(OpenGLESCases, ParseVersionProfileTest,
+INSTANTIATE_TEST_SUITE_P(OpenGLESCases, ParseVersionProfileTest,
                         ValuesIn(std::vector<ParseVersionProfileCase>{
                             {"100es", true, 100, EEsProfile},
                             {"300es", true, 300, EEsProfile},
@@ -79,12 +79,12 @@ INSTANTIATE_TEST_CASE_P(OpenGLESCases, ParseVersionProfileTest,
                             {"320es", true, 320, EEsProfile},
                             {"99es", false, 0, EBadProfile},
                             {"500es", false, 0, EBadProfile},
-                        }), );
+                        }));
 
 // For OpenGL GLSL versions, see
 // https://www.khronos.org/registry/OpenGL/index_gl.php
 
-INSTANTIATE_TEST_CASE_P(OpenGLBlankCases, ParseVersionProfileTest,
+INSTANTIATE_TEST_SUITE_P(OpenGLBlankCases, ParseVersionProfileTest,
                         ValuesIn(std::vector<ParseVersionProfileCase>{
                             {"110", true, 110, ENoProfile},
                             {"120", true, 120, ENoProfile},
@@ -103,7 +103,7 @@ INSTANTIATE_TEST_CASE_P(OpenGLBlankCases, ParseVersionProfileTest,
                             {"500", false, 0, EBadProfile},
                         }), );
 
-INSTANTIATE_TEST_CASE_P(OpenGLCoreCases, ParseVersionProfileTest,
+INSTANTIATE_TEST_SUITE_P(OpenGLCoreCases, ParseVersionProfileTest,
                         ValuesIn(std::vector<ParseVersionProfileCase>{
                             {"320core", true, 320, ECoreProfile},
                             {"330core", true, 330, ECoreProfile},
@@ -116,7 +116,7 @@ INSTANTIATE_TEST_CASE_P(OpenGLCoreCases, ParseVersionProfileTest,
                             {"460core", true, 460, ECoreProfile},
                         }), );
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     OpenGLCompatibilityCases, ParseVersionProfileTest,
     ValuesIn(std::vector<ParseVersionProfileCase>{
         {"320compatibility", true, 320, ECompatibilityProfile},


### PR DESCRIPTION
INSTANTIATE_TEST_CASE_P has been deprecated. We need to use
INSTANTIATE_TEST_SUITE_P instead.