### PR TITLE
Roll third_party/glslang 9866ad9195ce..def9662348b0 (4 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
-  'glslang_revision': '9866ad9195cec8f266f16191fb4ec2ce4896e5c0',
+  'glslang_revision': 'def9662348b029a6578f7fa9f46fde0e605b3a6c',
   'googletest_revision': 'e110929a7b496714c1f6f6be2edcf494a18e5676',
   're2_revision': '848dfb7e1d7ba641d598cb66f81590f3999a555a',
   'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',


### PR DESCRIPTION

https://github.com/KhronosGroup/glslang.git
/compare/9866ad9195ce..def9662348b0

git log 9866ad9195cec8f266f16191fb4ec2ce4896e5c0..def9662348b029a6578f7fa9f46fde0e605b3a6c --date=short --no-merges --format=%ad %ae %s
2019-06-12 siglesias@igalia.com Add missing GL_ARB_shader_ballot builtins to Geometry and Tessellation shaders
2019-06-14 jbolz@nvidia.com Add gl_SemanticsVolatile to GL_KHR_memory_scope_semantics, and make volatile-qualified atomics generate MemorySemanticsVolatile when using the Vulkan memory model
2019-06-13 alanbaker@google.com Update test expectations for new SPIRV-Tools
2019-06-13 alanbaker@google.com Update known good SPIRV-Tools

The AutoRoll server is located here: https://autoroll.skia.org/r/glslang-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

