### PR TITLE
spvc: Add some flags.

### DIFF
--- a/libshaderc_spvc/include/shaderc/spvc.h
+++ b/libshaderc_spvc/include/shaderc/spvc.h
@@ -67,11 +67,33 @@ shaderc_spvc_compile_options_clone(
 SHADERC_EXPORT void shaderc_spvc_compile_options_release(
     shaderc_spvc_compile_options_t options);
 
+// Sets the entry point.
+SHADERC_EXPORT void shaderc_spvc_compile_options_set_entry_point(
+    shaderc_spvc_compile_options_t options,
+    const char *entry_point);
+
+// If true, unused variables will not appear in the output.
+SHADERC_EXPORT void shaderc_spvc_compile_options_set_remove_unused_variables(
+    shaderc_spvc_compile_options_t options, bool b);
+
 // Sets the target shader environment, affecting which warnings or errors will
 // be issued during validation.
 SHADERC_EXPORT void shaderc_spvc_compile_options_set_target_env(
     shaderc_spvc_compile_options_t options, shaderc_target_env target,
     shaderc_env_version version);
+
+// If true, Vulkan GLSL features are used instead of GL-compatible features.
+SHADERC_EXPORT void shaderc_spvc_compile_options_set_vulkan_semantics(
+    shaderc_spvc_compile_options_t options, bool b);
+
+// If true, gl_PerVertex is explicitly redeclared in vertex, geometry and tessellation shaders.
+// The members of gl_PerVertex is determined by which built-ins are declared by the shader.
+SHADERC_EXPORT void shaderc_spvc_compile_options_set_separate_shader_objects(
+    shaderc_spvc_compile_options_t options, bool b);
+
+// Flatten uniform or push constant variable into (i|u)vec4 array.
+SHADERC_EXPORT void shaderc_spvc_compile_options_set_flatten_ubo(
+    shaderc_spvc_compile_options_t options, bool b);
 
 // Set language version.  Default is 450.
 SHADERC_EXPORT void shaderc_spvc_compile_options_set_output_language_version(

--- a/libshaderc_spvc/include/shaderc/spvc.h
+++ b/libshaderc_spvc/include/shaderc/spvc.h
@@ -69,8 +69,7 @@ SHADERC_EXPORT void shaderc_spvc_compile_options_release(
 
 // Sets the entry point.
 SHADERC_EXPORT void shaderc_spvc_compile_options_set_entry_point(
-    shaderc_spvc_compile_options_t options,
-    const char *entry_point);
+    shaderc_spvc_compile_options_t options, const char* entry_point);
 
 // If true, unused variables will not appear in the output.
 SHADERC_EXPORT void shaderc_spvc_compile_options_set_remove_unused_variables(
@@ -86,8 +85,9 @@ SHADERC_EXPORT void shaderc_spvc_compile_options_set_target_env(
 SHADERC_EXPORT void shaderc_spvc_compile_options_set_vulkan_semantics(
     shaderc_spvc_compile_options_t options, bool b);
 
-// If true, gl_PerVertex is explicitly redeclared in vertex, geometry and tessellation shaders.
-// The members of gl_PerVertex is determined by which built-ins are declared by the shader.
+// If true, gl_PerVertex is explicitly redeclared in vertex, geometry and
+// tessellation shaders. The members of gl_PerVertex is determined by which
+// built-ins are declared by the shader.
 SHADERC_EXPORT void shaderc_spvc_compile_options_set_separate_shader_objects(
     shaderc_spvc_compile_options_t options, bool b);
 

--- a/libshaderc_spvc/include/shaderc/spvc.hpp
+++ b/libshaderc_spvc/include/shaderc/spvc.hpp
@@ -102,6 +102,32 @@ class CompileOptions {
     shaderc_spvc_compile_options_set_target_env(options_, target, version);
   }
 
+  // Set the entry point.
+  void SetEntryPoint(const std::string& entry_point) {
+    shaderc_spvc_compile_options_set_entry_point(options_, entry_point.c_str());
+  }
+
+  // If true, unused variables will not appear in the output.
+  void SetRemoveUnusedVariables(bool b) {
+    shaderc_spvc_compile_options_set_remove_unused_variables(options_, b);
+  }
+
+  // If true, Vulkan GLSL features are used instead of GL-compatible features.
+  void SetVulkanSemantics(bool b) {
+    shaderc_spvc_compile_options_set_vulkan_semantics(options_, b);
+  }
+
+  // If true, gl_PerVertex is explicitly redeclared in vertex, geometry and tessellation shaders.
+  // The members of gl_PerVertex is determined by which built-ins are declared by the shader.
+  void SetSeparateShaderObjects(bool b) {
+    shaderc_spvc_compile_options_set_separate_shader_objects(options_, b);
+  }
+
+  // Flatten uniform or push constant variable into (i|u)vec4 array.
+  void SetFlattenUbo(bool b) {
+    shaderc_spvc_compile_options_set_flatten_ubo(options_, b);
+  }
+
   // Which GLSL version should be produced.  Default is 450.
   void SetOutputLanguageVersion(uint32_t version) {
     shaderc_spvc_compile_options_set_output_language_version(options_, version);

--- a/libshaderc_spvc/include/shaderc/spvc.hpp
+++ b/libshaderc_spvc/include/shaderc/spvc.hpp
@@ -117,8 +117,9 @@ class CompileOptions {
     shaderc_spvc_compile_options_set_vulkan_semantics(options_, b);
   }
 
-  // If true, gl_PerVertex is explicitly redeclared in vertex, geometry and tessellation shaders.
-  // The members of gl_PerVertex is determined by which built-ins are declared by the shader.
+  // If true, gl_PerVertex is explicitly redeclared in vertex, geometry and
+  // tessellation shaders. The members of gl_PerVertex is determined by which
+  // built-ins are declared by the shader.
   void SetSeparateShaderObjects(bool b) {
     shaderc_spvc_compile_options_set_separate_shader_objects(options_, b);
   }

--- a/spvc/test/run_spirv_cross_tests.py
+++ b/spvc/test/run_spirv_cross_tests.py
@@ -107,16 +107,27 @@ def test_glsl(shader, filename, optimize):
     # Run spvc to convert Vulkan to GLSL.  Up to two tests are performed:
     # - Regular test on most files
     # - Vulkan-specific test on Vulkan test input
-    flags = []
+    flags = ['--entry=main']
+    if not '.noeliminate' in filename:
+        flags.append('--remove-unused-variables')
+    if '.legacy.' in filename:
+        flags.extend(['--version=100', '--es'])
+    if '.flatten.' in filename:
+        flags.append('--flatten-ubo')
+    if '.flatten_dim.' in filename:
+        flags.append('--flatten-multidimensional-arrays')
+    if '.sso.' in filename:
+        flags.append('--separate-shader-objects')
+
     output = None
     if not '.nocompat.' in filename:
         test_count += 1
         output = spvc(tmpfile, tmpfile + filename , flags)
+
     output_vk = None
     if '.vk.' in filename or '.asm.' in filename:
-        #TODO(fjhenigman): add Vulkan-specific flags.
         test_count += 1
-        output_vk = spvc(tmpfile, tmpfile + 'vk' + filename, flags)
+        output_vk = spvc(tmpfile, tmpfile + 'vk' + filename, flags + ['--vulkan-semantics'])
 
     # Check results.
     # Compare either or both files produced above to appropriate reference file.
@@ -163,4 +174,4 @@ spvc_path, spirv_as_path, spirv_opt_path, glslangValidator_path, spirv_cross_dir
 main(spirv_cross_dir)
 
 # TODO: remove the magic number once all tests pass
-sys.exit(pass_count != 169)
+sys.exit(pass_count != 526)


### PR DESCRIPTION
This builds on https://github.com/google/shaderc/pull/578

spvc: Add some flags.
    
Implement the following spvc flags and update the test:
  --entry
  --version
  --remove-unused-variables
  --vulkan-semantics
  --separate-shader-objects
  --flatten-ubo
The old --version flag is now -v.
