### PR TITLE
Roll third_party/glslang f88e5824d2cf..9866ad9195ce (33 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
-  'glslang_revision': 'f88e5824d2cfca5edc58c7c2101ec9a4ec36afac',
+  'glslang_revision': '9866ad9195cec8f266f16191fb4ec2ce4896e5c0',
   'googletest_revision': '0599a7b8410dc5cfdb477900b280475ae775d7f9',
   're2_revision': '90970542fe952602f42150c6e71d086f5afebcb3',
   'spirv_headers_revision': 'c4f8f65792d4bf2657ca751904c511bbcf2ac77b',


### PR DESCRIPTION

https://github.com/KhronosGroup/glslang.git
/compare/f88e5824d2cf..9866ad9195ce

git log f88e5824d2cfca5edc58c7c2101ec9a4ec36afac..9866ad9195cec8f266f16191fb4ec2ce4896e5c0 --date=short --no-merges --format=%ad %ae %s
2019-06-04 dkoch@nvidia.com Add support for GL_NV_shader_sm_builtins
2019-06-08 cepheus@frii.com GLSL: Revert f6873f7 to fix #1764.
2019-06-07 jbolz@nvidia.com Use spvValidatorOptionsSetBeforeHlslLegalization for pre-legalized HLSL
2019-06-06 greg@lunarg.com Uppdate spirv-tools known-good
2019-06-05 dsinclair@chromium.org Remove unused parameter
2019-06-04 jbolz@nvidia.com Add missing NV_EXTENSIONS ifdef
2019-06-03 jbolz@nvidia.com Support GL_ARB_fragment_shader_interlock
2019-05-27 dkoch@nvidia.com Fix subgroup support for ray tracing
2019-05-30 dkoch@nvidia.com Add AST tests for ray tracing shaders
2019-05-30 dkoch@nvidia.com Add AST tests for mesh and task shaders
2019-05-30 dkoch@nvidia.com Add more subgroup testing
2019-05-30 jbolz@nvidia.com Allow runtime-sized arrays of acceleration structures
2019-05-28 dkoch@nvidia.com Fix include guard for GL_EXT_multiview
2019-05-28 dkoch@nvidia.com Return consistent names from CapabilityString
2019-05-23 mattparks5855@gmail.com Fixed .dll install on MSVC.
2019-05-17 thomasanderson@google.com Remove non-source sources from binary targets
2019-05-16 syoussefi@chromium.org Build.gn: allow optimization in glslang lib and standalone
2019-05-16 dneto@google.com Update SPIRV-Tools, SPIRV-Headers
2019-05-10 cepheus@frii.com Build: Fix 3 warnings.
2019-05-10 cepheus@frii.com Bump version and revision.
2019-05-09 cepheus@frii.com SPV 1.4: Move to 1.4 validation, removing all 1.4 validation failures.
2019-03-31 cepheus@frii.com SPV 1.4: Emit SignExtend and ZeroExtend for integer image reads/writes.
2019-02-07 cepheus@frii.com SPV 1.4: Lookup tables: Use variable initializer and NonWritable...
2019-01-15 cepheus@frii.com SPV 1.4: Add support for OpCopyLogical, careful of Boolean differences.
2019-01-12 cepheus@frii.com SPV 1.4: Implement the 5 new loop controls.
2019-01-10 cepheus@frii.com SPV 1.4: Use OpSelect for trivial typed non-scalar/vector expressions.
2019-01-04 cepheus@frii.com SPV 1.4: Add testing infrastructure for SPV 1.4 tests.
2019-01-04 cepheus@frii.com SPV 1.4: Generate all globals on OpEntryPoint interface list.
2019-05-09 cepheus@frii.com SPV: Move to the SPIR-V 1.4 header.
2019-05-09 cepheus@frii.com Latest known-good SPIRV-Tools: WARNING: Needs python 3.x.
2019-05-09 cepheus@frii.com Bump revision.
2019-05-08 jbolz@nvidia.com For nonuniformEXT constructor, make a copy of the node to decorate
2019-03-08 jbolz@nvidia.com Add support for GL_EXT_buffer_reference2

The AutoRoll server is located here: https://autoroll.skia.org/r/glslang-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

