### PR TITLE
Roll third_party/spirv-tools 9c0830133b07..9477c91deca9 (3 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,8 +8,8 @@ vars = {
   'glslang_revision': '9866ad9195cec8f266f16191fb4ec2ce4896e5c0',
   'googletest_revision': 'f7c178ecb33c92763fa41d4999db30aaf43a6b30',
   're2_revision': '0c95bcce2f1f0f071a786ca2c42384b211b8caba',
-  'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
-  'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',
+  'spirv_headers_revision': 'e74c389f81915d0a48d6df1af83c3862c5ad85ab',
+  'spirv_tools_revision': '9477c91deca9a16c09194bdc64e6315facb7a031',
   'spirv_cross_revision': '4104e363005a079acc215f0920743a8affb31278',
 }
 


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Tools.git
/compare/9c0830133b07..9477c91deca9

git log 9c0830133b07203a47ddc101fa4b298bab4438d8..9477c91deca9a16c09194bdc64e6315facb7a031 --date=short --no-merges --format=%ad %ae %s
2019-06-14 dneto@google.com Fix uint -&gt; uint32_t in fuzz.cpp (#2675)
2019-06-13 afdx@google.com Add replayer tool for spirv-fuzz. (#2664)
2019-06-13 33432579&#43;alan-baker@users.noreply.github.com Add validation for Subgroup builtins (#2637)
Also rolling transitive DEPS:
  third_party/spirv-headers de99d4d834ae..e74c389f8191


The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-tools-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

