### PR TITLE
Roll third_party/glslang def9662348b0..9db72785beb3 (1 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
-  'glslang_revision': 'def9662348b029a6578f7fa9f46fde0e605b3a6c',
+  'glslang_revision': '9db72785beb33a89729d801249b23fdda79ae91d',
   'googletest_revision': '176eccfb8f42339b8ea2341e926f6835f7932bc4',
   're2_revision': '848dfb7e1d7ba641d598cb66f81590f3999a555a',
   'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',


### PR DESCRIPTION

https://github.com/KhronosGroup/glslang.git
/compare/def9662348b0..9db72785beb3

git log def9662348b029a6578f7fa9f46fde0e605b3a6c..9db72785beb33a89729d801249b23fdda79ae91d --date=short --no-merges --format=%ad %ae %s
2019-06-17 siglesias@igalia.com Delete duplicated gl_SubGroupSizeARB builtin treatment

The AutoRoll server is located here: https://autoroll.skia.org/r/glslang-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

