### PR TITLE
Rolling 3 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '4bef5dbed590d1edfd3e34bc83d4141f41b998b0',
-  'glslang_revision': '3cea2e5882e3455731a8b6657fb06db913eb3aa1',
-  'googletest_revision': 'b4961ab1cbda56295823594e4214b0c188052fef',
+  'glslang_revision': '37fc4d27d612d3b0c916933e16dab3da5bb7ab34',
+  'googletest_revision': '90a443f9c2437ca8a682a1ac625eba64e1d74a8a',
   're2_revision': '67bce690decdb507b13e14050661f8b9ebfcfe6c',
   'spirv_headers_revision': 'e4322e3be589e1ddd44afb20ea842a977c1319b8',
-  'spirv_tools_revision': '698b56a8f02495d115cd6c5eefd89b812d55b13d',
+  'spirv_tools_revision': 'f701237f2d88af13fe9f920f29f288dc7157c262',
   'spirv_cross_revision': '4ce04480ec5469fe7ebbdd66c3016090a704d81b',
 }
 

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -96,6 +96,7 @@ shaders/flatten/multi-dimensional.desktop.invalid.flatten_dim.frag,False
 shaders/flatten/multi-dimensional.desktop.invalid.flatten_dim.frag,True
 shaders/frag/16bit-constants.invalid.frag,False
 shaders/frag/16bit-constants.invalid.frag,True
+shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk,True
 shaders/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp.vk,False
 shaders/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp.vk,True
 shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag.vk,False


### PR DESCRIPTION
Also updated known_failures

Roll third_party/glslang/ 3cea2e588..37fc4d27d (4 commits)

https://github.com/KhronosGroup/glslang/compare/3cea2e5882e3...37fc4d27d612

$ git log 3cea2e588..37fc4d27d --date=short --no-merges --format='%ad %ae %s'
2019-08-09 rharrison Make non-emscripten flags platform agnostic.
2019-08-09 rharrison Converted ENABLE_HLSL to a dependent option, so it can be always disabled in web builds
2019-08-09 rharrison Move build instructions to README.md
2019-08-08 rharrison Add WASM build target for Web version of glslang

Roll third_party/googletest/ b4961ab1c..90a443f9c (6 commits)

https://github.com/google/googletest/compare/b4961ab1cbda...90a443f9c243

$ git log b4961ab1c..90a443f9c --date=short --no-merges --format='%ad %ae %s'
2019-08-07 absl-team Googletest export
2019-08-07 absl-team Googletest export
2019-08-07 krystian.kuzniarek fix an improperly generated table
2019-08-06 krystian.kuzniarek fix broken links
2019-08-06 antoine Fix #2371: Redirect Windows CRT assertions to stderr
2019-08-01 krystian.kuzniarek remove an excessive mutable type specifier

Roll third_party/spirv-tools/ 698b56a8f..f701237f2 (9 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/698b56a8f024...f701237f2d88

$ git log 698b56a8f..f701237f2 --date=short --no-merges --format='%ad %ae %s'
2019-08-12 stevenperron Remove useless semi-colons (#2789)
2019-08-09 greg Instrument: Fix version 2 output record write for tess eval shaders. (#2782)
2019-08-08 stevenperron Start SPIRV-Tools v2019.5
2019-08-08 stevenperron Finalize SPIRV-Tools v2019.4
2019-08-08 stevenperron Add descriptor array scalar replacement (#2742)
2019-08-08 stevenperron Update CHANGES
2019-08-08 greg Add SPV_EXT_physical_storage_buffer to opt whitelists (#2779)
2019-08-07 stevenperron Handle RelaxedPrecision in SROA (#2788)
2019-08-07 zoddicus Add -fextra-semi to Clang builds (#2787)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools