### PR TITLE
Avoid leading dot slash in cmake target.

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -161,15 +161,7 @@ function(shaderc_combine_static_lib new_target target)
   shaderc_get_transitive_libs(${target} all_libs)
 
   set(libname
-      ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${new_target}${CMAKE_STATIC_LIBRARY_SUFFIX})
-
-  if (CMAKE_CONFIGURATION_TYPES)
-    list(LENGTH CMAKE_CONFIGURATION_TYPES num_configurations)
-    if (${num_configurations} GREATER 1)
-      set(libname
-          ${CMAKE_CFG_INTDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${new_target}${CMAKE_STATIC_LIBRARY_SUFFIX})
-    endif()
-  endif()
+      ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${new_target}${CMAKE_STATIC_LIBRARY_SUFFIX})
 
   if (MSVC)
     string(REPLACE ";" ">;$<TARGET_FILE:" temp_string "${all_libs}")


### PR DESCRIPTION
Including shaderc in project that declares multiple build configurations
and then using generator that doesn't support multi-configuration would
result in a target path with a leading dot slash.  Ninja doesn't work
in that case.

Prepend CMAKE_CURRENT_BINARY_DIR in order to get an absolute path and
make ninja happy.  This works in all cases so we remove code specific
to multi-configuration.

Fixes #568.