### PR TITLE
Remove app_dummy call in Android test

### DIFF
--- a/android_test/test.cpp
+++ b/android_test/test.cpp
@@ -16,7 +16,6 @@
 #include <android_native_app_glue.h>
 
 void android_main(struct android_app* state) {
-  app_dummy();
   shaderc::Compiler compiler;
   const char* test_program = "void main() {}";
   compiler.CompileGlslToSpv(test_program, strlen(test_program),


### PR DESCRIPTION
Since NDK 15b, that has been deprecated.  Remove it now from our
test code to avoid the deprecation warning.
See https://github.com/android-ndk/ndk/issues/381