### PR TITLE
Roll third_party/spirv-cross 00a8539d1ddf..95053ea4bc22 (2 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ vars = {
   're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
   'spirv_headers_revision': '9cf7c3a7d2d203b1ee35896547b9644e28d9280e',
   'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',
-  'spirv_cross_revision': '00a8539d1ddf8d0d934813e409500af6363c96f1',
+  'spirv_cross_revision': '95053ea4bc22c35960a95ffa4b3b78ada2c89838',
 }
 
 deps = {


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Cross.git
/compare/00a8539d1ddf..95053ea4bc22

git log 00a8539d1ddf8d0d934813e409500af6363c96f1..95053ea4bc22c35960a95ffa4b3b78ada2c89838 --date=short --no-merges --format=%ad %ae %s
2019-06-12 post@arntzen-software.no MSL: Support stencil export.
2019-06-12 post@arntzen-software.no GLSL: Support GL_ARB_shader_stencil_export.

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-cross-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

