### PR TITLE
Roll third_party/re2 0c95bcce2f1f..848dfb7e1d7b (2 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -7,7 +7,7 @@ vars = {
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
   'glslang_revision': '9866ad9195cec8f266f16191fb4ec2ce4896e5c0',
   'googletest_revision': '26afdba792e52cac00ce11644c3c0b1789c40bf7',
-  're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
+  're2_revision': '848dfb7e1d7ba641d598cb66f81590f3999a555a',
   'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
   'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',
   'spirv_cross_revision': '00a8539d1ddf8d0d934813e409500af6363c96f1',


### PR DESCRIPTION

https://github.com/google/re2.git
/compare/0c95bcce2f1f..848dfb7e1d7b

git log 0c95bcce2f1f0f071a786ca2c42384b211b8caba..848dfb7e1d7ba641d598cb66f81590f3999a555a --date=short --no-merges --format=%ad %ae %s
2019-06-13 junyer@google.com Don&#39;t let DFA execution bail when slow for RE2::Set.
2019-06-13 junyer@google.com Expose FilteredRE2::GetRE2() as public.

The AutoRoll server is located here: https://autoroll.skia.org/r/re2-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

