### PR TITLE
Roll third_party/spirv-headers 9cf7c3a7d2d2..de99d4d834ae (1 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'glslang_revision': '9866ad9195cec8f266f16191fb4ec2ce4896e5c0',
   'googletest_revision': '89656ddbe62f9f0eeb6447868b31f2ec3b1052bb',
   're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
-  'spirv_headers_revision': '9cf7c3a7d2d203b1ee35896547b9644e28d9280e',
+  'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
   'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',
   'spirv_cross_revision': '00a8539d1ddf8d0d934813e409500af6363c96f1',
 }


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Headers.git
/compare/9cf7c3a7d2d2..de99d4d834ae

git log 9cf7c3a7d2d203b1ee35896547b9644e28d9280e..de99d4d834aeb51dd9f099baa285bd44fd04bb3d --date=short --no-merges --format=%ad %ae %s
2019-06-12 dneto@google.com Add Volatile to Memory Semantics, for SPV_KHR_vulkan_memory_model

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-headers-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

