### PR TITLE
Add invert-y option for glslc and libshaderc.

### DIFF
--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -66,6 +66,7 @@ Options:
   -fhlsl_functionality1, -fhlsl-functionality1
                     Enable extension SPV_GOOGLE_hlsl_functionality1 for HLSL
                     compilation.
+  -finvert-y        Invert position.Y output in vertex shader.
   -fhlsl-iomap      Use HLSL IO mappings for bindings.
   -fhlsl-offsets    Use HLSL offset rules for packing members of blocks.
                     Affects only GLSL.  HLSL rules are always used for HLSL.
@@ -296,6 +297,8 @@ int main(int argc, char** argv) {
       compiler.options().SetHlslOffsets(true);
     } else if (arg == "-fhlsl_functionality1" || arg == "-fhlsl-functionality1") {
       compiler.options().SetHlslFunctionality1(true);
+    } else if (arg == "-finvert-y") {
+      compiler.options().SetInvertY(true);
     } else if (((u_kind = shaderc_uniform_kind_image),
                 (arg == "-fimage-binding-base")) ||
                ((u_kind = shaderc_uniform_kind_texture),

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -450,6 +450,10 @@ SHADERC_EXPORT void shaderc_compile_options_set_hlsl_register_set_and_binding(
 SHADERC_EXPORT void shaderc_compile_options_set_hlsl_functionality1(
     shaderc_compile_options_t options, bool enable);
 
+// Sets whether the compiler should invert position.Y output in vertex shader.
+SHADERC_EXPORT void shaderc_compile_options_set_invert_y(
+    shaderc_compile_options_t options, bool enable);
+
 // An opaque handle to the results of a call to any shaderc_compile_into_*()
 // function.
 typedef struct shaderc_compilation_result* shaderc_compilation_result_t;

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -326,6 +326,11 @@ class CompileOptions {
     shaderc_compile_options_set_hlsl_functionality1(options_, enable);
   }
 
+  // Sets whether the compiler should invert position.Y output in vertex shader.
+  void SetInvertY(bool enable) {
+    shaderc_compile_options_set_invert_y(options_, enable);
+  }
+
  private:
   CompileOptions& operator=(const CompileOptions& other) = delete;
   shaderc_compile_options_t options_;

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -538,6 +538,11 @@ void shaderc_compile_options_set_hlsl_functionality1(
   options->compiler.EnableHlslFunctionality1(enable);
 }
 
+void shaderc_compile_options_set_invert_y(
+    shaderc_compile_options_t options, bool enable) {
+  options->compiler.EnableInvertY(enable);
+}
+
 shaderc_compiler_t shaderc_compiler_initialize() {
   static shaderc_util::GlslangInitializer* initializer =
       new shaderc_util::GlslangInitializer;

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -231,6 +231,7 @@ class Compiler {
         hlsl_offsets_(false),
         hlsl_legalization_enabled_(true),
         hlsl_functionality1_enabled_(false),
+        invert_y_enabled_(false),
         hlsl_explicit_bindings_() {}
 
   // Requests that the compiler place debug information into the object code,
@@ -246,6 +247,9 @@ class Compiler {
 
   // Enables or disables extension SPV_GOOGLE_hlsl_functionality1
   void EnableHlslFunctionality1(bool enable);
+
+  // Enables or disables invert position.Y output in vertex shader.
+  void EnableInvertY(bool enable);
 
   // When a warning is encountered it treat it as an error.
   void SetWarningsAsErrors();
@@ -517,6 +521,9 @@ class Compiler {
 
   // True if the compiler should support extension SPV_GOOGLE_hlsl_functionality1.
   bool hlsl_functionality1_enabled_;
+
+  // True if the compiler should invert position.Y output in vertex shader.
+  bool invert_y_enabled_;
 
   // A sequence of triples, each triple representing a specific HLSL register
   // name, and the set and binding numbers it should be mapped to, but in

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -301,6 +301,7 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   if (hlsl_functionality1_enabled_) {
     shader.setEnvTargetHlslFunctionality1();
   }
+  shader.setInvertY(invert_y_enabled_);
 
   const EShMessages rules = GetMessageRules(target_env_, source_language_,
                                             hlsl_offsets_,
@@ -449,6 +450,10 @@ void Compiler::EnableHlslFunctionality1(bool enable) {
   hlsl_functionality1_enabled_ = enable;
 }
 
+void Compiler::EnableInvertY(bool enable) {
+  invert_y_enabled_ = enable;
+}
+
 void Compiler::SetSuppressWarnings() { suppress_warnings_ = true; }
 
 std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
@@ -481,6 +486,7 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
   if (hlsl_functionality1_enabled_) {
     shader.setEnvTargetHlslFunctionality1();
   }
+  shader.setInvertY(invert_y_enabled_);
 
   // The preprocessor might be sensitive to the target environment.
   // So combine the existing rules with the just-give-me-preprocessor-output


### PR DESCRIPTION
Option invert-y for compiler is simple way for using DirectX shader code for Vulkan which uses a different coordinate system. Without the need to do it manually: ```gl_Position.y = -gl_Position.y``` or use [VK_KHR_MAINTENANCE1](https://www.saschawillems.de/blog/2019/03/29/flipping-the-vulkan-viewport/) extension.