### PR TITLE
Change 'target' env to 'source' env in spvc API

### DIFF
--- a/libshaderc_spvc/include/shaderc/spvc.h
+++ b/libshaderc_spvc/include/shaderc/spvc.h
@@ -75,10 +75,10 @@ SHADERC_EXPORT void shaderc_spvc_compile_options_set_entry_point(
 SHADERC_EXPORT void shaderc_spvc_compile_options_set_remove_unused_variables(
     shaderc_spvc_compile_options_t options, bool b);
 
-// Sets the target shader environment, affecting which warnings or errors will
+// Sets the source shader environment, affecting which warnings or errors will
 // be issued during validation.
-SHADERC_EXPORT void shaderc_spvc_compile_options_set_target_env(
-    shaderc_spvc_compile_options_t options, shaderc_target_env target,
+SHADERC_EXPORT void shaderc_spvc_compile_options_set_source_env(
+    shaderc_spvc_compile_options_t options, shaderc_target_env env,
     shaderc_env_version version);
 
 // If true, Vulkan GLSL features are used instead of GL-compatible features.

--- a/libshaderc_spvc/include/shaderc/spvc.h
+++ b/libshaderc_spvc/include/shaderc/spvc.h
@@ -76,7 +76,7 @@ SHADERC_EXPORT void shaderc_spvc_compile_options_set_remove_unused_variables(
     shaderc_spvc_compile_options_t options, bool b);
 
 // Sets the source shader environment, affecting which warnings or errors will
-// be issued during validation.
+// be issued during validation. Default value for environment is Vulkan 1.0.
 SHADERC_EXPORT void shaderc_spvc_compile_options_set_source_env(
     shaderc_spvc_compile_options_t options, shaderc_target_env env,
     shaderc_env_version version);

--- a/libshaderc_spvc/include/shaderc/spvc.hpp
+++ b/libshaderc_spvc/include/shaderc/spvc.hpp
@@ -95,11 +95,10 @@ class CompileOptions {
     other.options_ = nullptr;
   }
 
-  // Which environment should be used to validate the input SPIR-V.  Default is
-  // Vulkan 1.0.
-  void SetTargetEnvironment(shaderc_target_env target,
+  // Set the environment for the input SPIR-V.  Default is Vulkan 1.0.
+  void SetSourceEnvironment(shaderc_target_env env,
                             shaderc_env_version version) {
-    shaderc_spvc_compile_options_set_target_env(options_, target, version);
+    shaderc_spvc_compile_options_set_source_env(options_, env, version);
   }
 
   // Set the entry point.

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -38,7 +38,7 @@ struct shaderc_spvc_compile_options {
   bool remove_unused_variables = false;
   bool flatten_ubo = false;
   std::string entry_point;
-  spv_target_env target_env = SPV_ENV_VULKAN_1_0;
+  spv_target_env source_env = SPV_ENV_VULKAN_1_0;
   spirv_cross::CompilerGLSL::Options glsl;
   spirv_cross::CompilerHLSL::Options hlsl;
   spirv_cross::CompilerMSL::Options msl;
@@ -66,15 +66,15 @@ void shaderc_spvc_compile_options_release(
   delete options;
 }
 
-void shaderc_spvc_compile_options_set_target_env(
-    shaderc_spvc_compile_options_t options, shaderc_target_env target,
+void shaderc_spvc_compile_options_set_source_env(
+    shaderc_spvc_compile_options_t options, shaderc_target_env env,
     shaderc_env_version version) {
-  switch (target) {
+  switch (env) {
     case shaderc_target_env_opengl:
     case shaderc_target_env_opengl_compat:
       switch (version) {
         case shaderc_env_version_opengl_4_5:
-          options->target_env = SPV_ENV_OPENGL_4_5;
+          options->source_env = SPV_ENV_OPENGL_4_5;
           break;
         default:
           break;
@@ -83,10 +83,10 @@ void shaderc_spvc_compile_options_set_target_env(
     case shaderc_target_env_vulkan:
       switch (version) {
         case shaderc_env_version_vulkan_1_0:
-          options->target_env = SPV_ENV_VULKAN_1_0;
+          options->source_env = SPV_ENV_VULKAN_1_0;
           break;
         case shaderc_env_version_vulkan_1_1:
-          options->target_env = SPV_ENV_VULKAN_1_1;
+          options->source_env = SPV_ENV_VULKAN_1_1;
           break;
         default:
           break;
@@ -184,7 +184,7 @@ shaderc_spvc_compilation_result_t validate_and_compile(
   if (!result) return nullptr;
 
   if (options->validate) {
-    spvtools::SpirvTools tools(options->target_env);
+    spvtools::SpirvTools tools(options->source_env);
     if (!tools.IsValid()) return nullptr;
     tools.SetMessageConsumer(std::bind(
         consume_validation_message, result, std::placeholders::_1,

--- a/spvc/README.asciidoc
+++ b/spvc/README.asciidoc
@@ -47,9 +47,9 @@ with a `.glsl,` `.hlsl` or `.msl` extension, as appropriate.
 
 `--version` displays version information.
 
-==== `--validate=<target env>`
+==== `--validate=<source env>`
 
-`--validate` validates the input with the given target environment, which is one of:
+`--validate` validates the input with the given environment, which is one of:
 
 * vulkan1.0
 * vulkan1.1

--- a/spvc/src/main.cc
+++ b/spvc/src/main.cc
@@ -220,16 +220,16 @@ int main(int argc, char** argv) {
       }
       options.SetShaderModel(shader_model_num);
     } else if (arg.starts_with("--validate=")) {
-      string_piece target_env;
-      GetOptionArgument(argc, argv, &i, "--validate=", &target_env);
-      if (target_env == "vulkan1.0") {
-        options.SetTargetEnvironment(shaderc_target_env_vulkan,
+      string_piece env;
+      GetOptionArgument(argc, argv, &i, "--validate=", &env);
+      if (env == "vulkan1.0") {
+        options.SetSourceEnvironment(shaderc_target_env_vulkan,
                                      shaderc_env_version_vulkan_1_0);
-      } else if (target_env == "vulkan1.1") {
-        options.SetTargetEnvironment(shaderc_target_env_vulkan,
+      } else if (env == "vulkan1.1") {
+        options.SetSourceEnvironment(shaderc_target_env_vulkan,
                                      shaderc_env_version_vulkan_1_1);
       } else {
-        std::cerr << "spvc: error: invalid value '" << target_env
+        std::cerr << "spvc: error: invalid value '" << env
                   << "' in --validate=" << std::endl;
         return 1;
       }


### PR DESCRIPTION
Clarify that the environment being referenced is the one associated
with the provided SPIR-V, and not the produced artifact.

Fixes #609