### PR TITLE
Explicitly use python3 for git-sync-deps

### DIFF
--- a/utils/git-sync-deps
+++ b/utils/git-sync-deps
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014 Google Inc.
 #
 # Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
On few distributions Python is still being symlinked to Python 2 if it is installed.
Because this script only works on Python 3, we can simply ask for it directly.