### PR TITLE
Roll third_party/spirv-headers 9242862c84fe..9cf7c3a7d2d2 (1 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'glslang_revision': '9866ad9195cec8f266f16191fb4ec2ce4896e5c0',
   'googletest_revision': '076b7f7788833ca31206bc30e5a2cfbdb9628f29',
   're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
-  'spirv_headers_revision': '9242862c84fe295ca0c9d26b36a6a891bb3ed6a7',
+  'spirv_headers_revision': '9cf7c3a7d2d203b1ee35896547b9644e28d9280e',
   'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',
   'spirv_cross_revision': '5e9e8918f9a22d488811c575a97ccda2d8a8726d',
 }


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Headers.git
/compare/9242862c84fe..9cf7c3a7d2d2

git log 9242862c84fe295ca0c9d26b36a6a891bb3ed6a7..9cf7c3a7d2d203b1ee35896547b9644e28d9280e --date=short --no-merges --format=%ad %ae %s
2019-06-10 ehsannas@gmail.com Add grammar and symbols for UserTypeGOOGLE extension to unified1.

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-headers-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

