### PR TITLE
Roll third_party/spirv-cross 00a8539d1ddf..4104e363005a (3 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ vars = {
   're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
   'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
   'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',
-  'spirv_cross_revision': '00a8539d1ddf8d0d934813e409500af6363c96f1',
+  'spirv_cross_revision': '4104e363005a079acc215f0920743a8affb31278',
 }
 
 deps = {


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Cross.git
/compare/00a8539d1ddf..4104e363005a

git log 00a8539d1ddf8d0d934813e409500af6363c96f1..4104e363005a079acc215f0920743a8affb31278 --date=short --no-merges --format=%ad %ae %s
2019-06-13 post@arntzen-software.no MSL: Fix regression with Private parameter declaration.
2019-06-12 post@arntzen-software.no MSL: Support stencil export.
2019-06-12 post@arntzen-software.no GLSL: Support GL_ARB_shader_stencil_export.

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-cross-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

