### PR TITLE
Add --target-spv option to set target SPIR-V version

### DIFF
--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -23,10 +23,12 @@ glslc [-c|-S|-E]
       [-fhlsl-functionality1]
       [-fentry-point=<name>]
       [-fauto-map-locations]
+      [-finvert-y]
       [-flimit=...]
       [-flimit-file <resource-limits-file>]
       [-fshader-stage=...]
       [--target-env=...]
+      [--target-spv=...]
       [-g]
       [-O0|-Os]
       [-Idirectory...]
@@ -134,6 +136,11 @@ multiple files generated. A filename of `-` represents standard output.
 
 === Language and Mode Selection Options
 
+[[option-finverty]]
+==== `-finverty`
+
+Inverts position.Y output in a vertex shader.
+
 [[option-flimit]]
 ==== `-flimit=`
 
@@ -232,6 +239,21 @@ the following:
 Generated code uses SPIR-V 1.0, except that code compiled for Vulkan 1.1 uses SPIR-V 1.3.
 
 If this option is not specified, a default of `vulkan1.0` is used.
+
+==== `--target-spv=`
+
+`--target-spv=<value>` lets you specify the SPIR-V version to be used by the generated
+module.  The default is to use the highest version of SPIR-V required to be supported
+by the target environment.  For example, the default is SPIR-V 1.0 for Vulkan 1.0, and
+and SPIR-V 1.3 for Vulkan 1.1.
+
+The ``<value>`` can be one of the following:
+
+* `spv1.0`
+* `spv1.1`
+* `spv1.2`
+* `spv1.3`
+* `spv1.4`
 
 ==== `-x`
 

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -32,6 +32,7 @@
 #include "libshaderc_util/string_piece.h"
 #include "resource_parse.h"
 #include "shader_stage.h"
+#include "shaderc/env.h"
 #include "shaderc/shaderc.h"
 #include "spirv-tools/libspirv.h"
 
@@ -155,6 +156,14 @@ Options:
                         vulkan          # Same as vulkan1.0
                         opengl4.5
                         opengl          # Same as opengl4.5
+  --target-spv=<spirv-version>
+                    Set the SPIR-V version to be used for the generated SPIR-V
+                    module.  The default is the highest version of SPIR-V
+                    required to be supported for the target environment.
+                    For example, default for vulkan1.0 is spv1.0, and
+                    the default for vulkan1.1 is spv1.3.
+                    Values are:
+                        spv1.0, spv1.1, spv1.2, spv1.3, spv1.4
   --version         Display compiler version information.
   -w                Suppresses all warning messages.
   -Werror           Treat all warnings as errors.
@@ -430,6 +439,25 @@ int main(int argc, char** argv) {
         return 1;
       }
       compiler.options().SetTargetEnvironment(target_env, version);
