### PR TITLE
Re-introduce SetShaderModel for backwards compatibility

### DIFF
--- a/libshaderc_spvc/include/shaderc/spvc.h
+++ b/libshaderc_spvc/include/shaderc/spvc.h
@@ -164,6 +164,10 @@ shaderc_spvc_compile_options_set_msl_discrete_descriptor_sets(
     shaderc_spvc_compile_options_t options, const uint32_t* descriptors,
     size_t num_descriptors);
 
+// DEPRECATED: Set HLSL shader model.  Default is 30.
+SHADERC_EXPORT void shaderc_spvc_compile_options_set_shader_model(
+    shaderc_spvc_compile_options_t options, uint32_t model);
+
 // Set HLSL shader model.  Default is 30.
 SHADERC_EXPORT void shaderc_spvc_compile_options_set_hlsl_shader_model(
     shaderc_spvc_compile_options_t options, uint32_t model);

--- a/libshaderc_spvc/include/shaderc/spvc.hpp
+++ b/libshaderc_spvc/include/shaderc/spvc.hpp
@@ -203,6 +203,11 @@ class CompileOptions {
         options_, descriptors.data(), descriptors.size());
   }
 
+  // DEPRECATED: Which HLSL shader model should be used.  Default is 30.
+  void SetShaderModel(uint32_t model) {
+    shaderc_spvc_compile_options_set_shader_model(options_, model);
+  }
+
   // Which HLSL shader model should be used.  Default is 30.
   void SetHLSLShaderModel(uint32_t model) {
     shaderc_spvc_compile_options_set_hlsl_shader_model(options_, model);

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -206,6 +206,11 @@ void shaderc_spvc_compile_options_set_msl_discrete_descriptor_sets(
               options->msl_discrete_descriptor_sets.begin());
 }
 
+void shaderc_spvc_compile_options_set_shader_model(
+    shaderc_spvc_compile_options_t options, uint32_t model) {
+  options->hlsl.shader_model = model;
+}
+
 void shaderc_spvc_compile_options_set_hlsl_shader_model(
     shaderc_spvc_compile_options_t options, uint32_t model) {
   options->hlsl.shader_model = model;


### PR DESCRIPTION
This method needs to live a little longer to allow downstream users to
migrate without causing build breakages.

This is part of #673