### PR TITLE
Extract common test environment bits out into a class

### DIFF
--- a/spvc/test/CMakeLists.txt
+++ b/spvc/test/CMakeLists.txt
@@ -2,9 +2,6 @@ if(${SHADERC_ENABLE_TESTS})
   add_test(NAME spvc_spirv_cross_tests
     COMMAND ${PYTHON_EXECUTABLE}
     ${CMAKE_CURRENT_SOURCE_DIR}/run_spirv_cross_tests.py
-    $<TARGET_FILE:spvc_exe>
-    $<TARGET_FILE:spirv-as>
-    $<TARGET_FILE:spirv-opt>
-    $<TARGET_FILE:glslangValidator>
+    ${CMAKE_BINARY_DIR}
     ${SHADERC_SPIRV_CROSS_DIR})
 endif()

--- a/spvc/test/CMakeLists.txt
+++ b/spvc/test/CMakeLists.txt
@@ -2,6 +2,9 @@ if(${SHADERC_ENABLE_TESTS})
   add_test(NAME spvc_spirv_cross_tests
     COMMAND ${PYTHON_EXECUTABLE}
     ${CMAKE_CURRENT_SOURCE_DIR}/run_spirv_cross_tests.py
-    ${CMAKE_BINARY_DIR}
+    $<TARGET_FILE:spvc_exe>
+    $<TARGET_FILE:spirv-as>
+    $<TARGET_FILE:spirv-opt>
+    $<TARGET_FILE:glslangValidator>
     ${SHADERC_SPIRV_CROSS_DIR})
 endif()

--- a/spvc/test/run_spirv_cross_tests.py
+++ b/spvc/test/run_spirv_cross_tests.py
@@ -25,114 +25,170 @@ import sys
 import tempfile
 
 
-def log_unexpected_successes(script_args, successes):
-    if not len(successes):
-        log_string = 'Encountered 0 unexpected successes'
-    else:
-        log_string = 'Encountered {} unexpected success(es):\n'.format(
-            len(successes))
-        successes = ['\t{}'.format(success) for success in successes]
-        log_string += '\n'.join(successes)
+class TestEnv:
+    """Container for cross-test environmental data and operations."""
 
-    if script_args.log:
-        script_args.log.write(log_string + '\n')
-        script_args.log.flush()
-    else:
+    def __init__(self, script_args):
+        """Takes in the output of ArgumentParser.parse_args()"""
+        # TODO(bug 737): Add new log data structure.
+        self.dry_run = script_args.dry_run
+        self.give_up = script_args.give_up
+        self.cross_dir = script_args.cross_dir
+        self.spvc = os.path.join(script_args.build_dir, 'spvc', 'spvc')
+        self.glslang = os.path.join(
+            script_args.build_dir, 'third_party', 'glslang', 'StandAlone', 'glslangValidator')
+        spirv_tools_dir = os.path.join(
+            script_args.build_dir, 'third_party', 'spirv-tools', 'tools')
+
+        self.spirv_as = os.path.join(spirv_tools_dir, 'spirv-as')
+        self.spirv_opt = os.path.join(spirv_tools_dir, 'spirv-opt')
+
+    def log_unexpected_successes(self, successes):
+        """Log list of unexpected test case successes."""
+        if not len(successes):
+            log_string = 'Encountered 0 unexpected successes'
+        else:
+            log_string = 'Encountered {} unexpected success(es):\n'.format(
+                len(successes))
+            successes = ['\t{}'.format(success) for success in successes]
+            log_string += '\n'.join(successes)
+
+        # TODO(but 737): Re-enable after fixing log support
+        # if test_env.log:
+        #     test_env.log.write(log_string + '\n')
+        #     test_env.log.flush()
+        # else:
         print(log_string)
 
+    def log_unexpected_failures(self, failures):
+        """Log list of unexpected test case failures."""
+        if not len(failures):
+            log_string = 'Encountered 0 unexpected failures'
+        else:
+            log_string = 'Encountered {} unexpected failures(s):\n'.format(
+                len(failures))
+            failures = ['\t{}'.format(failure) for failure in failures]
+            log_string += '\n'.join(failures)
 
