### PR TITLE
1.4: GOOGLE suffix drops from certain instructions

### DIFF
--- a/glslc/test/option_fhlsl_functionality1.py
+++ b/glslc/test/option_fhlsl_functionality1.py
@@ -46,7 +46,7 @@ class TestHlslFunctionality1DecoratesCounter(expect.ValidAssemblyFileWithSubstr)
     shader = FileShader(HLSL_VERTEX_SHADER_WITH_COUNTER_BUFFER, '.frag')
     glslc_args = ['-S', '-x', 'hlsl', '-fhlsl_functionality1',
                   '-fauto-bind-uniforms', shader]
-    expected_assembly_substr = 'OpDecorateStringGOOGLE'
+    expected_assembly_substr = 'OpDecorateString'
 
 
 ## Next tests use the option with the hypen instead of underscore.
@@ -68,4 +68,4 @@ class TestHlslHyphenFunctionality1DecoratesCounter(expect.ValidAssemblyFileWithS
     shader = FileShader(HLSL_VERTEX_SHADER_WITH_COUNTER_BUFFER, '.frag')
     glslc_args = ['-S', '-x', 'hlsl', '-fhlsl_functionality1',
                   '-fauto-bind-uniforms', shader]
-    expected_assembly_substr = 'OpDecorateStringGOOGLE'
+    expected_assembly_substr = 'OpDecorateString'

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -1409,7 +1409,7 @@ TEST_F(CppInterface, HlslFunctionality1OffByDefault) {
   options.SetAutoBindUniforms(true);
   const std::string disassembly_text = AssemblyOutput(
       kHlslShaderWithCounterBuffer, shaderc_glsl_fragment_shader, options);
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorateStringGOOGLE")));
+  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorateString")));
 }
 
 TEST_F(CppInterface, HlslFunctionality1Respected) {
@@ -1421,7 +1421,7 @@ TEST_F(CppInterface, HlslFunctionality1Respected) {
   options.SetHlslFunctionality1(true);
   const std::string disassembly_text = AssemblyOutput(
       kHlslShaderWithCounterBuffer, shaderc_glsl_fragment_shader, options);
-  EXPECT_THAT(disassembly_text, HasSubstr("OpDecorateStringGOOGLE"));
+  EXPECT_THAT(disassembly_text, HasSubstr("OpDecorateString"));
 }
 
 TEST_F(CppInterface, HlslFunctionality1SurvivesCloning) {
@@ -1434,7 +1434,7 @@ TEST_F(CppInterface, HlslFunctionality1SurvivesCloning) {
   CompileOptions cloned_options(options);
   const std::string disassembly_text = AssemblyOutput(
       kHlslShaderWithCounterBuffer, shaderc_glsl_fragment_shader, cloned_options);
-  EXPECT_THAT(disassembly_text, HasSubstr("OpDecorateStringGOOGLE"));
+  EXPECT_THAT(disassembly_text, HasSubstr("OpDecorateString"));
 }
 
 }  // anonymous namespace

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -1801,7 +1801,7 @@ TEST_F(CompileStringWithOptionsTest, HlslFunctionality1OffByDefault) {
   const std::string disassembly_text =
       CompilationOutput(kHlslShaderWithCounterBuffer, shaderc_fragment_shader,
                         options_.get(), OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorateStringGOOGLE")))
+  EXPECT_THAT(disassembly_text, Not(HasSubstr("OpDecorateString")))
       << disassembly_text;
 }
 
@@ -1814,7 +1814,7 @@ TEST_F(CompileStringWithOptionsTest, HlslFunctionality1Respected) {
   const std::string disassembly_text =
       CompilationOutput(kHlslShaderWithCounterBuffer, shaderc_fragment_shader,
                         options_.get(), OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text, HasSubstr("OpDecorateStringGOOGLE"));
+  EXPECT_THAT(disassembly_text, HasSubstr("OpDecorateString"));
 }
 
 TEST_F(CompileStringWithOptionsTest, HlslFunctionality1SurvivesCloning) {
@@ -1828,7 +1828,7 @@ TEST_F(CompileStringWithOptionsTest, HlslFunctionality1SurvivesCloning) {
   const std::string disassembly_text =
       CompilationOutput(kHlslShaderWithCounterBuffer, shaderc_fragment_shader,
                         cloned_options.get(), OutputType::SpirvAssemblyText);
-  EXPECT_THAT(disassembly_text, HasSubstr("OpDecorateStringGOOGLE"));
+  EXPECT_THAT(disassembly_text, HasSubstr("OpDecorateString"));
 }
 
 TEST_F(CompileStringWithOptionsTest, HlslFlexibleMemoryLayoutAllowed) {

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -736,8 +736,8 @@ TEST_F(CompilerTest, HlslFunctionality1Enabled) {
               HasSubstr("OpExtension \"SPV_GOOGLE_hlsl_functionality1\""))
       << disassembly;
   EXPECT_THAT(disassembly,
-              HasSubstr("OpDecorateStringGOOGLE %_entryPointOutput "
-                        "HlslSemanticGOOGLE \"SV_TARGET0\""))
+              HasSubstr("OpDecorateString %_entryPointOutput "
+                        "UserSemantic \"SV_TARGET0\""))
       << disassembly;
 }
 


### PR DESCRIPTION
This is required for SPIR-V 1.4 support