### PR TITLE
Convert vars['foo'] to Var('foo')

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -14,24 +14,24 @@ vars = {
 }
 
 deps = {
-  'third_party/effcee': vars['google_git'] + '/effcee.git@' +
-      vars['effcee_revision'],
+  'third_party/effcee': Var('google_git') + '/effcee.git@' +
+      Var('effcee_revision'),
 
-  'third_party/googletest': vars['google_git'] + '/googletest.git@' +
-      vars['googletest_revision'],
+  'third_party/googletest': Var('google_git') + '/googletest.git@' +
+      Var('googletest_revision'),
 
-  'third_party/glslang': vars['khronos_git'] + '/glslang.git@' +
-      vars['glslang_revision'],
+  'third_party/glslang': Var('khronos_git') + '/glslang.git@' +
+      Var('glslang_revision'),
 
-  'third_party/re2': vars['google_git'] + '/re2.git@' +
-      vars['re2_revision'],
+  'third_party/re2': Var('google_git') + '/re2.git@' +
+      Var('re2_revision'),
 
-  'third_party/spirv-headers': vars['khronos_git'] + '/SPIRV-Headers.git@' +
-      vars['spirv_headers_revision'],
+  'third_party/spirv-headers': Var('khronos_git') + '/SPIRV-Headers.git@' +
+      Var('spirv_headers_revision'),
 
-  'third_party/spirv-tools': vars['khronos_git'] + '/SPIRV-Tools.git@' +
-      vars['spirv_tools_revision'],
+  'third_party/spirv-tools': Var('khronos_git') + '/SPIRV-Tools.git@' +
+      Var('spirv_tools_revision'),
 
-  'third_party/spirv-cross': vars['khronos_git'] + '/SPIRV-Cross.git@' +
-      vars['spirv_cross_revision'],
+  'third_party/spirv-cross': Var('khronos_git') + '/SPIRV-Cross.git@' +
+      Var('spirv_cross_revision'),
 }

--- a/utils/git-sync-deps
+++ b/utils/git-sync-deps
@@ -53,6 +53,7 @@ Git Config:
 
 
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -190,7 +191,12 @@ def git_checkout_to_directory(git, repo, checkoutable, directory, verbose):
 
 def parse_file_to_dict(path):
   dictionary = {}
-  exec(open(path).read(), dictionary)
+  contents = open(path).read()
+  # Need to convert Var() to vars[], so that the DEPS is actually Python. Var()
+  # comes from Autoroller using gclient which has a slightly different DEPS
+  # format.
+  contents = re.sub(r"Var\((.*)\)", r"vars[\1]", contents)
+  exec(contents, dictionary)
   return dictionary
 
 


### PR DESCRIPTION
This is the format that glcient, which is used by Autoroller
expects. Adding to git-sync-deps translating for internal
processing.

Fixes #662