-def log_unexpected_failures(script_args, failures):
-    if not len(failures):
-        log_string = 'Encountered 0 unexpected failures'
-    else:
-        log_string = 'Encountered {} unexpected failures(s):\n'.format(
-            len(failures))
-        failures = ['\t{}'.format(failure) for failure in failures]
-        log_string += '\n'.join(failures)
-
-    if script_args.log:
-        script_args.log.write(log_string + '\n')
-        script_args.log.flush()
-    else:
+        # TODO(but 737): Re-enable after fixing log support
+        # if test_env.log:
+        #     test_env.log.write(log_string + '\n')
+        #     test_env.log.flush()
+        # else:
         print(log_string)
 
-
-def log_failure(script_args, shader, optimize):
-    log_string = 'FAILED {}, optimize = {}'.format(shader, optimize)
-    if script_args.log:
-        script_args.log.write(log_string + '\n')
-        script_args.log.flush()
-    else:
+    def log_failure(self, shader, optimize):
+        """Log a test case failure."""
+        log_string = 'FAILED {}, optimize = {}'.format(shader, optimize)
+        # TODO(but 737): Re-enable after fixing log support
+        # if test_env.log:
+        #     test_env.log.write(log_string + '\n')
+        #     test_env.log.flush()
+        # else:
         print(log_string)
 
+    def log_command(self, cmd):
+        """Log calling a command."""
+        # TODO(but 737): Re-enable after fixing log support
+        # if test_env.log:
+        #     # make sure it's all strings
+        #     cmd = [str(x) for x in cmd]
+        #     # first item is the command path, keep only last component
+        #     cmd[0] = os.path.basename(cmd[0])
+        #     # if last item is a path in SPIRV-Cross dir, trim that dir
+        #     if cmd[-1].startswith(test_env.cross_dir):
+        #         cmd[-1] = cmd[-1][len(test_env.cross_dir) + 1:]
+        #     log_string = ''.join(cmd) + '\n'
+        #     print(log_string)
+        #     test_env.log.write(log_string)
+        #     test_env.log.flush()
+        pass
 
-def log_command(script_args, cmd):
-    if script_args.log:
-        # make sure it's all strings
-        cmd = [str(x) for x in cmd]
-        # first item is the command path, keep only last component
-        cmd[0] = os.path.basename(cmd[0])
-        # if last item is a path in SPIRV-Cross dir, trim that dir
-        if cmd[-1].startswith(script_args.cross_dir):
-            cmd[-1] = cmd[-1][len(script_args.cross_dir) + 1:]
-        script_args.log.write(''.join(cmd) + '\n')
-        script_args.log.flush()
+    def check_call(self, cmd):
+        """Quietly run a command.
+
+        Throw exception on failure.
+        """
+        self.log_command(cmd)
+        if not self.dry_run:
+            subprocess.check_call(cmd, stdout=subprocess.DEVNULL)
+
+    def run_spirv_as(self, inp, out, flags):
+        """Run spirv-as.
+
+        Throw exception on failure.
+        """
+        self.check_call([self.spirv_as] + flags + ['-o', out, inp])
+
+    def run_spirv_opt(self, inp, out, flags):
+        """Run spirv-opt.
+
+        Throw exception on failure.
+        """
+        self.check_call([self.spirv_opt] + flags +
+                        ['--skip-validation', '-O', '-o', out, inp])
+
+    def run_glslang_compile(self, inp, out, flags):
+        """Run glslangValidator as a compiler.
+
+        Throw exception on failure.
+        """
+        self.check_call([self.glslang] + flags + ['-o', out, inp])
+
+    def run_spvc(self, inp, out, flags):
+        """Run spvc, return 'out' on success, None on failure."""
+        cmd = [self.spvc] + flags + ['-o', out,
+                                     '--source-env=vulkan1.1', '--target-env=vulkan1.1', inp]
+        self.log_command(cmd)
+        if self.dry_run or subprocess.call(cmd, stdout=subprocess.DEVNULL) == 0:
+            return out
+        if self.give_up:
+            sys.exit()
+
+    def check_reference(self, result, shader, optimize):
+        """Compare result file to reference file and count matches.
+
+        Returns the result of the comparison and the reference file
+        being used.  Exits if |give_up| set on failure.
+        """
+        if optimize:
+            reference = os.path.join('reference', 'opt', shader)
+        else:
+            reference = os.path.join('reference', shader)
+        self.log_command(['reference', reference])
+        if self.dry_run or filecmp.cmp(
+                result, os.path.join(self.cross_dir, reference), False):
+            return True, reference
+        elif self.give_up:
+            sys.exit()
+        return False, reference
+
+    def compile_input_shader(self, shader, filename, optimize):
+        """Prepare Vulkan binary for input to spvc.
+
+        The test input is either:
+            - Vulkan text, assembled with spirv-as
+            - GLSL, converted with glslang
+        Optionally pass through spirv-opt.
+        Returns the temp file that the shader was compiled to.
+        """
+        _, tmpfile = tempfile.mkstemp()
+        shader_path = os.path.join(self.cross_dir, shader)
+        if '.asm.' in filename:
+            flags = ['--target-env', 'vulkan1.1']
+            if '.preserve.' in filename:
+                flags.append('--preserve-numeric-ids')
+            self.run_spirv_as(shader_path, tmpfile, flags)
+        else:
+            self.run_glslang_compile(shader_path, tmpfile, [
+                '--target-env', 'vulkan1.1', '-V'])
+        if optimize:
+            self.run_spirv_opt(tmpfile, tmpfile, [])
+        return tmpfile
 
 
-# Quietly run a command.  Throw exception on failure.
-def check_call(script_args, cmd):
-    log_command(script_args, cmd)
-    if not script_args.dry_run:
-        subprocess.check_call(cmd, stdout=subprocess.DEVNULL)
-
-
-# Run spirv-as.  Throw exception on failure.
-def spirv_as(script_args, inp, out, flags):
-    check_call(script_args, [script_args.spirv_as] + flags + ['-o', out, inp])
-
-
-# Run spirv-opt.  Throw exception on failure.
-def spirv_opt(script_args, inp, out, flags):
-    check_call(script_args, [script_args.spirv_opt] +
-               flags + ['--skip-validation', '-O', '-o', out, inp])
-
-
-# Run glslangValidator as a compiler.  Throw exception on failure.
-def glslang_compile(script_args, inp, out, flags):
-    check_call(script_args, [script_args.glslang] + flags + ['-o', out, inp])
-
-
-# Run spvc, return 'out' on success, None on failure.
-def spvc(script_args, inp, out, flags):
-    cmd = [script_args.spvc] + flags + ['-o', out,
-                                        '--source-env=vulkan1.1', '--target-env=vulkan1.1', inp]
-    log_command(script_args, cmd)
-    if script_args.dry_run or subprocess.call(
-            cmd, stdout=subprocess.DEVNULL) == 0:
-        return out
-    if script_args.give_up:
-        sys.exit()
-
-
-# Compare result file to reference file and count matches. Returns the result of
-# the comparison and the reference file being used. Exits if |give_up| set on
-# failure.
-def check_reference(script_args, result, shader, optimize):
-    if optimize:
-        reference = os.path.join('reference', 'opt', shader)
-    else:
-        reference = os.path.join('reference', shader)
-    log_command(script_args, ['reference', reference])
-    if script_args.dry_run or filecmp.cmp(
-            result, os.path.join(script_args.cross_dir, reference), False):
-        return True, reference
-    elif script_args.give_up:
-        sys.exit()
-    return False, reference
-
-
-# Remove files and be quiet if they don't exist or can't be removed.
 def remove_files(*filenames):
+    """Remove files and be quiet if they don't exist or can't be removed."""
     for i in filenames:
         try:
             os.remove(i)
@@ -140,37 +196,18 @@ def remove_files(*filenames):
             pass
 
 
-# Prepare Vulkan binary for input to spvc.  The test input is either:
-# - Vulkan text, assembled with spirv-as
-# - GLSL, converted with glslang
-# Optionally pass through spirv-opt.
-# Returns the temp file that the shader was compiled to.
-def compile_input_shader(script_args, shader, filename, optimize):
-    _, tmpfile = tempfile.mkstemp()
-    shader_path = os.path.join(script_args.cross_dir, shader)
-    if '.asm.' in filename:
-        flags = ['--target-env', 'vulkan1.1']
-        if '.preserve.' in filename:
-            flags.append('--preserve-numeric-ids')
-        spirv_as(script_args, shader_path, tmpfile, flags)
-    else:
-        glslang_compile(script_args, shader_path, tmpfile, [
-                        '--target-env', 'vulkan1.1', '-V'])
-    if optimize:
-        spirv_opt(script_args, tmpfile, tmpfile, [])
-    return tmpfile
+def test_glsl(test_env, shader, filename, optimize):
+    """Test spvc producing GLSL the same way SPIRV-Cross is tested.
 
+    There are three steps: compile input, convert to GLSL, check result.
 
-# Test spvc producing GLSL the same way SPIRV-Cross is tested.
-# There are three steps: compile input, convert to GLSL, check result.
-# Returns a list of successful tests and a list of failed tests.
-def test_glsl(script_args, shader, filename, optimize):
-    input = compile_input_shader(script_args, shader, filename,
-                                 optimize and not '.noopt.' in filename and not '.invalid.' in filename)
+    Returns a list of successful tests and a list of failed tests.
+    """
+    input = test_env.compile_input_shader(
+        shader, filename, optimize and not '.noopt.' in filename and not '.invalid.' in filename)
     if not '.invalid.' in filename:
         # logged for compatibility with SPIRV-Cross test script
-        log_command(script_args, ['spirv-val',
-                                  '--target-env', 'vulkan1.1', input])
+        test_env.log_command(['spirv-val', '--target-env', 'vulkan1.1', input])
 
     successes = []
     failures = []
@@ -193,53 +230,55 @@ def test_glsl(script_args, shader, filename, optimize):
 
     output = None
     if not '.nocompat.' in filename:
-        output = spvc(script_args, input, input + filename, flags)
+        output = test_env.run_spvc(input, input + filename, flags)
         # logged for compatibility with SPIRV-Cross test script
-        log_command(script_args, [script_args.glslang, output])
+        test_env.log_command([test_env.glslang, output])
 
     output_vk = None
     if '.vk.' in filename:
-        output_vk = spvc(script_args, input, input + 'vk' +
-                         filename, flags + ['--vulkan-semantics'])
+        output_vk = test_env.run_spvc(input, input + 'vk' +
+                                      filename, flags + ['--vulkan-semantics'])
         # logged for compatibility with SPIRV-Cross test script
-        log_command(script_args, [script_args.glslang,
-                                  '--target-env', 'vulkan1.1', '-V', output_vk])
+        test_env.log_command(
+            [test_env.glslang, '--target-env', 'vulkan1.1', '-V', output_vk])
 
     # Check result(s).
     # Compare either or both files produced above to appropriate reference
     # file.
     if not '.nocompat.' in filename:
         if output:
-            result, _ = check_reference(script_args, output, shader, optimize)
+            result, _ = test_env.check_reference(output, shader, optimize)
             if result:
                 successes.append((shader, optimize))
             else:
                 failures.append((shader, optimize))
-                log_failure(script_args, shader, optimize)
+                test_env.log_failure(shader, optimize)
         else:
             failures.append((shader, optimize))
-            log_failure(script_args, shader, optimize)
+            test_env.log_failure(shader, optimize)
 
     if '.vk.' in filename:
         if output_vk:
-            result, _ = check_reference(
-                script_args, output_vk, shader + '.vk', optimize)
+            result, _ = test_env.check_reference(
+                output_vk, shader + '.vk', optimize)
             if result:
                 successes.append((shader + '.vk', optimize))
             else:
                 failures.append((shader + '.vk', optimize))
-                log_failure(script_args, shader + '.vk', optimize)
+                test_env.log_failure(shader + '.vk', optimize)
         else:
             failures.append((shader + '.vk', optimize))
-            log_failure(script_args, shader + '.vk', optimize)
+            test_env.log_failure(shader + '.vk', optimize)
 
     remove_files(input, output, output_vk)
     return successes, failures
 
 
-# Search first column of 'table' to return item from second column.
-# The last item will be returned if nothing earlier matches.
 def lookup(table, filename):
+    """Search first column of 'table' to return item from second column.
+
+    The last item will be returned if nothing earlier matches.
+    """
     for needle, haystack in zip(table[0::2], table[1::2]):
         if '.' + needle + '.' in filename:
             break
@@ -273,12 +312,15 @@ msl_standards_macos = (
 )
 
 
-# Test spvc producing MSL the same way SPIRV-Cross is tested.
-# There are three steps: compile input, convert to HLSL, check result.
-# Returns a list of successful tests and a list of failed tests.
-def test_msl(script_args, shader, filename, optimize):
-    input = compile_input_shader(
-        script_args, shader, filename, optimize and not '.noopt.' in filename)
+def test_msl(test_env, shader, filename, optimize):
+    """Test spvc producing MSL the same way SPIRV-Cross is tested.
+
+    There are three steps: compile input, convert to HLSL, check result.
+
+    Returns a list of successful tests and a list of failed tests.
+    """
+    input = test_env.compile_input_shader(
+        shader, filename, optimize and not '.noopt.' in filename)
 
     successes = []
     failures = []
@@ -301,78 +343,80 @@ def test_msl(script_args, shader, filename, optimize):
         flags.append('--msl-discrete-descriptor-set=2')
         flags.append('--msl-discrete-descriptor-set=3')
 
-    output = spvc(script_args, input, input + filename, flags)
+    output = test_env.run_spvc(input, input + filename, flags)
     if not '.invalid.' in filename:
         # logged for compatibility with SPIRV-Cross test script
-        log_command(script_args, ['spirv-val',
-                                  '--target-env', 'vulkan1.1', input])
+        test_env.log_command(['spirv-val', '--target-env', 'vulkan1.1', input])
 
     # Check result.
     if output:
-        result, reference = check_reference(
-            script_args, output, shader, optimize)
+        result, reference = test_env.check_reference(output, shader, optimize)
         if result:
             successes.append((shader, optimize))
         else:
             failures.append((shader, optimize))
-            log_failure(script_args, shader, optimize)
+            test_env.log_failure(shader, optimize)
         # logged for compatibility with SPIRV-Cross test script
-        log_command(script_args, ['xcrun', '--sdk',
-                                  'iphoneos' if '.ios.' in filename else 'macosx',
-                                  'metal', '-x', 'metal',
-                                  lookup(
-                                      msl_standards_ios if '.ios.' in filename else msl_standards_macos,
-                                      filename),
-                                  '-Werror', '-Wno-unused-variable',
-                                  reference])
+        test_env.log_command(['xcrun', '--sdk',
+                              'iphoneos' if '.ios.' in filename else 'macosx',
+                              'metal', '-x', 'metal',
+                              lookup(
+                                  msl_standards_ios if '.ios.' in filename else msl_standards_macos,
+                                  filename),
+                              '-Werror', '-Wno-unused-variable',
+                              reference])
     else:
         failures.append((shader, optimize))
-        log_failure(script_args, shader, optimize)
+        test_env.log_failure(shader, optimize)
 
     remove_files(input, output)
     return successes, failures
 
 
-# Test spvc producing HLSL the same way SPIRV-Cross is tested.
-# There are three steps: compile input, convert to HLSL, check result.
-# Returns a list of successful tests and a list of failed tests.
-def test_hlsl(script_args, shader, filename, optimize):
-    input = compile_input_shader(
-        script_args, shader, filename, optimize and not '.noopt.' in filename)
+def test_hlsl(test_env, shader, filename, optimize):
+    """Test spvc producing HLSL the same way SPIRV-Cross is tested.
+
+    There are three steps: compile input, convert to HLSL, check result.
+
+    Returns a list of successful tests and a list of failed tests.
+    """
+    input = test_env.compile_input_shader(
+        shader, filename, optimize and not '.noopt.' in filename)
 
     successes = []
     failures = []
     # Run spvc to convert Vulkan to HLSL.
-    output = spvc(script_args, input, input + filename,
-                  ['--entry=main', '--language=hlsl', '--hlsl-enable-compat', '--shader-model=' + lookup(shader_models, filename)])
+    output = test_env.run_spvc(input, input + filename, ['--entry=main', '--language=hlsl',
+                                                         '--hlsl-enable-compat', '--shader-model=' + lookup(shader_models, filename)])
     if not '.invalid.' in filename:
         # logged for compatibility with SPIRV-Cross test script
-        log_command(script_args, ['spirv-val',
-                                  '--target-env', 'vulkan1.1', input])
+        test_env.log_command(['spirv-val', '--target-env', 'vulkan1.1', input])
 
     if output:
         # logged for compatibility with SPIRV-Cross test script
-        log_command(script_args, [script_args.glslang, '-e', 'main',
-                                  '-D', '--target-env', 'vulkan1.1', '-V', output])
+        test_env.log_command([test_env.glslang, '-e', 'main',
+                              '-D', '--target-env', 'vulkan1.1', '-V', output])
         # TODO(bug 649): Log dxc run here
-        result, _ = check_reference(script_args, output, shader, optimize)
+        result, _ = test_env.check_reference(output, shader, optimize)
         if result:
             successes.append((shader, optimize))
         else:
             failures.append((shader, optimize))
-            log_failure(script_args, shader, optimize)
+            test_env.log_failure(shader, optimize)
     else:
         failures.append((shader, optimize))
-        log_failure(script_args, shader, optimize)
+        test_env.log_failure(shader, optimize)
 
     remove_files(input, output)
     return successes, failures
 
 
-# Currently a no-op test. Needs to be implemented. Currently returns a tuple
-# indicating the passed in test has failed.
-def test_reflection(script_args, shader, filename, optimize):
-    log_failure(script_args, shader, optimize)
+def test_reflection(test_env, shader, filename, optimize):
+    """Currently a no-op test. Needs to be implemented.
+
+    Returns a tuple indicating the passed in test has failed.
+    """
+    test_env.log_failure(shader, optimize)
     return [], [(shader, optimize)]
     # TODO(bug 650): Implement this test
 
@@ -393,6 +437,7 @@ test_case_dirs = (
 )
 
 
+# TODO(bug 737): Replace this with the new multiprocessing safe infra.
 class FileArgAction(argparse.Action):
     def __call__(self, parser, namespace, value, option):
         if value == '-':
@@ -407,14 +452,16 @@ class FileArgAction(argparse.Action):
 
 
 def work_function(work_args):
