### PR TITLE
Rolling 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
-  'glslang_revision': '9db72785beb33a89729d801249b23fdda79ae91d',
-  'googletest_revision': '176eccfb8f42339b8ea2341e926f6835f7932bc4',
+  'glslang_revision': 'f9d08a25fbe17e0677a89d398f4d7f232339c3f9',
+  'googletest_revision': 'ee32b72e12048c14868012a8f339202f82f1ef7d',
   're2_revision': '848dfb7e1d7ba641d598cb66f81590f3999a555a',
   'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
-  'spirv_tools_revision': '59983a601091f1e30fe59f6b2585d9e79ac34a2a',
-  'spirv_cross_revision': '146dc453bcecc2d24721461a2d100e154f41dc76',
+  'spirv_tools_revision': '001e823b65345145bcaaeb94d39290b10f8661b3',
+  'spirv_cross_revision': '05ea055096df8b7b8b3e3f7e121279acf83f74c0',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ 9db72785b..f9d08a25f (6 commits)

https://github.com/KhronosGroup/glslang/compare/9db72785beb3...f9d08a25fbe1

$ git log 9db72785b..f9d08a25f --date=short --no-merges --format='%ad %ae %s'
2019-06-18 cepheus Bump revision.
2019-06-17 cepheus AST/SPV: Fix #930: translate uvec4 <-> uint64 for SubgroupGeMask et. al.
2019-06-18 cepheus Bump revision.
2019-06-17 cepheus SPV: Add a switch for favoring non-NaN operands in min, max, and clamp.
2019-06-17 cepheus Bump revision.
2019-02-17 jbolz Add Float16/Int8/Int16 capabilities for private variables and function parameters

Roll third_party/googletest/ 176eccfb8..ee32b72e1 (12 commits)

https://github.com/google/googletest/compare/176eccfb8f42...ee32b72e1204

$ git log 176eccfb8..ee32b72e1 --date=short --no-merges --format='%ad %ae %s'
2019-06-18 misterg Googletest export
2019-06-17 misterg Googletest export
2019-06-17 misterg Fixing CI break by going to bazel 0.26.1
2019-06-17 misterg Revert "testing, explicitly specify compiler"
2019-06-17 absl-team Googletest export
2019-06-17 misterg Googletest export
2019-06-17 misterg revert travis.yml, irrelevant
2019-06-17 misterg bazel 0.26.1
2019-06-17 misterg bazel 0.26.1
2019-06-17 misterg testing with bazel 0.26.1
2019-06-17 misterg testing with bazel 0.26.1
2019-06-17 misterg testing, explicitly specify compiler

Roll third_party/spirv-cross/ 146dc453b..05ea05509 (2 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/146dc453bcec...05ea055096df

$ git log 146dc453b..05ea05509 --date=short --no-merges --format='%ad %ae %s'
2019-06-18 post Make sure args.msl22 is set in test_shaders.py.
2019-06-18 post MSL: Fix path check in test_shaders.py.

Roll third_party/spirv-tools/ 59983a601..001e823b6 (5 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/59983a601091...001e823b6534

$ git log 59983a601..001e823b6 --date=short --no-merges --format='%ad %ae %s'
2019-06-18 afdx Add fuzzer pass to obfuscate constants. (#2671)
2019-06-17 33432579+alan-baker Handle volatile memory semantics in upgrade (#2674)
2019-06-17 33432579+alan-baker Validate Volatile memory semantics bit (#2672)
2019-06-17 33432579+alan-baker Disallow stores to UBOs (#2651)
2019-06-17 dneto Another fix uint -> uint32_t (#2676)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools