### PR TITLE
Roll third_party/spirv-tools 9c0830133b07..42830e5a68c3 (2 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ vars = {
   'googletest_revision': '89656ddbe62f9f0eeb6447868b31f2ec3b1052bb',
   're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
   'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
-  'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',
+  'spirv_tools_revision': '42830e5a68c38b4bf7a8ad39ee83cc7ab60eb972',
   'spirv_cross_revision': '00a8539d1ddf8d0d934813e409500af6363c96f1',
 }
 


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Tools.git
/compare/9c0830133b07..42830e5a68c3

git log 9c0830133b07203a47ddc101fa4b298bab4438d8..42830e5a68c38b4bf7a8ad39ee83cc7ab60eb972 --date=short --no-merges --format=%ad %ae %s
2019-06-13 afdx@google.com Add replayer tool for spirv-fuzz. (#2664)
2019-06-13 33432579&#43;alan-baker@users.noreply.github.com Add validation for Subgroup builtins (#2637)

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-tools-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

