### PR TITLE
spvc is optional, off by default, in Android.mk

### DIFF
--- a/kokoro/ndk-build/build.sh
+++ b/kokoro/ndk-build/build.sh
@@ -51,6 +51,7 @@ $ANDROID_NDK/ndk-build \
   V=1 \
   SPVTOOLS_LOCAL_PATH=$SRC/third_party/spirv-tools \
   SPVHEADERS_LOCAL_PATH=$SRC/third_party/spirv-headers \
+  SHADERC_ENABLE_SPVC=1 \
   -j 8
 
 echo $(date): ndk-build completed.

--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -23,11 +23,13 @@ endif
 # Now include the SPIRV-Tools dependency
 include $(SPVTOOLS_LOCAL_PATH)/Android.mk
 
-# Set the location of SPIRV-Cross.
-# Allow the user to override it, but default it to under our third_party directory.
-ifeq ($(SPVCROSS_LOCAL_PATH),)
-  SPVCROSS_LOCAL_PATH:=$(THIRD_PARTY_PATH)/spirv-cross
-endif
+ifeq ($(SHADERC_ENABLE_SPVC),1)
+  # Set the location of SPIRV-Cross.
+  # Allow the user to override it, but default it to under our third_party directory.
+  ifeq ($(SPVCROSS_LOCAL_PATH),)
+    SPVCROSS_LOCAL_PATH:=$(THIRD_PARTY_PATH)/spirv-cross
+  endif
 
-# Now include the SPIRV-Cross dependency
-include $(SPVCROSS_LOCAL_PATH)/jni/Android.mk
+  # Now include the SPIRV-Cross dependency
+  include $(SPVCROSS_LOCAL_PATH)/jni/Android.mk
+endif


### PR DESCRIPTION
We need this until the NDK build has the SPIRV-Cross source.