### PR TITLE
Rolling 4 dependencies and update known_failures

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -7,10 +7,10 @@ vars = {
   'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
   'glslang_revision': '4b4b41a63499d34c527ee4f714dde8072f60c900',
   'googletest_revision': '437e1008c97b6bf595fec85da42c6925babd96b2',
-  're2_revision': '848dfb7e1d7ba641d598cb66f81590f3999a555a',
-  'spirv_headers_revision': '123dc278f204f8e833e1a88d31c46d0edf81d4b2',
-  'spirv_tools_revision': '9702d47c6fe4cefbc55f905b0e9966452124b6c2',
-  'spirv_cross_revision': '9a6e2534e97acb4436288cf1e015209384543bd2',
+  're2_revision': 'e356bd3f80e0c15c1050323bb5a2d0f8ea4845f4',
+  'spirv_headers_revision': '29c11140baaf9f7fdaa39a583672c556bf1795a1',
+  'spirv_tools_revision': 'b8ab80843f67479b1b0c096138e62ec78145f05b',
+  'spirv_cross_revision': '53ab2144b90abede33be5161aec5dfc94ddc3caf',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -61,6 +61,8 @@ shaders-reflection/frag/spec-constant.vk.frag,False
 shaders-reflection/rgen/acceleration_structure.vk.rgen,False
 shaders-reflection/vert/read-from-row-major-array.vert,False
 shaders-reflection/vert/texture_buffer.vert,False
+shaders/asm/extended-debug-extinst.invalid.asm.comp,False
+shaders/asm/extended-debug-extinst.invalid.asm.comp,True
 shaders/asm/frag/line-directive.line.asm.frag,False
 shaders/asm/frag/line-directive.line.asm.frag,True
 shaders/flatten/multi-dimensional.desktop.invalid.flatten_dim.frag,False


### PR DESCRIPTION
Roll third_party/re2/ 848dfb7e1..e356bd3f8 (6 commits)

https://github.com/google/re2/compare/848dfb7e1d7b...e356bd3f80e0

$ git log 848dfb7e1..e356bd3f8 --date=short --no-merges --format='%ad %ae %s'
2019-07-07 junyer Make RE2::Set canonicalize DFA states.
2019-07-05 junyer Fix SimplifyStringSet() for really reals. And the test.
2019-07-04 junyer Don't let Prefilter::OrStrings() return NULL.
2019-07-04 junyer Fix SimplifyStringSet() properly. Ensure test coverage.
2019-07-04 junyer Fix a typographical error.
2019-07-04 junyer Stop SimplifyStringSet() from finding "" in everything.

Roll third_party/spirv-cross/ 9a6e2534e..53ab2144b (7 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/9a6e2534e97a...53ab2144b90a

$ git log 9a6e2534e..53ab2144b --date=short --no-merges --format='%ad %ae %s'
2019-07-08 post Fall back to complex loop if non-trivial continue block is found.
2019-07-08 post Add test shaders for NonUniformEXT propagation.
2019-07-08 post Propagate NonUniformEXT to dependent expressions.
2019-07-05 post Add simple test for extended debug operations.
2019-07-04 lifeng.pan Parse SPIR-V debug information extended instructions, as well as OpNoLine.
2019-07-03 post Don't use scalar dot().
2019-07-03 post MSL/HLSL: Support scalar reflect and refract.

Roll third_party/spirv-headers/ 123dc278f..29c11140b (1 commit)

https://github.com/KhronosGroup/SPIRV-Headers/compare/123dc278f204...29c11140baaf

$ git log 123dc278f..29c11140b --date=short --no-merges --format='%ad %ae %s'
2019-06-15 antiagainst Reserve ID 23 for MLIR SPIR-V Serializer

Roll third_party/spirv-tools/ 9702d47c6..b8ab80843 (5 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/9702d47c6fe4...b8ab80843f67

$ git log 9702d47c6..b8ab80843 --date=short --no-merges --format='%ad %ae %s'
2019-07-07 afdx Shrinker for spirv-fuzz (#2708)
2019-07-04 stevenperron Perform merge return with single return in loop. (#2714)
2019-07-04 stevenperron Do not inline OpKill Instructions (#2713)
2019-07-04 afdx Refactor reducer options (#2709)
2019-07-03 52076061+digit-google Fix BUILD.gn for Fuchsia platform build. (#2692)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools