### PR TITLE
Roll third_party/spirv-headers c4f8f65792d4..9242862c84fe (15 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'glslang_revision': 'f88e5824d2cfca5edc58c7c2101ec9a4ec36afac',
   'googletest_revision': '0599a7b8410dc5cfdb477900b280475ae775d7f9',
   're2_revision': '90970542fe952602f42150c6e71d086f5afebcb3',
-  'spirv_headers_revision': 'c4f8f65792d4bf2657ca751904c511bbcf2ac77b',
+  'spirv_headers_revision': '9242862c84fe295ca0c9d26b36a6a891bb3ed6a7',
   'spirv_tools_revision': '0125b28ed4214d1860696f22d230dbfc965c6c2c',
   'spirv_cross_revision': 'fce83b7e8b0f6599efd4481992b2eb30f69f21de',
 }


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Headers.git
/compare/c4f8f65792d4..9242862c84fe

git log c4f8f65792d4bf2657ca751904c511bbcf2ac77b..9242862c84fe295ca0c9d26b36a6a891bb3ed6a7 --date=short --no-merges --format=%ad %ae %s
2019-06-07 cepheus@frii.com Add missing &#34;version&#34; : &#34;None&#34; to a bunch of reserved enumerants.
2019-06-07 cepheus@frii.com Add more detail about reserving tokens to the README.
2019-06-07 cepheus@frii.com Restore numerical order in enumerants.
2019-06-02 jbolz@nvidia.com Add SPV_EXT_fragment_shader_interlock
2019-05-17 dkoch@nvidia.com Add support for SPV_NV_sm_shader_builtins
2019-05-31 cepheus@frii.com OpenCL ext. inst. header: Support C in addition to C&#43;&#43;.
2019-05-27 michael.kinsner@intel.com Proposed LoopControl bitfield allocation mechanism in spir-v.xml
2019-05-23 victor@codeplay.com Reserve token range for Codeplay
2019-05-18 mchiasson@gmail.com Update CMakeLists.txt
2019-05-16 jbolz@nvidia.com Update HasResultAndType code generation to skip duplicate enum values. There weren&#39;t any until SPIR-V 1.4 release, now there are two.
2019-05-16 mchiasson@gmail.com updated as per code review
2019-05-12 alan@alankemp.com Compare enum names rather than values to determine last element
2019-05-11 mchiasson@gmail.com cmake development configuration package Fixes #104
2019-05-09 rex.xu@amd.com Enable Groups capability by the extension SPV_AMD_shader_ballot
2019-04-30 ian.d.romanick@intel.com Add INTEL_shader_integer_functions2

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-headers-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

