### PR TITLE
Roll third_party/spirv-cross fccf1d046204..00a8539d1ddf (1 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ vars = {
   're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
   'spirv_headers_revision': '9cf7c3a7d2d203b1ee35896547b9644e28d9280e',
   'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',
-  'spirv_cross_revision': 'fccf1d046204802aa04f05b4af7ca91fab37c50f',
+  'spirv_cross_revision': '00a8539d1ddf8d0d934813e409500af6363c96f1',
 }
 
 deps = {


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Cross.git
/compare/fccf1d046204..00a8539d1ddf

git log fccf1d046204802aa04f05b4af7ca91fab37c50f..00a8539d1ddf8d0d934813e409500af6363c96f1 --date=short --no-merges --format=%ad %ae %s
2019-06-11 post@arntzen-software.no MSL: Support Invariant qualifier on position.

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-cross-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

