### PR TITLE
Fix Windows build uploads.

### DIFF
--- a/kokoro/linux/build.sh
+++ b/kokoro/linux/build.sh
@@ -24,7 +24,6 @@ set -x
 
 BUILD_ROOT=$PWD
 SRC=$PWD/github/shaderc
-INSTALL_DIR="$SRC/install"
 CONFIG=$1
 COMPILER=$2
 
@@ -78,7 +77,7 @@ cd $SRC/build
 # Invoke the build.
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}
 echo $(date): Starting build...
-cmake -GNinja -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DSHADERC_ENABLE_SPVC=ON -DRE2_BUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=$BUILD_TYPE $ADDITIONAL_CMAKE_FLAGS $CMAKE_C_CXX_COMPILER ..
+cmake -GNinja -DCMAKE_INSTALL_PREFIX=$KOKORO_ARTIFACTS_DIR/install -DSHADERC_ENABLE_SPVC=ON -DRE2_BUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=$BUILD_TYPE $ADDITIONAL_CMAKE_FLAGS $CMAKE_C_CXX_COMPILER ..
 
 echo $(date): Build glslang...
 ninja glslangValidator
@@ -106,5 +105,5 @@ echo $(date): ctest completed.
 
 # Package the build.
 ninja install
-cd $(dirname $INSTALL_DIR)
-tar czf $KOKORO_ARTIFACTS_DIR/install.tgz $(basename $INSTALL_DIR)
+cd $KOKORO_ARTIFACTS_DIR
+tar czf install.tgz install

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -23,7 +23,6 @@ set -x
 
 BUILD_ROOT=$PWD
 SRC=$PWD/github/shaderc
-INSTALL_DIR="$SRC/install"
 BUILD_TYPE=$1
 
 # Get NINJA.
@@ -41,7 +40,7 @@ cd $SRC/build
 # Invoke the build.
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}
 echo $(date): Starting build...
-cmake -GNinja -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DSHADERC_ENABLE_SPVC=ON -DRE2_BUILD_TESTING=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+cmake -GNinja -DCMAKE_INSTALL_PREFIX=$KOKORO_ARTIFACTS_DIR/install -DSHADERC_ENABLE_SPVC=ON -DRE2_BUILD_TESTING=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
 
 echo $(date): Build glslang...
 ninja glslangValidator
@@ -60,5 +59,5 @@ echo $(date): ctest completed.
 
 # Package the build.
 ninja install
-cd $(dirname $INSTALL_DIR)
-tar czf $KOKORO_ARTIFACTS_DIR/install.tgz $(basename $INSTALL_DIR)
+cd $KOKORO_ARTIFACTS_DIR
+tar czf install.tgz install

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -56,7 +56,7 @@ if "%KOKORO_GITHUB_COMMIT%." == "." (
   set BUILD_SHA=%KOKORO_GITHUB_COMMIT%
 )
 
-set CMAKE_FLAGS=-DCMAKE_INSTALL_PREFIX=%SRC%\install -DSHADERC_ENABLE_SPVC=ON -DRE2_BUILD_TESTING=OFF -GNinja -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe
+set CMAKE_FLAGS=-DCMAKE_INSTALL_PREFIX=%KOKORO_ARTIFACTS_DIR%\install -DSHADERC_ENABLE_SPVC=ON -DRE2_BUILD_TESTING=OFF -GNinja -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe
 
 :: Skip building SPIRV-Tools tests for VS2013
 if %VS_VERSION% == 2013 (
@@ -96,7 +96,7 @@ echo "Tests passed %DATE% %TIME%"
 :: Install and package.
 :: ################################################
 ninja install
-cd %SRC%
+cd %KOKORO_ARTIFACTS_DIR%
 zip -r install.zip install
 
 :: Clean up some directories.


### PR DESCRIPTION
The Windows package was not being put in the same place as the others
and was not being found by the uploader.  This makes the build scripts
more consistent with each other and lets the Windows upload work.