### PR TITLE
Remove extra semicolons in shaderc

### DIFF
--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -113,7 +113,7 @@ class StageDeducer {
  public:
   explicit StageDeducer(
       shaderc_shader_kind kind = shaderc_glsl_infer_from_source)
-      : kind_(kind), error_(false){};
+      : kind_(kind), error_(false){}
   // The method that underlying glslang will call to determine the shader stage
   // to be used in current compilation. It is called only when there is neither
   // forced shader kind (or say stage, in the view of glslang), nor #pragma
@@ -133,7 +133,7 @@ class StageDeducer {
       error_ = false;
     }
     return stage;
-  };
+  }
 
   // Returns true if there is error during shader stage deduction.
   bool error() const { return error_; }
@@ -210,9 +210,9 @@ class InternalFileIncluder : public shaderc_util::CountingIncluder {
                        void* user_data)
       : resolver_(resolver),
         result_releaser_(result_releaser),
-        user_data_(user_data){};
+        user_data_(user_data){}
   InternalFileIncluder()
-      : resolver_(nullptr), result_releaser_(nullptr), user_data_(nullptr){};
+      : resolver_(nullptr), result_releaser_(nullptr), user_data_(nullptr){}
 
  private:
   // Check the validity of the callbacks.


### PR DESCRIPTION
The extra semicolons will be treat as warning error if build shaderc as a third party library.