### PR TITLE
Spvc tests: Assemble explicitly for Vulkan1.1 env

### DIFF
--- a/spvc/test/run_spirv_cross_tests.py
+++ b/spvc/test/run_spirv_cross_tests.py
@@ -112,7 +112,7 @@ def compile_input_shader(shader, filename, optimize):
     global tmpfile
     shader_path = os.path.join(args.cross_dir, shader)
     if '.asm.' in filename:
-        flags = []
+        flags = ['--target-env', 'vulkan1.1']
         if '.preserve.' in filename:
             flags.append('--preserve-numeric-ids')
         spirv_as(shader_path, tmpfile, flags)


### PR DESCRIPTION
By default, SPIRV-Tools will assemble for the latest supported
version of SPIR-V.  With SPIR-V 1.4 arriving, that will generally
make modules which are not consumable by Vuklan 1.1.  So update
the Spvc tests to explicitly assemble for Vulkan 1.1.