### PR TITLE
Rolling 4 dependencies and updating known_failures

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
-  'glslang_revision': '4162de4bbfc58ef37600c23e4e8fcf58e604f382',
+  'glslang_revision': '4b4b41a63499d34c527ee4f714dde8072f60c900',
   'googletest_revision': '437e1008c97b6bf595fec85da42c6925babd96b2',
   're2_revision': '848dfb7e1d7ba641d598cb66f81590f3999a555a',
-  'spirv_headers_revision': 'de99d4d834aeb51dd9f099baa285bd44fd04bb3d',
-  'spirv_tools_revision': 'e6e3e2ccc6a2a9bf43730d8edccf0b1a212d660a',
-  'spirv_cross_revision': '8ee8e60f70f937c72379ab1fc404a1c36d660a31',
+  'spirv_headers_revision': '123dc278f204f8e833e1a88d31c46d0edf81d4b2',
+  'spirv_tools_revision': '9702d47c6fe4cefbc55f905b0e9966452124b6c2',
+  'spirv_cross_revision': '9a6e2534e97acb4436288cf1e015209384543bd2',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -35,6 +35,10 @@ shaders-msl/frag/subgroup-builtins.msl22.frag,False
 shaders-msl/frag/subgroup-builtins.msl22.frag,True
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,True
+shaders-msl/vulkan/frag/basic.multiview.nocompat.vk.frag,False
+shaders-msl/vulkan/frag/basic.multiview.nocompat.vk.frag,True
+shaders-msl/vulkan/vert/multiview.multiview.nocompat.vk.vert,False
+shaders-msl/vulkan/vert/multiview.multiview.nocompat.vk.vert,True
 shaders-reflection/asm/aliased-entry-point-names.asm.multi,False
 shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp,False


### PR DESCRIPTION
Roll third_party/glslang/ 4162de4bb..4b4b41a63 (5 commits)

https://github.com/KhronosGroup/glslang/compare/4162de4bbfc5...4b4b41a63499

$ git log 4162de4bb..4b4b41a63 --date=short --no-merges --format='%ad %ae %s'
2019-07-03 cepheus HLSL: Fix #1815: Don't constant fold spec-constant array indexing.
2019-07-02 jbolz update spirv-headers to pick up demote_to_helper_invocation
2019-07-02 cepheus Standalone: Fix #1814: Check that linkage was specified for reflection.
2019-07-02 cepheus Build: Tweak PR #1808 to avoid an implicit conversion warning.
2019-07-01 jbolz Implement GL_EXT_demote_to_helper_invocation

Roll third_party/spirv-cross/ 8ee8e60f7..9a6e2534e (4 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/8ee8e60f70f9...9a6e2534e97a

$ git log 8ee8e60f7..9a6e2534e --date=short --no-merges --format='%ad %ae %s'
2019-07-03 post Fix variable scope when an if or else block dominates a variable.
2019-05-31 cdavis MSL: Support SubgroupLocalInvocationId and SubgroupSize in all stages.
2019-07-01 post MSL/HLSL: Support OpOuterProduct.
2019-05-31 cdavis MSL: Support SPV_KHR_multiview.

Roll third_party/spirv-headers/ de99d4d83..123dc278f (1 commit)

https://github.com/KhronosGroup/SPIRV-Headers/compare/de99d4d834ae...123dc278f204

$ git log de99d4d83..123dc278f --date=short --no-merges --format='%ad %ae %s'
2019-07-01 jbolz add SPV_EXT_demote_to_helper_invocation

Roll third_party/spirv-tools/ e6e3e2ccc..9702d47c6 (1 commit)

https://github.com/KhronosGroup/SPIRV-Tools/compare/e6e3e2ccc6a2...9702d47c6fe4

$ git log e6e3e2ccc..9702d47c6 --date=short --no-merges --format='%ad %ae %s'
2019-07-02 cmarcelo Validate that in OpenGL env block variables have Binding (#2685)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools