### PR TITLE
Remove commas for googltest test suite macro

### DIFF
--- a/glslc/src/resource_parse_test.cc
+++ b/glslc/src/resource_parse_test.cc
@@ -70,6 +70,6 @@ INSTANTIATE_TEST_SUITE_P(ParseResources, ParseResourceSettingsTest,
     {"generalConstantMatrixVectorIndexing 1", true, {}, ""},
     // Check an ignore case with a regular case
     {"whileLoops 1 MaxLights 99", true, {{shaderc_limit_max_lights, 99}}, ""},
-  }), );
+  }));
 
 }  // anonymous namespace

--- a/libshaderc_util/src/version_profile_test.cc
+++ b/libshaderc_util/src/version_profile_test.cc
@@ -101,7 +101,7 @@ INSTANTIATE_TEST_SUITE_P(OpenGLBlankCases, ParseVersionProfileTest,
                             {"460", true, 460, ENoProfile},
                             {"99", false, 0, EBadProfile},
                             {"500", false, 0, EBadProfile},
-                        }), );
+                        }));
 
 INSTANTIATE_TEST_SUITE_P(OpenGLCoreCases, ParseVersionProfileTest,
                         ValuesIn(std::vector<ParseVersionProfileCase>{
@@ -114,7 +114,7 @@ INSTANTIATE_TEST_SUITE_P(OpenGLCoreCases, ParseVersionProfileTest,
                             {"440core", true, 440, ECoreProfile},
                             {"450core", true, 450, ECoreProfile},
                             {"460core", true, 460, ECoreProfile},
-                        }), );
+                        }));
 
 INSTANTIATE_TEST_SUITE_P(
     OpenGLCompatibilityCases, ParseVersionProfileTest,
@@ -128,6 +128,6 @@ INSTANTIATE_TEST_SUITE_P(
         {"440compatibility", true, 440, ECompatibilityProfile},
         {"450compatibility", true, 450, ECompatibilityProfile},
         {"460compatibility", true, 460, ECompatibilityProfile},
-    }), );
+    }));
 
 }  // anonymous namespace


### PR DESCRIPTION
This is required to compile against latest googletest.