### PR TITLE
Rolling 5 dependencies and update known_failures

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,13 +4,13 @@ vars = {
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
 
-  'effcee_revision' : 'b83b58d177b797edd1f94c5f10837f2cc2863f0a',
-  'glslang_revision': '4b4b41a63499d34c527ee4f714dde8072f60c900',
-  'googletest_revision': '437e1008c97b6bf595fec85da42c6925babd96b2',
+  'effcee_revision' : '4bef5dbed590d1edfd3e34bc83d4141f41b998b0',
+  'glslang_revision': 'f970253a5d4185be28d5a479c1652f54eb89db61',
+  'googletest_revision': 'ee3aa831172090fd5442820f215cb04ab6062756',
   're2_revision': 'e356bd3f80e0c15c1050323bb5a2d0f8ea4845f4',
   'spirv_headers_revision': '29c11140baaf9f7fdaa39a583672c556bf1795a1',
-  'spirv_tools_revision': 'b8ab80843f67479b1b0c096138e62ec78145f05b',
-  'spirv_cross_revision': '53ab2144b90abede33be5161aec5dfc94ddc3caf',
+  'spirv_tools_revision': '5ce8cf781fe1198e32f1b4aab2083051c0c6adcb',
+  'spirv_cross_revision': '44f688bf0b77d4f1a2c87de85980be0696974881',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -19,6 +19,8 @@ shaders-msl/asm/frag/min-lod.msl22.asm.frag,True
 shaders-msl/asm/frag/min-max-clamp.invalid.asm.frag,False
 shaders-msl/comp/int64.invalid.msl22.comp,False
 shaders-msl/comp/int64.invalid.msl22.comp,True
+shaders-msl/frag/16bit-constants.frag,False
+shaders-msl/frag/16bit-constants.frag,True
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,True
 shaders-msl/frag/barycentric-nv.msl22.frag,False
@@ -67,6 +69,8 @@ shaders/asm/frag/line-directive.line.asm.frag,False
 shaders/asm/frag/line-directive.line.asm.frag,True
 shaders/flatten/multi-dimensional.desktop.invalid.flatten_dim.frag,False
 shaders/flatten/multi-dimensional.desktop.invalid.flatten_dim.frag,True
+shaders/frag/16bit-constants.frag,False
+shaders/frag/16bit-constants.frag,True
 shaders/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp.vk,False
 shaders/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp.vk,True
 shaders/vulkan/frag/nonuniform-qualifier.vk.nocompat.frag.vk,False


### PR DESCRIPTION
Roll third_party/effcee/ b83b58d17..4bef5dbed (2 commits)

https://github.com/google/effcee/compare/b83b58d177b7...4bef5dbed590

$ git log b83b58d17..4bef5dbed --date=short --no-merges --format='%ad %ae %s'
2019-07-08 dneto Require Python 3
2019-07-08 dneto Add Clang warning -Wextra-semi

Roll third_party/glslang/ 4b4b41a63..f970253a5 (3 commits)

https://github.com/KhronosGroup/glslang/compare/4b4b41a63499...f970253a5d41

$ git log 4b4b41a63..f970253a5 --date=short --no-merges --format='%ad %ae %s'
2019-07-08 alanbaker Test updates
2019-07-08 alanbaker Update SPIRV-Tools revision
2019-07-06 rex.xu Change implementation of gl_SIMDGroupSizeAMD

Roll third_party/googletest/ 437e1008c..ee3aa8311 (1 commit)

https://github.com/google/googletest/compare/437e1008c97b...ee3aa8311720

$ git log 437e1008c..ee3aa8311 --date=short --no-merges --format='%ad %ae %s'
2019-07-10 sam.sobell Fix bad advice in cook book (#2308)

Roll third_party/spirv-cross/ 53ab2144b..44f688bf0 (3 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/53ab2144b90a...44f688bf0b77

$ git log 53ab2144b..44f688bf0 --date=short --no-merges --format='%ad %ae %s'
2019-07-10 post Forget loop variable enables after emitting block chain.
2019-07-10 post MSL: Re-roll array expressions in initializers.
2019-07-09 post MSVC 2013: Work around another compiler bug with array init.

Roll third_party/spirv-tools/ b8ab80843..5ce8cf781 (6 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/b8ab80843f67...5ce8cf781fe1

$ git log b8ab80843..5ce8cf781 --date=short --no-merges --format='%ad %ae %s'
2019-07-10 stevenperron Change the order branches are simplified in dead branch elim (#2728)
2019-07-11 troughton Add —preserve-bindings and —preserve-spec-constants (#2693)
2019-07-10 stevenperron Handle decorations better in some optimizations (#2716)
2019-07-10 zoddicus Update memory scope rules for WebGPU (#2725)
2019-07-08 33432579+alan-baker Remove extra semis (#2717)
2019-07-08 33432579+alan-baker Validate usage of 8- and 16-bit types with only storage capabilities (#2704)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools