### PR TITLE
Add -fnan-clamp

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,10 @@
 Revision history for Shaderc
 
 v2019.1-dev 2019-06-04
- - Start v2019.1-dev
+ - Add -fnan-clamp: Generate code for max and min builtins so that,
+   given a NaN operand, will return the other operand. Similarly, the
+   clamp builtin favours non-NaN operands, as if clamp was implemented
+   as the composition of max and min.
 
 v2019.0 2019-06-04
  - Add optional spvc, libshaderc_spvc as wrapper around SPIRV-Cross:

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -77,6 +77,10 @@ Options:
                     several times, only the last setting takes effect.
   -flimit-file <file>
                     Set limits as specified in the given file.
+  -fnan-clamp       Generate code for max and min builtins so that, when given
+                    a NaN operand, the other operand is returned. Similarly,
+                    the clamp builtin will favour the non-NaN operands, as if
+                    clamp were implemented as a composition of max and min.
   -fresource-set-binding [stage] <reg0> <set0> <binding0>
                         [<reg1> <set1> <binding1>...]
                     Explicitly sets the descriptor set and binding for
@@ -299,6 +303,8 @@ int main(int argc, char** argv) {
       compiler.options().SetHlslFunctionality1(true);
     } else if (arg == "-finvert-y") {
       compiler.options().SetInvertY(true);
+    } else if (arg == "-fnan-clamp") {
+      compiler.options().SetNanClamp(true);
     } else if (((u_kind = shaderc_uniform_kind_image),
                 (arg == "-fimage-binding-base")) ||
                ((u_kind = shaderc_uniform_kind_texture),

--- a/glslc/test/option_dash_fnan_clamp.py
+++ b/glslc/test/option_dash_fnan_clamp.py
@@ -1,0 +1,69 @@
+# Copyright 2019 The Shaderc Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import expect
+from glslc_test_framework import inside_glslc_testsuite
+from placeholder import FileShader
+
+# A GLSL shader using the clamp, max, and min builtin functions.
+GLSL_FRAG_SHADER_WITH_CLAMP = """#version 450
+layout(location=0) in vec4 i;
+layout(location=0) out vec4 o;
+void main() {
+  o = clamp(i, vec4(0.5), vec4(1.0))
+  +   max(i, vec4(0.5))
+  +   min(i, vec4(0.5));
+}
+"""
+
+
+@inside_glslc_testsuite('OptionFNanClamp')
+class TestClampMapsToFClampByDefault(expect.ValidAssemblyFileWithSubstr):
+    shader = FileShader(GLSL_FRAG_SHADER_WITH_CLAMP, '.frag')
+    glslc_args = ['-S', shader]
+    expected_assembly_substr = 'OpExtInst %v4float %1 FClamp'
+
+
+@inside_glslc_testsuite('OptionFNanClamp')
+class TestMaxMapsToFMaxByDefault(expect.ValidAssemblyFileWithSubstr):
+    shader = FileShader(GLSL_FRAG_SHADER_WITH_CLAMP, '.frag')
+    glslc_args = ['-S', shader]
+    expected_assembly_substr = 'OpExtInst %v4float %1 FMax'
+
+
+@inside_glslc_testsuite('OptionFNanClamp')
+class TestMinMapsToFMinByDefault(expect.ValidAssemblyFileWithSubstr):
+    shader = FileShader(GLSL_FRAG_SHADER_WITH_CLAMP, '.frag')
+    glslc_args = ['-S', shader]
+    expected_assembly_substr = 'OpExtInst %v4float %1 FMin'
+
+
+@inside_glslc_testsuite('OptionFNanClamp')
+class TestClampMapsToNClampWithFlag(expect.ValidAssemblyFileWithSubstr):
+    shader = FileShader(GLSL_FRAG_SHADER_WITH_CLAMP, '.frag')
+    glslc_args = ['-S', '-fnan-clamp', shader]
+    expected_assembly_substr = 'OpExtInst %v4float %1 NClamp'
+
+@inside_glslc_testsuite('OptionFNanClamp')
+class TestMaxMapsToNMaxWithFlag(expect.ValidAssemblyFileWithSubstr):
+    shader = FileShader(GLSL_FRAG_SHADER_WITH_CLAMP, '.frag')
+    glslc_args = ['-S', '-fnan-clamp', shader]
+    expected_assembly_substr = 'OpExtInst %v4float %1 NMax'
+
+
+@inside_glslc_testsuite('OptionFNanClamp')
+class TestMinMapsToNMinWithFlag(expect.ValidAssemblyFileWithSubstr):
+    shader = FileShader(GLSL_FRAG_SHADER_WITH_CLAMP, '.frag')
+    glslc_args = ['-S', '-fnan-clamp', shader]
+    expected_assembly_substr = 'OpExtInst %v4float %1 NMin'

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -82,6 +82,10 @@ Options:
                     several times, only the last setting takes effect.
   -flimit-file <file>
                     Set limits as specified in the given file.
+  -fnan-clamp       Generate code for max and min builtins so that, when given
+                    a NaN operand, the other operand is returned. Similarly,
+                    the clamp builtin will favour the non-NaN operands, as if
+                    clamp were implemented as a composition of max and min.
   -fresource-set-binding [stage] <reg0> <set0> <binding0>
                         [<reg1> <set1> <binding1>...]
                     Explicitly sets the descriptor set and binding for

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -454,6 +454,13 @@ SHADERC_EXPORT void shaderc_compile_options_set_hlsl_functionality1(
 SHADERC_EXPORT void shaderc_compile_options_set_invert_y(
     shaderc_compile_options_t options, bool enable);
 
+// Sets whether the compiler generates code for max and min builtins which,
+// if given a NaN operand, will return the other operand. Similarly, the clamp
+// builtin will favour the non-NaN operands, as if clamp were implemented
+// as a composition of max and min.
+SHADERC_EXPORT void shaderc_compile_options_set_nan_clamp(
+    shaderc_compile_options_t options, bool enable);
+
 // An opaque handle to the results of a call to any shaderc_compile_into_*()
 // function.
 typedef struct shaderc_compilation_result* shaderc_compilation_result_t;

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -331,6 +331,14 @@ class CompileOptions {
     shaderc_compile_options_set_invert_y(options_, enable);
   }
 
+  // Sets whether the compiler should generates code for max an min which,
+  // if given a NaN operand, will return the other operand. Similarly, the
+  // clamp builtin will favour the non-NaN operands, as if clamp were
+  // implemented as a composition of max and min.
+  void SetNanClamp(bool enable) {
+    shaderc_compile_options_set_nan_clamp(options_, enable);
+  }
+
  private:
   CompileOptions& operator=(const CompileOptions& other) = delete;
   shaderc_compile_options_t options_;

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -400,6 +400,13 @@ const char kHlslMemLayoutResourceSelect[] =
          return Tex.Sample(samp, float2(0.5, 0.5)) + float4(a, b);
        })";
 
+const char kGlslShaderWithClamp[] =
+    R"(#version 450
+    layout(location=0) in vec4 i;
+    layout(location=0) out vec4 o;
+    void main() { o = clamp(i, vec4(0.5), vec4(1.0)); }
+    )";
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -543,6 +543,11 @@ void shaderc_compile_options_set_invert_y(
   options->compiler.EnableInvertY(enable);
 }
 
+void shaderc_compile_options_set_nan_clamp(shaderc_compile_options_t options,
+                                           bool enable) {
+  options->compiler.SetNanClamp(enable);
+}
+
 shaderc_compiler_t shaderc_compiler_initialize() {
   static shaderc_util::GlslangInitializer* initializer =
       new shaderc_util::GlslangInitializer;

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -1437,4 +1437,28 @@ TEST_F(CppInterface, HlslFunctionality1SurvivesCloning) {
   EXPECT_THAT(disassembly_text, HasSubstr("OpDecorateString"));
 }
 
+TEST_F(CppInterface, NanClampDefaultsOff) {
+  CompileOptions options;
+  const std::string disassembly_text = AssemblyOutput(
+      kGlslShaderWithClamp, shaderc_glsl_fragment_shader, options);
+  EXPECT_THAT(disassembly_text, HasSubstr("OpExtInst %v4float %1 FClamp"));
+}
+
+TEST_F(CppInterface, NanClampMapsClampToNClamp) {
+  CompileOptions options;
+  options.SetNanClamp(true);
+  const std::string disassembly_text = AssemblyOutput(
+      kGlslShaderWithClamp, shaderc_glsl_fragment_shader, options);
+  EXPECT_THAT(disassembly_text, HasSubstr("OpExtInst %v4float %1 NClamp"));
+}
+
+TEST_F(CppInterface, NanClampSurvivesCloning) {
+  CompileOptions options;
+  options.SetNanClamp(true);
+  CompileOptions cloned_options(options);
+  const std::string disassembly_text = AssemblyOutput(
+      kGlslShaderWithClamp, shaderc_glsl_fragment_shader, cloned_options);
+  EXPECT_THAT(disassembly_text, HasSubstr("OpExtInst %v4float %1 NClamp"));
+}
+
 }  // anonymous namespace

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -232,6 +232,7 @@ class Compiler {
         hlsl_legalization_enabled_(true),
         hlsl_functionality1_enabled_(false),
         invert_y_enabled_(false),
+        nan_clamp_(false),
         hlsl_explicit_bindings_() {}
 
   // Requests that the compiler place debug information into the object code,
@@ -250,6 +251,12 @@ class Compiler {
 
   // Enables or disables invert position.Y output in vertex shader.
   void EnableInvertY(bool enable);
+
+  // Sets whether the compiler generates code for max and min builtins which,
+  // if given a NaN operand, will return the other operand.  Also, the clamp
+  // builtin will favour the non-NaN operands, as if clamp were implemented
+  // as a composition of max and min.
+  void SetNanClamp(bool enable);
 
   // When a warning is encountered it treat it as an error.
   void SetWarningsAsErrors();
@@ -524,6 +531,12 @@ class Compiler {
 
   // True if the compiler should invert position.Y output in vertex shader.
   bool invert_y_enabled_;
+
+  // True if the compiler generates code for max and min builtins which,
+  // if given a NaN operand, will return the other operand.  Also, the clamp
+  // builtin will favour the non-NaN operands, as if clamp were implemented
+  // as a composition of max and min.
+  bool nan_clamp_;
 
   // A sequence of triples, each triple representing a specific HLSL register
   // name, and the set and binding numbers it should be mapped to, but in

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -302,6 +302,7 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
     shader.setEnvTargetHlslFunctionality1();
   }
   shader.setInvertY(invert_y_enabled_);
+  shader.setNanMinMaxClamp(nan_clamp_);
 
   const EShMessages rules = GetMessageRules(target_env_, source_language_,
                                             hlsl_offsets_,
@@ -454,6 +455,8 @@ void Compiler::EnableInvertY(bool enable) {
   invert_y_enabled_ = enable;
 }
 
+void Compiler::SetNanClamp(bool enable) { nan_clamp_ = enable; }
+
 void Compiler::SetSuppressWarnings() { suppress_warnings_ = true; }
 
 std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
@@ -487,6 +490,7 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
     shader.setEnvTargetHlslFunctionality1();
   }
   shader.setInvertY(invert_y_enabled_);
+  shader.setNanMinMaxClamp(nan_clamp_);
 
   // The preprocessor might be sensitive to the target environment.
   // So combine the existing rules with the just-give-me-preprocessor-output


### PR DESCRIPTION
Tells the compiler to generate code for max and min builtins so that
when given a NaN operand, the builtin returns the other operand.
Similarly, the clamp builtin will favour the non-NaN operands, as
if clamp were implemented as a composition of max and min.