-    (test_function, script_args, shader, filename, optimize) = work_args
-    return test_function(script_args, shader, filename, optimize)
+    """"Unpacks the test case args and invokes the appropriate in test
+    function."""
+    (test_function, test_env, shader, filename, optimize) = work_args
+    return test_function(test_env, shader, filename, optimize)
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--log', action=FileArgAction,
-                        help='log commands to file')
+                        help='log commands to file. Currently broken, see issue #737 for status..')
     parser.add_argument('-n', '--dry-run', dest='dry_run', action='store_true',
                         help='do not execute commands')
     parser.add_argument('-g', '--give-up', dest='give_up', action='store_true',
@@ -422,12 +469,12 @@ def main():
     parser.add_argument('-f', '--test-filter', dest='test_filter',
                         action='store', metavar='<test filter regex>',
                         help='only run tests that contain given regex string')
-    parser.add_argument('spvc', metavar='<spvc executable>')
-    parser.add_argument('spirv_as', metavar='<spirv-as executable>')
-    parser.add_argument('spirv_opt', metavar='<spirv-opt executable>')
-    parser.add_argument('glslang', metavar='<glslangValidator executable>')
-    parser.add_argument('cross_dir', metavar='<SPIRV-cross directory>')
+    parser.add_argument('build_dir', metavar='<build dir directory>')
+    parser.add_argument(
+        'cross_dir', metavar='<SPIRV-cross directory, where tests are located>')
     script_args = parser.parse_args()
+
+    test_env = TestEnv(script_args)
 
     test_regex = None
     if script_args.test_filter:
@@ -443,7 +490,7 @@ def main():
             for filename in sorted(filenames):
                 shader = os.path.join(reldir, filename)
                 if not test_regex or re.search(test_regex, shader):
-                    tests.append((test_function, script_args,
+                    tests.append((test_function, test_env,
                                   shader, filename, optimize))
 
     pool = Pool()
@@ -480,8 +527,8 @@ def main():
         if failure not in known_failures:
             unexpected_failures.append(failure)
 
-    log_unexpected_successes(script_args, unexpected_successes)
-    log_unexpected_failures(script_args, unexpected_failures)
+    test_env.log_unexpected_successes(unexpected_successes)
+    test_env.log_unexpected_failures(unexpected_failures)
 
     if script_args.log is not None and script_args.log is not sys.stdout:
         script_args.log.close()

--- a/spvc/test/run_spirv_cross_tests.py
+++ b/spvc/test/run_spirv_cross_tests.py
@@ -34,14 +34,10 @@ class TestEnv:
         self.dry_run = script_args.dry_run
         self.give_up = script_args.give_up
         self.cross_dir = script_args.cross_dir
-        self.spvc = os.path.join(script_args.build_dir, 'spvc', 'spvc')
-        self.glslang = os.path.join(
-            script_args.build_dir, 'third_party', 'glslang', 'StandAlone', 'glslangValidator')
-        spirv_tools_dir = os.path.join(
-            script_args.build_dir, 'third_party', 'spirv-tools', 'tools')
-
-        self.spirv_as = os.path.join(spirv_tools_dir, 'spirv-as')
-        self.spirv_opt = os.path.join(spirv_tools_dir, 'spirv-opt')
+        self.spvc = script_args.spvc
+        self.spirv_as = script_args.spirv_as
+        self.spirv_opt = script_args.spirv_opt
+        self.glslang = script_args.glslang
 
     def log_unexpected_successes(self, successes):
         """Log list of unexpected test case successes."""
@@ -469,9 +465,12 @@ def main():
     parser.add_argument('-f', '--test-filter', dest='test_filter',
                         action='store', metavar='<test filter regex>',
                         help='only run tests that contain given regex string')
-    parser.add_argument('build_dir', metavar='<build dir directory>')
+    parser.add_argument('spvc', metavar='<spvc executable>')
+    parser.add_argument('spirv_as', metavar='<spirv-as executable>')
+    parser.add_argument('spirv_opt', metavar='<spirv-opt executable>')
+    parser.add_argument('glslang', metavar='<glslangValidator executable>')
     parser.add_argument(
-        'cross_dir', metavar='<SPIRV-cross directory, where tests are located>')
+        'cross_dir', metavar='<SPIRV-cross directory>')
     script_args = parser.parse_args()
 
     test_env = TestEnv(script_args)

--- a/spvc/test/run_spirv_cross_tests_wrapper.sh
+++ b/spvc/test/run_spirv_cross_tests_wrapper.sh
@@ -30,7 +30,7 @@
 #                 to.
 
 if [ "$#" -lt 2 ]; then
-  echo "Atleast 2 arguments are required, $# provided"
+  echo "At least 2 arguments are required, $# provided"
   exit 1
 fi
 

--- a/spvc/test/run_spirv_cross_tests_wrapper.sh
+++ b/spvc/test/run_spirv_cross_tests_wrapper.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Shaderc Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Wrapper for run_spirv_cross_tests.py that takes in the build directory and
+# spirv-cross locations, and assumes they are laid out in a standard way,
+# instead of requiring your to specify all of the paths. Assumes that is it a
+# sibling to the python file in the directory structure.
+#
+# To invoke:
+#   run_spirv_cross_tests_wrapper.sh <build_dir> <cross_dir>
+#
+#     <build_dir> is the directory the repo was built in, paths to binaries are
+#                 expected to conform to a default layout.
+#                 NOTE: If you need to specify per-binary paths, you will need to
+#                 invoke the .py directly.
+#     <cross_dir> is the directory the external spirv-cross repo was checked out
+#                 to.
+
+if [ "$#" -lt 2 ]; then
+  echo "Atleast 2 arguments are required, $# provided"
+  exit 1
+fi
+
+script_path=$(dirname "$0")
+build_path="$1"
+
+spvc_path="$1/spvc/spvc"
+glslang_path="$1/third_party/glslang/StandAlone/glslangValidator"
+spirv_tools_path="$1/third_party/spirv-tools/tools"
+spirv_as_path="$spirv_tools_path/spirv-as"
+spirv_opt_path="$spirv_tools_path/spirv-opt"
+cross_path="$2"
+
+shift 2
+
+python3 $script_path/run_spirv_cross_tests.py "$spvc_path" "$spirv_as_path" "$spirv_opt_path" "$glslang_path" "$cross_path" $@


### PR DESCRIPTION
Refactors all of the various bits of common state and operations for
the tests into a single class. This reduces the amount of arg passing
that needs to occur, which in turn makes the code more readable.

The arguments to the script are filtered through this new class, so
that test code does not need to directly touch the parsed args, which
can be error prone.

Additionally the inputs to the script are changed from being all of
the binaries to use + the test file directory, to the directory where
the binaries are built + the test file directory.

Finally, the existing logging path is commented out, since it is
mostly broken under multiprocessing. An issue for fixing this has been
filed.

Fixes #735