### PR TITLE
Roll third_party/re2 90970542fe95..0c95bcce2f1f (47 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -7,7 +7,7 @@ vars = {
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
   'glslang_revision': 'f88e5824d2cfca5edc58c7c2101ec9a4ec36afac',
   'googletest_revision': '0599a7b8410dc5cfdb477900b280475ae775d7f9',
-  're2_revision': '90970542fe952602f42150c6e71d086f5afebcb3',
+  're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
   'spirv_headers_revision': 'c4f8f65792d4bf2657ca751904c511bbcf2ac77b',
   'spirv_tools_revision': '0125b28ed4214d1860696f22d230dbfc965c6c2c',
   'spirv_cross_revision': 'fce83b7e8b0f6599efd4481992b2eb30f69f21de',


### PR DESCRIPTION

https://github.com/google/re2.git
/compare/90970542fe95..0c95bcce2f1f

git log 90970542fe952602f42150c6e71d086f5afebcb3..0c95bcce2f1f0f071a786ca2c42384b211b8caba --date=short --no-merges --format=%ad %ae %s
2019-05-22 junyer@google.com Add GCC 9.x to the Travis CI matrix.
2019-05-05 junyer@google.com Fix the bug in Regexp::ToString() that emitted [^].
2019-04-19 junyer@google.com Set an ALIAS and a NAMESPACE in the CMake configuration.
2019-04-18 junyer@google.com Configure CMake to install the re2Config &#34;export&#34;.
2019-04-17 junyer@google.com Address some clang-tidy gripes.
2019-04-11 jbw@google.com Update Consume&#39;s method comment re: empty matches.
2019-04-09 junyer@google.com Make the fuzzer check for large substrings as soon as possible.
2019-03-18 junyer@google.com Get rid of `using std::string;`. (part 7 of 7)
2019-03-18 junyer@google.com Get rid of `using std::string;`. (part 6 of N)
2019-03-18 junyer@google.com Get rid of `using std::string;`. (part 5 of N)
2019-03-18 junyer@google.com Get rid of `using std::string;`. (part 4 of N)
2019-03-18 junyer@google.com Get rid of `using std::string;`. (part 3 of N)
2019-03-18 junyer@google.com Get rid of `using std::string;`. (part 2 of N)
2019-03-18 junyer@google.com Get rid of `using std::string;`. (part 1 of N)
2019-03-14 junyer@google.com Make the BitState bitmap use list heads.
2019-03-13 junyer@google.com Make NFA use hints.
2019-03-11 junyer@google.com Avoid touching the bitmap even more.
2019-03-11 junyer@google.com Make BitState avoid touching the bitmap unnecessarily.
2019-03-10 junyer@google.com Give foldcase 1 bit and hint 15 bits.
2019-03-08 junyer@google.com Remove a bogus comment.
2019-03-08 junyer@google.com Handle foldcase when computing hints. Mea culpa.
2019-03-08 junyer@google.com Compute hints for ByteRange instructions. Make BitState use them.
2019-03-06 junyer@google.com Tidy up a call to fullrune().
2019-03-05 junyer@google.com Fix a silly buffer underflow.
2019-03-05 junyer@google.com Implement run length encoding for BitState.
2019-03-04 junyer@google.com Simplify AltMatch and Capture handling in BitState.
2019-02-25 junyer@google.com Make the fuzzer handle \p and \P specially.
2019-02-25 junyer@google.com Check onepass_nodes_.data(), not .size().
2019-02-25 ckennelly@google.com Use PODArray&lt;&gt; for OnePass nodes.
2019-02-13 junyer@google.com Update the Erlang wrapper URL.
2019-02-10 junyer@google.com Tidy up semicolons (mostly macro-related) in re2.h.
2019-01-31 junyer@google.com Clarify the scope of a comment.
2019-01-31 junyer@google.com Work around a bug in older versions of bash. :/
2019-01-31 junyer@google.com Refactor the CMake scripts.
2019-01-31 junyer@google.com Use bash on Windows since Kokoro offers it.
2019-01-31 junyer@google.com Refactor the Bazel scripts.
2019-01-29 junyer@google.com Try using bash on Windows since Kokoro offers it.
2019-01-25 junyer@google.com Crudely limit the use of various character classes when fuzzing.
2019-01-21 junyer@google.com Oops, std::string_view requires C&#43;&#43;17.
2019-01-21 junyer@google.com Support constructing StringPiece from std::string_view.
2019-01-21 junyer@google.com Add Clang 8 to the Travis CI matrix.
2019-01-11 junyer@google.com Avoid null PODArray&lt;&gt; issues in SparseSet and SparseArray&lt;&gt;.
2019-01-11 junyer@google.com Use PODArray&lt;&gt; in SparseArray&lt;&gt;.
2019-01-10 junyer@google.com Simplify SparseArray&lt;&gt; significantly.
2019-01-10 junyer@google.com Ensure we succeed at constructing new sparse and dense arrays.
2019-01-09 ckennelly@google.com Ensure we succeed at constructing new sparse and dense arrays.
2019-01-09 ckennelly@google.com Use PODArray&lt;&gt; in SparseSet.

The AutoRoll server is located here: https://autoroll.skia.org/r/re2-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

