### PR TITLE
Fix cmake build for libshaderc_spvc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,11 @@ endif()
 
 message(STATUS "Shaderc: build type is \"${CMAKE_BUILD_TYPE}\".")
 
+option(SHADERC_ENABLE_SPVC "Enable libshaderc_spvc" OFF)
+
 option(SHADERC_SKIP_INSTALL "Skip installation" ${SHADERC_SKIP_INSTALL})
 if(NOT ${SHADERC_SKIP_INSTALL})
   set(SHADERC_ENABLE_INSTALL ON)
-endif()
-
-option(SHADERC_SKIP_SPVC "Skip libshaderc_spvc" ${SHADERC_SKIP_SPVC})
-if(NOT ${SHADERC_SKIP_SPVC})
-  set(SHADERC_ENABLE_SPVC OFF)
 endif()
 
 option(SHADERC_SKIP_TESTS "Skip building tests" ${SHADERC_SKIP_TESTS})

--- a/libshaderc_spvc/CMakeLists.txt
+++ b/libshaderc_spvc/CMakeLists.txt
@@ -48,6 +48,8 @@ set(SPVC_LIBS
   ${CMAKE_THREAD_LIBS_INIT}
   SPIRV-Tools
   spirv-cross-glsl
+  spirv-cross-hlsl
+  spirv-cross-msl
 )
 
 target_link_libraries(shaderc_spvc PRIVATE ${SPVC_LIBS})


### PR DESCRIPTION
Fix faulty and confusing logic for enabling/disabling libshaderc_spvc.
Add a couple missing spirv-cross lib dependencies.