### PR TITLE
Export config files for pkg-config.  (#392)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,3 +84,32 @@ add_custom_target(build-version
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/update_build_version.py
   ${shaderc_SOURCE_DIR} ${spirv-tools_SOURCE_DIR} ${glslang_SOURCE_DIR}
   COMMENT "Update build-version.inc in the Shaderc build directory (if necessary).")
+
+function(define_pkg_config_file NAME LIBS)
+  add_custom_target(${NAME}-pkg-config ALL
+    COMMAND ${CMAKE_COMMAND}
+      -DCHANGES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/CHANGES
+      -DTEMPLATE_FILE=${CMAKE_CURRENT_SOURCE_DIR}/cmake/${NAME}.pc.in
+      -DOUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/${NAME}.pc
+      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+      -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
+      -DCMAKE_INSTALL_INCLUDEDIR=${CMAKE_INSTALL_INCLUDEDIR}
+      -DLIBS=${LIBS}
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/write_pkg_config.cmake
+  DEPENDS "CHANGES" "cmake/${NAME}.pc.in" "cmake/write_pkg_config.cmake")
+
+  if (SHADERC_ENABLE_INSTALL)
+    install(
+      FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.pc
+      DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+  endif()
+endfunction()
+
+if(SHADERC_ENABLE_SPVC)
+  set(EXTRA_STATIC_PKGCONFIG_LIBS -lshaderc_spvc)
+endif()
+define_pkg_config_file(shaderc -lshaderc_shared)
+define_pkg_config_file(shaderc_static "-lshaderc ${EXTRA_STATIC_PKGCONFIG_LIBS} -lshaderc_util")
+define_pkg_config_file(shaderc_combined -lshaderc_combined)

--- a/cmake/shaderc.pc.in
+++ b/cmake/shaderc.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: shaderc
+Description: Tools and libraries for Vulkan shader compilation
+Version: @CURRENT_VERSION@
+URL: https://github.com/google/shaderc
+
+Libs: -L${libdir} @LIBS@
+Cflags: -I${includedir}

--- a/cmake/shaderc_combined.pc.in
+++ b/cmake/shaderc_combined.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: shaderc
+Description: Tools and libraries for Vulkan shader compilation
+Version: @CURRENT_VERSION@
+URL: https://github.com/google/shaderc
+
+Libs: -L${libdir} @LIBS@
+Cflags: -I${includedir}

--- a/cmake/shaderc_static.pc.in
+++ b/cmake/shaderc_static.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: shaderc
+Description: Tools and libraries for Vulkan shader compilation
+Version: @CURRENT_VERSION@
+URL: https://github.com/google/shaderc
+
+Libs: -L${libdir} @LIBS@
+Cflags: -I${includedir}

--- a/cmake/write_pkg_config.cmake
+++ b/cmake/write_pkg_config.cmake
@@ -1,0 +1,31 @@
+# Copyright (c) 2017 Pierre Moreau
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# First, retrieve the current version from CHANGES
+file(STRINGS ${CHANGES_FILE} CHANGES_CONTENT)
+string(
+REGEX
+  MATCH "v[0-9]+(.[0-9]+)?(-dev)? [0-9]+-[0-9]+-[0-9]+"
+  FIRST_VERSION_LINE
+  ${CHANGES_CONTENT})
+string(
+REGEX
+  REPLACE "^v([^ ]+) .+$" "\\1"
+  CURRENT_VERSION
+  "${FIRST_VERSION_LINE}")
+# If this is a development version, replace "-dev" by ".0" as pkg-config nor
+# CMake support "-dev" in the version.
+# If it's not a "-dev" version then ensure it ends with ".1"
+string(REGEX REPLACE "-dev.1" ".0" CURRENT_VERSION "${CURRENT_VERSION}.1")
+configure_file(${TEMPLATE_FILE} ${OUT_FILE} @ONLY)


### PR DESCRIPTION
Extracts the current version from the file CHANGES

The -dev suffix maps to a minor version number of .0
No -dev suffix maps to a minor version number of .1

Uses a first class target spirv-tools-pkg-config

Stolen from SPIRV-Tools.