### PR TITLE
Roll third_party/spirv-cross 4104e363005a..146dc453bcec (2 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ vars = {
   're2_revision': '848dfb7e1d7ba641d598cb66f81590f3999a555a',
   'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
   'spirv_tools_revision': '9c0830133b07203a47ddc101fa4b298bab4438d8',
-  'spirv_cross_revision': '4104e363005a079acc215f0920743a8affb31278',
+  'spirv_cross_revision': '146dc453bcecc2d24721461a2d100e154f41dc76',
 }
 
 deps = {


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Cross.git
/compare/4104e363005a..146dc453bcec

git log 4104e363005a079acc215f0920743a8affb31278..146dc453bcecc2d24721461a2d100e154f41dc76 --date=short --no-merges --format=%ad %ae %s
2019-06-17 post@arntzen-software.no MSL: Conditionally validate MSL 2.2 shaders.
2019-06-14 post@arntzen-software.no MSL: New SDK errors out on cull distance.

The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-cross-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

