### PR TITLE
Use the full spirv-cross dependency.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -114,7 +114,7 @@ component("libshaderc_spvc") {
     ":shaderc_util_sources",
     "${spirv_tools_dir}:spvtools",
     "${spirv_tools_dir}:spvtools_val",
-    "${spirv_cross_dir}:spirv_cross",
+    "${spirv_cross_dir}:spirv_cross_full_for_fuzzers",
   ]
 
   configs -= [ "//build/config/compiler:chromium_code" ]


### PR DESCRIPTION
We need the dependency "spirv_cross_full_for_fuzzers" which represents
all of spirv-cross.  The dependency "spirv_cross" can omit parts of
spirv-cross.  This should fix the chrome build.