### PR TITLE
Roll third_party/spirv-tools 59983a601091..2090d7a2d26c (4 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,8 +8,8 @@ vars = {
   'glslang_revision': 'def9662348b029a6578f7fa9f46fde0e605b3a6c',
   'googletest_revision': '176eccfb8f42339b8ea2341e926f6835f7932bc4',
   're2_revision': '848dfb7e1d7ba641d598cb66f81590f3999a555a',
-  'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
-  'spirv_tools_revision': '59983a601091f1e30fe59f6b2585d9e79ac34a2a',
+  'spirv_headers_revision': 'e74c389f81915d0a48d6df1af83c3862c5ad85ab',
+  'spirv_tools_revision': '2090d7a2d26cb9bb0b8738f36a156ed3084a7ab0',
   'spirv_cross_revision': '4104e363005a079acc215f0920743a8affb31278',
 }
 


### PR DESCRIPTION

https://github.com/KhronosGroup/SPIRV-Tools.git
/compare/59983a601091..2090d7a2d26c

git log 59983a601091f1e30fe59f6b2585d9e79ac34a2a..2090d7a2d26cb9bb0b8738f36a156ed3084a7ab0 --date=short --no-merges --format=%ad %ae %s
2019-06-17 33432579&#43;alan-baker@users.noreply.github.com Handle volatile memory semantics in upgrade (#2674)
2019-06-17 33432579&#43;alan-baker@users.noreply.github.com Validate Volatile memory semantics bit (#2672)
2019-06-17 33432579&#43;alan-baker@users.noreply.github.com Disallow stores to UBOs (#2651)
2019-06-17 dneto@google.com Another fix uint -&gt; uint32_t (#2676)
Also rolling transitive DEPS:
  third_party/spirv-headers de99d4d834ae..e74c389f8191


The AutoRoll server is located here: https://autoroll.skia.org/r/spirv-tools-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

