### PR TITLE
Fixing duplicate absolute install paths when using Visual Studio generators

### DIFF
--- a/libshaderc/CMakeLists.txt
+++ b/libshaderc/CMakeLists.txt
@@ -84,7 +84,7 @@ if(SHADERC_ENABLE_INSTALL)
     # around this problem by manually substitution.
     string(REPLACE "$(Configuration)" "\${CMAKE_INSTALL_CONFIG_NAME}"
       install_location "${generated_location}")
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES ${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
   else()
     install(FILES ${generated_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()

--- a/libshaderc_spvc/CMakeLists.txt
+++ b/libshaderc_spvc/CMakeLists.txt
@@ -89,7 +89,7 @@ if(SHADERC_ENABLE_INSTALL)
     # around this problem by manually substitution.
     string(REPLACE "$(Configuration)" "\${CMAKE_INSTALL_CONFIG_NAME}"
       install_location "${generated_location}")
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES ${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
   else()
     install(FILES ${generated_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
   endif()


### PR DESCRIPTION
A slight bug occurs when running a cmake install on shaderc when using Visual Studio as a generator, where the source install file paths are incorrect. They contain a duplicate absolute path.

This issue occurred when a pull request was merged in order to fix the Ninja build system back in this PR https://github.com/google/shaderc/pull/570

The issue is fixed by relying on the shaderc_combine_static_lib() function to properly set an absolute path on the location of the shaderc_combined custom target.

You can verify that this install behavior now works properly by running this on a Windows machine, generating for VS2017:

```
git clone https://github.com/RikoOphorst/shaderc
cd shaderc
mkdir build
cd build
cmake ../ -G"Visual Studio 15 2017 Win64"
cmake --build . --target install
```

Apologies if I'm submitting this pull request incorrectly, this is the first time I've made a pull request in any repo. 