### PR TITLE
Roll DEPS.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '8f0a61dc95e0df18c18e0ac56d83b3fa9d2fe90b',
-  'glslang_revision': 'a51d3d9f223361165127ded3cd2e59d81e22d91f',
+  'glslang_revision': 'ef807f4bc543e061f25dbbee6cb64dd5053b2adc',
   'googletest_revision': '0599a7b8410dc5cfdb477900b280475ae775d7f9',
   're2_revision': '90970542fe952602f42150c6e71d086f5afebcb3',
-  'spirv_headers_revision': '03a081524afabdde274d885880c2fef213e46a59',
-  'spirv_tools_revision': 'bdcb155163d453fa67a03f59b4d5e00bd7c0f209',
-  'spirv_cross_revision': 'ed55e0ac6d797a338e7c19dad785237f0efc4d86',
+  'spirv_headers_revision': '111a25e4ae45e2b4d7c18415e1d6884712b958c4',
+  'spirv_tools_revision': '12e4a7b649e6fe28683de9fc352200c82948a1f0',
+  'spirv_cross_revision': '8db9ae0e9cd0b0515c872c801a72b198dd757424',
 }
 
 deps = {

--- a/spvc/test/run_spirv_cross_tests.py
+++ b/spvc/test/run_spirv_cross_tests.py
@@ -237,4 +237,4 @@ def main():
 main()
 
 # TODO: remove the magic number once all tests pass
-sys.exit(pass_count != 526)
+sys.exit(pass_count != 546)


### PR DESCRIPTION
Pick up a fix to SPIRV-Tools that will let us add more spvc tests without
blowing up in debug builds.
The SPIRV-Tools roll itself broke some SPIRV-Cross tests, so we also
have to roll in a new SPIRV-Cross that works with the new SPIRV-Tools.
Update glslang and SPIRV-Headers to stay in sync with the new SPIRV-Cross.