+    } else if (arg.starts_with("--target-spv=")) {
+      shaderc_spirv_version ver = shaderc_spirv_version_1_0;
+      const string_piece ver_str = arg.substr(std::strlen("--target-spv="));
+      if (ver_str == "spv1.0") {
+        ver = shaderc_spirv_version_1_0;
+      } else if (ver_str == "spv1.1") {
+        ver = shaderc_spirv_version_1_1;
+      } else if (ver_str == "spv1.2") {
+        ver = shaderc_spirv_version_1_2;
+      } else if (ver_str == "spv1.3") {
+        ver = shaderc_spirv_version_1_3;
+      } else if (ver_str == "spv1.4") {
+        ver = shaderc_spirv_version_1_4;
+      } else {
+        std::cerr << "glslc: error: invalid value '" << ver_str
+                  << "' in '--target-spv=" << ver_str << "'" << std::endl;
+        return 1;
+      }
+      compiler.options().SetTargetSpirv(ver);
     } else if (arg.starts_with("-mfmt=")) {
       const string_piece binary_output_format =
           arg.substr(std::strlen("-mfmt="));

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -160,6 +160,14 @@ Options:
                         vulkan          # Same as vulkan1.0
                         opengl4.5
                         opengl          # Same as opengl4.5
+  --target-spv=<spirv-version>
+                    Set the SPIR-V version to be used for the generated SPIR-V
+                    module.  The default is the highest version of SPIR-V
+                    required to be supported for the target environment.
+                    For example, default for vulkan1.0 is spv1.0, and
+                    the default for vulkan1.1 is spv1.3.
+                    Values are:
+                        spv1.0, spv1.1, spv1.2, spv1.3, spv1.4
   --version         Display compiler version information.
   -w                Suppresses all warning messages.
   -Werror           Treat all warnings as errors.

--- a/libshaderc/include/shaderc/env.h
+++ b/libshaderc/include/shaderc/env.h
@@ -48,6 +48,20 @@ typedef enum {
   shaderc_env_version_webgpu,
 } shaderc_env_version;
 
+// The known versions of SPIR-V.
+typedef enum {
+  // Use the values used for word 1 of a SPIR-V binary:
+  // - bits 24 to 31: zero
+  // - bits 16 to 23: major version number
+  // - bits 8 to 15: minor version number
+  // - bits 0 to 7: zero
+  shaderc_spirv_version_1_0 = (((uint32_t)0x010000)),
+  shaderc_spirv_version_1_1 = (((uint32_t)0x010100)),
+  shaderc_spirv_version_1_2 = (((uint32_t)0x010200)),
+  shaderc_spirv_version_1_3 = (((uint32_t)0x010300)),
+  shaderc_spirv_version_1_4 = (((uint32_t)0x010400))
+} shaderc_spirv_version;
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -385,6 +385,14 @@ SHADERC_EXPORT void shaderc_compile_options_set_target_env(
     shaderc_target_env target,
     uint32_t version);
 
+// Sets the target SPIR-V version. The generated module will use this version
+// of SPIR-V.  Each target environment determines what versions of SPIR-V
+// it can consume.  Defaults to the highest version of SPIR-V 1.0 which is
+// required to be supported by the target environment.  E.g. Default to SPIR-V
+// 1.0 for Vulkan 1.0 and SPIR-V 1.3 for Vulkan 1.1.
+SHADERC_EXPORT void shaderc_compile_options_set_target_spirv(
+    shaderc_compile_options_t options, shaderc_spirv_version version);
+
 // Sets the compiler mode to treat all warnings as errors. Note the
 // suppress-warnings mode overrides this option, i.e. if both
 // warning-as-errors and suppress-warnings modes are set, warnings will not

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -246,6 +246,15 @@ class CompileOptions {
     shaderc_compile_options_set_target_env(options_, target, version);
   }
 
+  // Sets the target SPIR-V version.  The generated module will use this version
+  // of SPIR-V.  Each target environment determines what versions of SPIR-V
+  // it can consume.  Defaults to the highest version of SPIR-V 1.0 which is
+  // required to be supported by the target environment.  E.g. Default to SPIR-V
+  // 1.0 for Vulkan 1.0 and SPIR-V 1.3 for Vulkan 1.1.
+  void SetTargetSpirv(shaderc_spirv_version version) {
+    shaderc_compile_options_set_target_spirv(options_, version);
+  }
+
   // Sets the compiler mode to make all warnings into errors. Note the
   // suppress-warnings mode overrides this option, i.e. if both
   // warning-as-errors and suppress-warnings modes are set on, warnings will not

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -477,6 +477,13 @@ void shaderc_compile_options_set_target_env(shaderc_compile_options_t options,
                                  GetCompilerTargetEnvVersion(version));
 }
 
