### PR TITLE
Shaderc requires Python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,13 +40,13 @@ if(SHADERC_ENABLE_NV_EXTENSIONS)
 endif(SHADERC_ENABLE_NV_EXTENSIONS)
 
 add_custom_target(check-copyright ALL
-  ${PYTHON_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
+  ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
   --check
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Check copyright")
 
 add_custom_target(add-copyright
-  ${PYTHON_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
+  ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Add copyright")
 
@@ -80,7 +80,7 @@ add_subdirectory(glslc)
 add_subdirectory(examples)
 
 add_custom_target(build-version
-  ${PYTHON_EXE}
+  ${PYTHON_EXECUTABLE}
   ${CMAKE_CURRENT_SOURCE_DIR}/utils/update_build_version.py
   ${shaderc_SOURCE_DIR} ${spirv-tools_SOURCE_DIR} ${glslang_SOURCE_DIR}
   COMMENT "Update build-version.inc in the Shaderc build directory (if necessary).")

--- a/README.md
+++ b/README.md
@@ -143,14 +143,7 @@ For building, testing, and profiling Shaderc, the following tools should be
 installed regardless of your OS:
 
 - [CMake](http://www.cmake.org/): for generating compilation targets.
-- [Python](http://www.python.org/): for utility scripts and running the test suite.
-
-Both Python2 and Python3 work.  However, if you use Python2, you will need the
-Python-future package installed:
-
-```
-pip install future
-```
+- [Python 3](http://www.python.org/): for utility scripts and running the test suite.
 
 On Linux, the following tools should be installed:
 

--- a/cmake/setup_build.cmake
+++ b/cmake/setup_build.cmake
@@ -36,18 +36,16 @@ endif(WIN32)
 if (ANDROID)
 # For android let's preemptively find the correct packages so that
 # child projects (glslang, googletest) do not fail to find them.
-find_host_package(PythonInterp)
+
+# Tests in glslc and SPIRV-Tools tests require Python 3, or a Python 2
+# with the "future" package.  Require Python 3 because we can't force
+# developers to manually install the "future" package.
+find_host_package(PythonInterp 3 REQUIRED)
 find_host_package(BISON)
+else()
+find_package(PythonInterp 3 REQUIRED)
 endif()
 
-foreach(PROGRAM echo python)
-  string(TOUPPER ${PROGRAM} PROG_UC)
-  if (ANDROID)
-    find_host_program(${PROG_UC}_EXE ${PROGRAM} REQUIRED)
-  else()
-    find_program(${PROG_UC}_EXE ${PROGRAM} REQUIRED)
-  endif()
-endforeach(PROGRAM)
 
 option(ENABLE_CODE_COVERAGE "Enable collecting code coverage." OFF)
 if (ENABLE_CODE_COVERAGE)
@@ -83,7 +81,7 @@ if (ENABLE_CODE_COVERAGE)
     # The symptom is that some .gcno files are wrong after code change and
     # recompiling. We don't know the exact reason yet. Figure it out.
     # Remove all .gcno files in the directory recursively.
-    COMMAND ${PYTHON_EXE}
+    COMMAND ${PYTHON_EXECUTABLE}
     ${shaderc_SOURCE_DIR}/utils/remove-file-by-suffix.py . ".gcno"
     # .gcno files are not tracked by CMake. So no recompiling is triggered
     # even if they are missing. Unfortunately, we just removed all of them

--- a/glslc/test/CMakeLists.txt
+++ b/glslc/test/CMakeLists.txt
@@ -3,7 +3,7 @@ shaderc_add_nosetests(glslc_test_framework)
 
 if(${SHADERC_ENABLE_TESTS})
   add_test(NAME glslc_tests
-    COMMAND ${PYTHON_EXE}
+    COMMAND ${PYTHON_EXECUTABLE}
     ${CMAKE_CURRENT_SOURCE_DIR}/glslc_test_framework.py
     $<TARGET_FILE:glslc_exe> $<TARGET_FILE:spirv-dis>
     --test-dir ${CMAKE_CURRENT_SOURCE_DIR})

--- a/spvc/test/CMakeLists.txt
+++ b/spvc/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(${SHADERC_ENABLE_TESTS})
   add_test(NAME spvc_spirv_cross_tests
-    COMMAND ${PYTHON_EXE}
+    COMMAND ${PYTHON_EXECUTABLE}
     ${CMAKE_CURRENT_SOURCE_DIR}/run_spirv_cross_tests.py
     $<TARGET_FILE:spvc_exe>
     $<TARGET_FILE:spirv-as>


### PR DESCRIPTION
Tests for glslc and SPIRV-Tools require either Python3 or Python2
with the "future" package.  But since we can't rely on developers
having the "future" package, migrate fully to Python3 now.