### PR TITLE
Roll third_party/glslang 9db72785beb3..d579c0a7d45a (1 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
-  'glslang_revision': '9db72785beb33a89729d801249b23fdda79ae91d',
+  'glslang_revision': 'd579c0a7d45aab62c858b832084f0c9ce2ffee7d',
   'googletest_revision': '176eccfb8f42339b8ea2341e926f6835f7932bc4',
   're2_revision': '848dfb7e1d7ba641d598cb66f81590f3999a555a',
   'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',


### PR DESCRIPTION

https://github.com/KhronosGroup/glslang.git
/compare/9db72785beb3..d579c0a7d45a

git log 9db72785beb33a89729d801249b23fdda79ae91d..d579c0a7d45aab62c858b832084f0c9ce2ffee7d --date=short --no-merges --format=%ad %ae %s
2019-06-17 cepheus@frii.com Bump revision.

The AutoRoll server is located here: https://autoroll.skia.org/r/glslang-shaderc-autoroll

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md

If the roll is causing failures, please contact the current sheriff (radial-bots&#43;shaderc-roll@google.com), and stop
the roller if necessary.

