### PR TITLE
Roll third_party/spirv-cross 5e9e8918f9a2..fccf1d046204 (1 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ vars = {
   're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
   'spirv_headers_revision': '9cf7c3a7d2d203b1ee35896547b9644e28d9280e',
   'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',
-  'spirv_cross_revision': '5e9e8918f9a22d488811c575a97ccda2d8a8726d',
+  'spirv_cross_revision': 'fccf1d046204802aa04f05b4af7ca91fab37c50f',
 }
 
 deps = {


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Cross.git
/compare/5e9e8918f9a2..fccf1d046204

git log 5e9e8918f9a22d488811c575a97ccda2d8a8726d..fccf1d046204802aa04f05b4af7ca91fab37c50f --date=short --no-merges --format=%ad %ae %s
2019-06-12 post@arntzen-software.no Add MSL 2.2 path in test_shaders.py.

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-cross-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

