### PR TITLE
Roll third_party/googletest af4c2cb098a3..26afdba792e5 (1 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,7 +6,7 @@ vars = {
 
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
   'glslang_revision': '9866ad9195cec8f266f16191fb4ec2ce4896e5c0',
-  'googletest_revision': 'af4c2cb098a35f4898c5089335c10ba4bd5a4fce',
+  'googletest_revision': '26afdba792e52cac00ce11644c3c0b1789c40bf7',
   're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
   'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
   'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',


### PR DESCRIPTION

https://github.com/google/googletest.git
/compare/af4c2cb098a3..26afdba792e5

git log af4c2cb098a35f4898c5089335c10ba4bd5a4fce..26afdba792e52cac00ce11644c3c0b1789c40bf7 --date=short --no-merges --format=%ad %ae %s
2019-06-12 matthias@matthiaswalter.org Setting CMP0054 policy to NEW. This allows to use the string &#34;SHARED&#34; without interpreting it as a variable.

The AutoRoll server is located here: https://autoroll.skia.org/r/googletest-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

