### PR TITLE
Roll third_party/googletest 0599a7b8410d..076b7f778883 (129 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ vars = {
 
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
   'glslang_revision': 'f88e5824d2cfca5edc58c7c2101ec9a4ec36afac',
-  'googletest_revision': '0599a7b8410dc5cfdb477900b280475ae775d7f9',
+  'googletest_revision': '076b7f7788833ca31206bc30e5a2cfbdb9628f29',
   're2_revision': '90970542fe952602f42150c6e71d086f5afebcb3',
   'spirv_headers_revision': 'c4f8f65792d4bf2657ca751904c511bbcf2ac77b',
   'spirv_tools_revision': '0125b28ed4214d1860696f22d230dbfc965c6c2c',


### PR DESCRIPTION

https://github.com/google/googletest.git
/compare/0599a7b8410d..076b7f778883

git log 0599a7b8410dc5cfdb477900b280475ae775d7f9..076b7f7788833ca31206bc30e5a2cfbdb9628f29 --date=short --no-merges --format=%ad %ae %s
2019-06-10 misterg@google.com remove obsolete codegear files
2019-06-10 misterg@google.com removing obsolete language from docs, CMake and Bazel is the only supporeted build methods
2019-06-10 misterg@google.com removing gmock msvc solution, as CMake and Bazel is the only supporeted build methods
2019-06-10 misterg@google.com removing build-aux files , as CMake and Bazel is the only supporeted build methods
2019-06-10 misterg@google.com removing xcode files , as CMake and Bazel is the only supporeted build methods
2019-06-10 misterg@google.com removing msvc solution, as CMake and Bazel is the only supporeted build methods
2019-06-06 llyanwenyuan@gmail.com fix typo
2019-06-05 absl-team@google.com Googletest export
2019-06-03 misterg@google.com Googletest export
2019-06-04 plevine457@gmail.com Don&#39;t allow signed/unsigned wchar_t in gcc 9 and later
2019-05-30 kmills@adobe.com Fuse gtest-spi.h into the resulting header.
2019-05-29 absl-team@google.com Googletest export
2019-05-28 m1brobbel@gmail.com Suppress CMake policy warning (CMP0048)
2019-05-27 gennadiycivil@users.noreply.github.com Update CONTRIBUTING.md
2019-05-27 gennadiycivil@users.noreply.github.com Update CONTRIBUTING.md
2019-05-22 gennadiycivil@users.noreply.github.com Update README.md
2019-05-22 misterg@google.com removing msvc
2019-05-22 misterg@google.com removing msvc
2019-05-22 misterg@google.com removing codegear
2019-05-22 lfy@google.com unbreak windows build
2019-05-19 yaneurabeya@gmail.com Fix typo introduced in 63be3dcc245 (maintaners -&gt; maintainers)
2019-05-17 gennadiycivil@users.noreply.github.com Update advanced.md
2019-05-13 chaorany@me.com add unit test for overload &amp; operator
2019-05-13 gennadiycivil@users.noreply.github.com Added docs for testing::RegisterTest
2019-05-12 chaorany@me.com Use std::addressof to instead of plain &#39;&amp;&#39;.
2019-05-08 absl-team@google.com Googletest export
2019-05-03 absl-team@google.com Googletest export
2019-04-29 misterg@google.com Googletest export
2019-05-02 daquexian566@gmail.com Fix -Wsign-conversion error by adding static_cast
2019-04-29 misterg@google.com Removing  obsolete msvc 2005 and 2010
2019-04-29 misterg@google.com Removing  obsolete codegear and msvc 2010
2019-04-29 misterg@google.com Googletest export
2019-04-26 ccna.syl@gmail.com Fix compilation on CentOS 7
2019-04-26 yaneurabeya@gmail.com Address fallout from -Wsign-conversion work on Windows
2019-04-22 absl-team@google.com Googletest export
2019-04-18 gennadiycivil@users.noreply.github.com Update README.md
2019-04-18 misterg@google.com Googletest export
2019-04-18 absl-team@google.com Googletest export
2019-04-18 misterg@google.com Googletest export
2019-04-16 absl-team@google.com Googletest export
2019-04-15 absl-team@google.com Googletest export
2019-04-12 calvin@hakobaito.co.uk Sort Haiku platform definition alphabetically.
2019-04-11 calvin@hakobaito.co.uk Add Haiku platform support.
2019-04-11 rong.ou@gmail.com replace test case with test suite in the primer
2019-04-09 davidben@google.com MSVC C5046 warning is unavailable in MSVC 2015.
2019-04-09 rong.ou@gmail.com add missing period
2019-04-07 gennadiycivil@users.noreply.github.com Update README.md
2019-04-06 ivo.kirov@gmail.com Update ForDummies.md
2019-03-08 yaneurabeya@gmail.com clang: fix `-Wsign-conversion` errors
2019-04-04 absl-team@google.com Googletest export
2019-02-21 yaneurabeya@gmail.com clang: explicitly enable/disable RTTI support with the compiler
2019-04-02 absl-team@google.com Googletest export
2019-04-01 absl-team@google.com Googletest export
2019-04-01 absl-team@google.com Googletest export
2019-03-29 yaneurabeya@gmail.com Handle GTEST_SKIP() when calling `Environment::SetUp()`
2019-03-04 yaneurabeya@gmail.com Prefix googletest binaries under its own subtree instead of `gtest`
2019-03-22 absl-team@google.com Googletest export
2019-03-28 gennadiycivil@users.noreply.github.com Update CONTRIBUTING.md
2019-03-28 gennadiycivil@users.noreply.github.com Update CONTRIBUTING.md
2019-03-26 syohex@gmail.com Update Xcode project file
2019-03-21 gennadiycivil@users.noreply.github.com Update googletest/docs/advanced.md
2019-03-19 absl-team@google.com Googletest export
2019-03-18 absl-team@google.com Googletest export
2019-03-21 michael.thenault@gmail.com Note about INSTANTIATE_TEST_SUITE_P / INSTANTIATE_TEST_CASE_P  keyword change
2019-03-15 Tobias_Mueller@twam.info Remove old_crtdbg_flag_ member if not required
2019-03-15 seth.raymond@maine.edu DesignDoc Markdown table was broken
2019-03-04 absl-team@google.com Googletest export
2019-03-04 absl-team@google.com Googletest export
2019-02-28 absl-team@google.com Googletest export
2019-02-26 absl-team@google.com Googletest export
2019-03-01 carlo@alinoe.com Minor build system fixes.
2019-02-25 absl-team@google.com Googletest export
2019-02-25 rsinnet@users.noreply.github.com Fix grammatical error in primer.md
2019-02-21 yaneurabeya@gmail.com Don&#39;t hardcode the filename in `CxxExceptionDeathTest.PrintsMessageForStdException`
2019-02-20 misterg@google.com Googletest export
2019-02-19 absl-team@google.com Googletest export
2019-02-20 dds@aueb.gr Avoid array index out of range
2019-02-18 yaneurabeya@gmail.com Ignore `-Wsign-conversion` issues
2019-02-13 yaneurabeya@gmail.com Fix clang `-Wunused-parameter` warnings
2019-02-13 yaneurabeya@gmail.com Fix clang `-Winconsistent-missing-override` warnings
2019-02-13 yaneurabeya@gmail.com Fix clang `-Winconsistent-missing-override` warnings
2019-02-13 yaneurabeya@gmail.com Add `cxx_strict_flags` for clang to match FreeBSD&#39;s WARNS flags
2019-02-12 yaneurabeya@gmail.com Import `patch-bsd-defines` from FreeBSD ports [1]
2019-02-12 yaneurabeya@gmail.com Compile clang with `-Wall -Wshadow -Werror`
2019-02-12 yaneurabeya@gmail.com Fix -Wunused-private-field issues with clang
2019-02-12 misterg@google.com Googletest export
2019-02-07 absl-team@google.com Googletest export
2019-02-05 absl-team@google.com Googletest export
2019-02-04 absl-team@google.com Googletest export
2018-02-10 knut.omang@oracle.com Set gtest version correctly for older cmake versions
2018-02-25 knut.omang@oracle.com Generate a libgtest.la to help libtool managing dependencies
2016-12-23 jwakely@redhat.com Stop TestInfo::Run() calling a function through null pointer
2019-02-05 chrisjohnsonmail@gmail.com fix:  Correct *-all.cc file paths
2019-02-05 keiichiw@chromium.org Fix an invalid example of JSON report in advanced.md
2019-02-04 gennadiycivil@users.noreply.github.com Update .travis.yml
2019-02-04 gennadiycivil@users.noreply.github.com Update .travis.yml
2019-01-12 yaneurabeya@gmail.com Test out changes with clang/OSX each PR using Travis CI
2019-02-04 misterg@google.com Googletest export
2019-02-04 misterg@google.com Googletest export
2019-02-01 absl-team@google.com Googletest export
2019-02-04 maetugr@gmail.com cmake: detect Cygwin which needs extensions to build
2019-02-04 maetugr@gmail.com cmake: move global project definition to beginning
2019-01-31 absl-team@google.com Googletest export
2019-02-01 chrisjohnsonmail@gmail.com chore: Add PlatformIO supported platforms list
2019-01-31 chrisjohnsonmail@gmail.com fix: Add Arduino to embedded platform list
2019-01-31 chrisjohnsonmail@gmail.com fix: Add *_all.cc files to ignore list
2019-01-31 g4691821@gmail.com Fix README.md broken link
2019-01-30 gennadiycivil@users.noreply.github.com Repeat #2090
2019-01-30 Kelly_G_Walker@hotmail.com Update advanced.md casing in example
2019-01-29 gennadiycivil@users.noreply.github.com Added -Wgnu-zero-variadic-macro-arguments&#34; clang
2019-01-28 hugo.lindstrom@trimble.se Avoid dynamic/static runtime linking (LNK4098) by properly replacing MD(d)-&gt;MT(d) in both C and CXX flags, resolves 2074
2019-01-24 acozzette@google.com Fixed &#34;make dist&#34;
2019-01-22 absl-team@google.com Googletest export
2019-01-22 absl-team@google.com Googletest export
2019-01-22 samolisov@gmail.com Enable CI on Windows (appveyor) with Bazel
2019-01-17 absl-team@google.com Googletest export
2019-01-18 mathbunnyru@gmail.com Fix INSTANTIATE_TEST_CASE_P with zero variadic arguments
2019-01-16 absl-team@google.com Googletest export
2019-01-14 misterg@google.com Googletest export
2019-01-12 absl-team@google.com Googletest export
2019-01-12 absl-team@google.com Googletest export
2019-01-14 samolisov@gmail.com Enable building as a shared library (dll) on Windows with Bazel
2019-01-07 chrisjohnsonmail@gmail.com fix:  Add Arduino setup()/loop() functions back
2019-01-03 chrisjohnsonmail@gmail.com misc:  Reapply Arduino functions
2019-01-03 chrisjohnsonmail@gmail.com misc:  Revert formatting changes.
2019-01-03 chrisjohnsonmail@gmail.com chore:  Add Windows cmake files to .gitignore
2019-01-03 chrisjohnsonmail@gmail.com chore:  Alphabetize exclude directories.
2019-01-03 chrisjohnsonmail@gmail.com fix:  Correct *_main.cc paths
2019-01-03 chrisjohnsonmail@gmail.com fix:  Remove Arduino entry points

The AutoRoll server is located here: https://autoroll.skia.org/r/googletest-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