+void shaderc_compile_options_set_target_spirv(shaderc_compile_options_t options,
+                                              shaderc_spirv_version ver) {
+  // We made the values match, so we can get away with a static cast.
+  options->compiler.SetTargetSpirv(
+      static_cast<shaderc_util::Compiler::SpirvVersion>(ver));
+}
+
 void shaderc_compile_options_set_warnings_as_errors(
     shaderc_compile_options_t options) {
   options->compiler.SetWarningsAsErrors();

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -121,6 +121,15 @@ class Compiler {
     OpenGL_4_5 = 450,
   };
 
+  // SPIR-V version.
+  enum class SpirvVersion : uint32_t {
+    v1_0 = 0x010000u,
+    v1_1 = 0x010100u,
+    v1_2 = 0x010200u,
+    v1_3 = 0x010300u,
+    v1_4 = 0x010400u,
+  };
+
   enum class OutputType {
     SpirvBinary,  // A binary module, as defined by the SPIR-V specification.
     SpirvAssemblyText,  // Assembly syntax defined by the SPIRV-Tools project.
@@ -222,6 +231,8 @@ class Compiler {
         enabled_opt_passes_(),
         target_env_(TargetEnv::Vulkan),
         target_env_version_(TargetEnvVersion::Default),
+        target_spirv_version_(SpirvVersion::v1_0),
+        target_spirv_version_is_forced_(false),
         source_language_(SourceLanguage::GLSL),
         limits_(kDefaultTBuiltInResource),
         auto_bind_uniforms_(false),
@@ -277,6 +288,12 @@ class Compiler {
   // 4.5 if the target environment is OpenGL.
   void SetTargetEnv(TargetEnv env,
                     TargetEnvVersion version = TargetEnvVersion::Default);
+
+  // Sets the target version of SPIR-V.  The module will use this version
+  // of SPIR-V.  Defaults to the highest version of SPIR-V required to be
+  // supported by the target environment.  E.g. default to SPIR-V 1.0 for
+  // Vulkan 1.0, and SPIR-V 1.3 for Vulkan 1.1.
+  void SetTargetSpirv(SpirvVersion version);
 
   // Sets the souce language.
   void SetSourceLanguage(SourceLanguage lang);
@@ -496,6 +513,11 @@ class Compiler {
   // for those defaults.
   TargetEnvVersion target_env_version_;
 
+  // The SPIR-V version to be used for the generated module.  Defaults to 1.0.
+  SpirvVersion target_spirv_version_;
+  // True if the user explicitly set the target SPIR-V version.
+  bool target_spirv_version_is_forced_;
+
   // The source language.  Defaults to GLSL.
   SourceLanguage source_language_;
 
@@ -588,6 +610,37 @@ inline Compiler::Stage ConvertToStage(EShLanguage stage) {
   assert(false && "Invalid case");
   return Compiler::Stage::Compute;
 }
+
+// A GlslangClientInfo captures target client version and desired SPIR-V
+// version.
+struct GlslangClientInfo {
+  GlslangClientInfo() {}
+  GlslangClientInfo(const std::string& e, glslang::EShClient c,
+                    glslang::EShTargetClientVersion cv,
+                    glslang::EShTargetLanguage l,
+                    glslang::EShTargetLanguageVersion lv)
+      : error(e),
+        client(c),
+        client_version(cv),
+        target_language(l),
+        target_language_version(lv) {}
+
+  std::string error;  // Empty if ok, otherwise contains the error message.
+  glslang::EShClient client = glslang::EShClientNone;
+  glslang::EShTargetClientVersion client_version;
+  glslang::EShTargetLanguage target_language = glslang::EShTargetSpv;
+  glslang::EShTargetLanguageVersion target_language_version =
+      glslang::EShTargetSpv_1_0;
+};
+
+// Returns the mappings to Glslang client, client version, and SPIR-V version.
+// Also indicates whether the input values were valid.
+GlslangClientInfo GetGlslangClientInfo(
+    const std::string& error_tag,  // Indicates source location, for errors.
+    shaderc_util::Compiler::TargetEnv env,
+    shaderc_util::Compiler::TargetEnvVersion env_version,
+    shaderc_util::Compiler::SpirvVersion spv_version,
+    bool spv_version_is_forced);
 
 }  // namespace shaderc_util
 #endif  // LIBSHADERC_UTIL_INC_COMPILER_H

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -15,8 +15,11 @@
 #include "libshaderc_util/compiler.h"
 
 #include <cstdint>
+#include <iomanip>
+#include <sstream>
 #include <tuple>
 
+#include "SPIRV/GlslangToSpv.h"
 #include "libshaderc_util/format.h"
 #include "libshaderc_util/io.h"
 #include "libshaderc_util/message.h"
@@ -25,8 +28,6 @@
 #include "libshaderc_util/spirv_tools_wrapper.h"
 #include "libshaderc_util/string_piece.h"
 #include "libshaderc_util/version_profile.h"
-
-#include "SPIRV/GlslangToSpv.h"
 
 namespace {
 using shaderc_util::string_piece;
@@ -70,8 +71,7 @@ std::pair<int, string_piece> DecodeLineDirective(string_piece directive) {
 // only valid combinations are used.
 EShMessages GetMessageRules(shaderc_util::Compiler::TargetEnv env,
                             shaderc_util::Compiler::SourceLanguage lang,
-                            bool hlsl_offsets,
-                            bool debug_info) {
+                            bool hlsl_offsets, bool debug_info) {
   using shaderc_util::Compiler;
   EShMessages result = EShMsgCascadingErrors;
   if (lang == Compiler::SourceLanguage::HLSL) {
@@ -93,54 +93,6 @@ EShMessages GetMessageRules(shaderc_util::Compiler::TargetEnv env,
   }
   if (debug_info) {
     result = static_cast<EShMessages>(result | EShMsgDebugInfo);
-  }
-  return result;
-}
-
-// A GlslangClientInfo captures target client version and desired SPIR-V
-// version.
-struct GlslangClientInfo {
-  bool valid_client = false;
-  glslang::EShClient client = glslang::EShClientNone;
-  bool valid_client_version = false;
-  glslang::EShTargetClientVersion client_version;
-  glslang::EShTargetLanguage target_language = glslang::EShTargetSpv;
-  glslang::EShTargetLanguageVersion target_language_version =
-      glslang::EShTargetSpv_1_0;
-};
-
-// Returns the mappings to Glslang client, client version, and SPIR-V version.
-// Also indicates whether the input values were valid.
-GlslangClientInfo GetGlslangClientInfo(
-    shaderc_util::Compiler::TargetEnv env,
-    shaderc_util::Compiler::TargetEnvVersion version) {
-  GlslangClientInfo result;
-
-  using shaderc_util::Compiler;
-  switch (env) {
-    case Compiler::TargetEnv::Vulkan:
-      result.valid_client = true;
-      result.client = glslang::EShClientVulkan;
-      if (version == Compiler::TargetEnvVersion::Default ||
-          version == Compiler::TargetEnvVersion::Vulkan_1_0) {
-        result.client_version = glslang::EShTargetVulkan_1_0;
-        result.valid_client_version = true;
-      } else if (version == Compiler::TargetEnvVersion::Vulkan_1_1) {
-        result.client_version = glslang::EShTargetVulkan_1_1;
-        result.valid_client_version = true;
-        result.target_language_version = glslang::EShTargetSpv_1_3;
-      }
-      break;
-    case Compiler::TargetEnv::OpenGLCompat:  // TODO(dneto): remove this
-    case Compiler::TargetEnv::OpenGL:
-      result.valid_client = true;
-      result.client = glslang::EShClientOpenGL;
-      if (version == Compiler::TargetEnvVersion::Default ||
-          version == Compiler::TargetEnvVersion::OpenGL_4_5) {
-        result.client_version = glslang::EShTargetOpenGL_450;
-        result.valid_client_version = true;
-      }
-      break;
   }
   return result;
 }
@@ -192,19 +144,11 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   size_t& compilation_output_data_size_in_bytes = std::get<2>(result_tuple);
 
   // Check target environment.
-  const auto target_client_info =
-      GetGlslangClientInfo(target_env_, target_env_version_);
-  if (!target_client_info.valid_client) {
-    *error_stream << "error:" << error_tag
-                  << ": Invalid target client environment " << int(target_env_);
-    *total_warnings = 0;
-    *total_errors = 1;
-    return result_tuple;
-  }
-  if (!target_client_info.valid_client_version) {
-    *error_stream << "error:" << error_tag << ": Invalid target client version "
-                  << static_cast<uint32_t>(target_env_version_)
-                  << " for environment " << int(target_env_);
+  const auto target_client_info = GetGlslangClientInfo(
+      error_tag, target_env_, target_env_version_, target_spirv_version_,
+      target_spirv_version_is_forced_);
+  if (!target_client_info.error.empty()) {
+    *error_stream << target_client_info.error;
     *total_warnings = 0;
     *total_errors = 1;
     return result_tuple;
@@ -304,13 +248,12 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   shader.setInvertY(invert_y_enabled_);
   shader.setNanMinMaxClamp(nan_clamp_);
 
-  const EShMessages rules = GetMessageRules(target_env_, source_language_,
-                                            hlsl_offsets_,
-                                            generate_debug_info_);
+  const EShMessages rules = GetMessageRules(
+      target_env_, source_language_, hlsl_offsets_, generate_debug_info_);
 
-  bool success = shader.parse(
-      &limits_, default_version_, default_profile_, force_version_profile_,
-      kNotForwardCompatible, rules, includer);
+  bool success = shader.parse(&limits_, default_version_, default_profile_,
+                              force_version_profile_, kNotForwardCompatible,
+                              rules, includer);
 
   success &= PrintFilteredErrors(error_tag, error_stream, warnings_as_errors_,
                                  suppress_warnings_, shader.getInfoLog(),
@@ -400,6 +343,11 @@ void Compiler::SetTargetEnv(Compiler::TargetEnv env,
   target_env_version_ = version;
 }
 
+void Compiler::SetTargetSpirv(Compiler::SpirvVersion version) {
+  target_spirv_version_ = version;
+  target_spirv_version_is_forced_ = true;
+}
+
 void Compiler::SetSourceLanguage(Compiler::SourceLanguage lang) {
   source_language_ = lang;
 }
@@ -451,9 +399,7 @@ void Compiler::EnableHlslFunctionality1(bool enable) {
   hlsl_functionality1_enabled_ = enable;
 }
 
-void Compiler::EnableInvertY(bool enable) {
-  invert_y_enabled_ = enable;
-}
+void Compiler::EnableInvertY(bool enable) { invert_y_enabled_ = enable; }
 
 void Compiler::SetNanClamp(bool enable) { nan_clamp_ = enable; }
 
@@ -470,19 +416,11 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
   shader.setStringsWithLengthsAndNames(&shader_strings, &shader_lengths,
                                        &string_names, 1);
   shader.setPreamble(shader_preamble.data());
-  auto target_client_info =
-      GetGlslangClientInfo(target_env_, target_env_version_);
-  if (!target_client_info.valid_client) {
-    std::ostringstream os;
-    os << "error:" << error_tag << ": Invalid target client "
-       << int(target_env_);
-    return std::make_tuple(false, "", os.str());
-  }
-  if (!target_client_info.valid_client_version) {
-    std::ostringstream os;
-    os << "error:" << error_tag << ": Invalid target client "
-       << int(target_env_version_) << " for environmnent " << int(target_env_);
-    return std::make_tuple(false, "", os.str());
+  auto target_client_info = GetGlslangClientInfo(
+      error_tag, target_env_, target_env_version_, target_spirv_version_,
+      target_spirv_version_is_forced_);
+  if (!target_client_info.error.empty()) {
+    return std::make_tuple(false, "", target_client_info.error);
   }
   shader.setEnvClient(target_client_info.client,
                       target_client_info.client_version);
@@ -713,6 +651,75 @@ std::vector<uint32_t> ConvertStringToVector(const std::string& str) {
   std::strncpy(reinterpret_cast<char*>(result_vec.data()), str.c_str(),
                str.size());
   return result_vec;
+}
+
+GlslangClientInfo GetGlslangClientInfo(
+    const std::string& error_tag, shaderc_util::Compiler::TargetEnv env,
+    shaderc_util::Compiler::TargetEnvVersion env_version,
+    shaderc_util::Compiler::SpirvVersion spv_version,
+    bool spv_version_is_forced) {
+  GlslangClientInfo result;
+  std::ostringstream errs;
+
+  using shaderc_util::Compiler;
+  switch (env) {
+    case Compiler::TargetEnv::Vulkan:
+      result.client = glslang::EShClientVulkan;
+      if (env_version == Compiler::TargetEnvVersion::Default ||
+          env_version == Compiler::TargetEnvVersion::Vulkan_1_0) {
+        result.client_version = glslang::EShTargetVulkan_1_0;
+      } else if (env_version == Compiler::TargetEnvVersion::Vulkan_1_1) {
+        result.client_version = glslang::EShTargetVulkan_1_1;
+        result.target_language_version = glslang::EShTargetSpv_1_3;
+      } else {
+        errs << "error:" << error_tag << ": Invalid target client version "
+             << static_cast<uint32_t>(env_version) << " for Vulkan environment "
+             << int(env);
+      }
+      break;
+    case Compiler::TargetEnv::OpenGLCompat:  // TODO(dneto): remove this
+    case Compiler::TargetEnv::OpenGL:
+      result.client = glslang::EShClientOpenGL;
+      if (env_version == Compiler::TargetEnvVersion::Default ||
+          env_version == Compiler::TargetEnvVersion::OpenGL_4_5) {
+        result.client_version = glslang::EShTargetOpenGL_450;
+      } else {
+        errs << "error:" << error_tag << ": Invalid target client version "
+             << static_cast<uint32_t>(env_version) << " for OpenGL environment "
+             << int(env);
+      }
+      break;
+    default:
+      errs << "error:" << error_tag << ": Invalid target client environment "
+           << int(env);
+      break;
+  }
+
+  if (spv_version_is_forced && errs.str().empty()) {
+    switch (spv_version) {
+      case Compiler::SpirvVersion::v1_0:
+        result.target_language_version = glslang::EShTargetSpv_1_0;
+        break;
+      case Compiler::SpirvVersion::v1_1:
+        result.target_language_version = glslang::EShTargetSpv_1_1;
+        break;
+      case Compiler::SpirvVersion::v1_2:
+        result.target_language_version = glslang::EShTargetSpv_1_2;
+        break;
+      case Compiler::SpirvVersion::v1_3:
+        result.target_language_version = glslang::EShTargetSpv_1_3;
+        break;
+      case Compiler::SpirvVersion::v1_4:
+        result.target_language_version = glslang::EShTargetSpv_1_4;
+        break;
+      default:
+        errs << "error:" << error_tag << ": Unknown SPIR-V version " << std::hex
+             << uint32_t(spv_version);
+        break;
+    }
+  }
+  result.error = errs.str();
+  return result;
 }
 
 }  // namespace shaderc_util


### PR DESCRIPTION
Adds shaderc_compile_options_set_targte_spirv and associated enums.
Defaults to SPIR-V 1.0.

Passes that down into Glslang so we generate a module with the
specified version of SPIR-V.

Refactor how we map to Glslang target and client, and test that
better.

Setting spirv version is just an override.

Plumb through to glslc