### PR TITLE
Roll third_party/spirv-tools 0125b28ed421..208d3132e6e8 (14 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ vars = {
   'googletest_revision': '0599a7b8410dc5cfdb477900b280475ae775d7f9',
   're2_revision': '90970542fe952602f42150c6e71d086f5afebcb3',
   'spirv_headers_revision': 'c4f8f65792d4bf2657ca751904c511bbcf2ac77b',
-  'spirv_tools_revision': '0125b28ed4214d1860696f22d230dbfc965c6c2c',
+  'spirv_tools_revision': '208d3132e6e8facd91aa7706e4f57bdcd7ce1ec9',
   'spirv_cross_revision': 'fce83b7e8b0f6599efd4481992b2eb30f69f21de',
 }
 


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Tools.git
/compare/0125b28ed421..208d3132e6e8

git log 0125b28ed4214d1860696f22d230dbfc965c6c2c..208d3132e6e8facd91aa7706e4f57bdcd7ce1ec9 --date=short --no-merges --format=%ad %ae %s
2019-06-07 stevenperron@google.com Cast __LINE__ to size_t (#2661)
2019-06-06 afdx@google.com Add transformation to replace a boolean constant with a numeric comparison (#2659)
2019-06-06 dgkoch@users.noreply.github.com Add builtin validation for SPV_NV_shader_sm_builtins (#2656)
2019-06-06 greg@lunarg.com Instrument: Fix code for version 2 output format. (#2655)
2019-06-05 afdx@google.com Fix bug in &#39;split blocks&#39;, and add tests for fuzzer. (#2658)
2019-06-05 dneto@google.com Optimizer: Handle array type with OpSpecConstantOp length (#2652)
2019-06-05 afdx@google.com Add fuzzer pass to add dead breaks. (#2654)
2019-06-04 afdx@google.com Add fuzzer pass that adds useful constructs to a module (#2647)
2019-06-03 jbolz@nvidia.com Add validation for SPV_EXT_fragment_shader_interlock (#2650)
2019-05-31 zoddicus@users.noreply.github.com Remove asserts from GetUnderlyingType (#2646)
2019-05-31 dsinclair@chromium.org Close opened file handles. (#2644)
2019-05-31 kevin.petit@arm.com Validate OpenCL rules for ImageRead and OpImageSampleExplicitLod (#2643)
2019-05-31 afdx@google.com Add spirv-fuzz pass to permute blocks. (#2642)
2019-05-29 pierremoreau@users.noreply.github.com Linker: Better type comparison for OpTypeArray and OpTypeForwardPointer (#2580)

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-tools-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

