### PR TITLE
Roll third_party/spirv-cross fce83b7e8b0f..5e9e8918f9a2 (37 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ vars = {
   're2_revision': '90970542fe952602f42150c6e71d086f5afebcb3',
   'spirv_headers_revision': 'c4f8f65792d4bf2657ca751904c511bbcf2ac77b',
   'spirv_tools_revision': '0125b28ed4214d1860696f22d230dbfc965c6c2c',
-  'spirv_cross_revision': 'fce83b7e8b0f6599efd4481992b2eb30f69f21de',
+  'spirv_cross_revision': '5e9e8918f9a22d488811c575a97ccda2d8a8726d',
 }
 
 deps = {


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Cross.git
/compare/fce83b7e8b0f..5e9e8918f9a2

git log fce83b7e8b0f6599efd4481992b2eb30f69f21de..5e9e8918f9a22d488811c575a97ccda2d8a8726d --date=short --no-merges --format=%ad %ae %s
2019-06-10 post@arntzen-software.no Expand constexpr sampler sanity check.
2019-06-10 post@arntzen-software.no MSL: Support remapping constexpr samplers by set/binding.
2019-06-10 post@arntzen-software.no Employ heuristics to figure out how to emit SSBO/UAV reflection names.
2019-06-06 post@arntzen-software.no Deal with nested loops.
2019-06-06 post@arntzen-software.no Use the existing loop dominator when doing loop variable preservation.
2019-06-06 post@arntzen-software.no Rewrite how loop dominators are propagated.
2019-06-06 post@arntzen-software.no Deal with case where a variable is dominated by inner part of a loop.
2019-06-05 pmours@nvidia.com Fix storage packing qualifiers missing on &#34;shaderRecordNV&#34; buffers
2019-06-05 pmours@nvidia.com Add test for callable data
2019-06-05 pmours@nvidia.com Fix callable data variables
2019-06-03 pmours@nvidia.com Add support for &#34;shaderRecordNV&#34; qualifier
2019-06-05 post@arntzen-software.no Deal with case where a block is somehow emitted in a duplicated fashion.
2019-06-02 post@arntzen-software.no Fix erronous default for emit_line_directives.
2019-05-31 post@arntzen-software.no MSL: Fix declaration of unused input variables.
2019-05-28 post@arntzen-software.no Fixup OpLine parsing comments.
2019-05-28 post@arntzen-software.no Support emitting OpLine directive.
2019-05-28 post@arntzen-software.no GLSL: Support std430 in UBOs with scalar layout.
2019-05-27 post@arntzen-software.no Run format_all.sh.
2019-05-27 post@arntzen-software.no MSL: Use correct address space when passing array-of-buffers.
2019-05-27 post@arntzen-software.no OpArrayLength must trigger active variables.
2019-05-27 post@arntzen-software.no MSL: Implement OpArrayLength.
2019-05-24 post@arntzen-software.no Add Git/timestamp --revision support.
2019-05-23 post@arntzen-software.no MSL: Add test case for complex type alias.
2019-05-23 post@arntzen-software.no MSL: Fix struct declaration order with complex type aliases.
2019-05-18 post@arntzen-software.no Fix formatting, update C ABI version.
2019-05-09 post@arntzen-software.no MSL: Support argument buffers and image swizzling.
2019-05-08 stuart.carnie@gmail.com Add get_member_name and active_buffer_ranges to C APIs
2019-05-17 amerkoleci@gmail.com Fix spvc_type_get_vector_size C function.
2019-05-16 cdavis@codeweavers.com Remove fallback for OpGroupNonUniformElect.
2019-05-15 cdavis@codeweavers.com MSL: Add support for subgroup operations.
2019-05-14 post@arntzen-software.no Only deploy on new tags.
2019-05-14 post@arntzen-software.no Add setup for Github releases via Travis.
2019-05-14 post@arntzen-software.no Validate that C ABI in CMakeLists.txt matches code.
2019-05-14 post@arntzen-software.no Run format_all.sh.
2019-05-11 laszlo.agocs@qt.io GLSL: Add option to disable buffer blocks regardless of version
2019-05-13 post@arntzen-software.no Fix nonuniform test for MSL.
2019-05-13 post@arntzen-software.no HLSL/MSL: Deal correctly with nonuniformEXT qualifier.

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-cross-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

