### PR TITLE
Rolling 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '4bef5dbed590d1edfd3e34bc83d4141f41b998b0',
-  'glslang_revision': '37fc4d27d612d3b0c916933e16dab3da5bb7ab34',
-  'googletest_revision': '90a443f9c2437ca8a682a1ac625eba64e1d74a8a',
-  're2_revision': '67bce690decdb507b13e14050661f8b9ebfcfe6c',
+  'glslang_revision': '95609e6d923a9cf9593afca36ab1c419999f3519',
+  'googletest_revision': 'c9ccac7cb7345901884aabf5d1a786cfa6e2f397',
+  're2_revision': 'be0e1305d264b2cbe1d35db66b8c5107fc2a727e',
   'spirv_headers_revision': 'e4322e3be589e1ddd44afb20ea842a977c1319b8',
-  'spirv_tools_revision': 'f701237f2d88af13fe9f920f29f288dc7157c262',
+  'spirv_tools_revision': 'bc62722b80a6360fc5c238dd1e91bbe910e36c43',
   'spirv_cross_revision': '4ce04480ec5469fe7ebbdd66c3016090a704d81b',
 }
 


### PR DESCRIPTION
Roll third_party/glslang/ 37fc4d27d..95609e6d9 (1 commit)

https://github.com/KhronosGroup/glslang/compare/37fc4d27d612...95609e6d923a

$ git log 37fc4d27d..95609e6d9 --date=short --no-merges --format='%ad %ae %s'
2019-08-14 johnkslang Set theme jekyll-theme-merlot

Roll third_party/googletest/ 90a443f9c..c9ccac7cb (18 commits)

https://github.com/google/googletest/compare/90a443f9c243...c9ccac7cb734

$ git log 90a443f9c..c9ccac7cb --date=short --no-merges --format='%ad %ae %s'
2019-08-19 misterg Googletest export
2019-08-16 absl-team Googletest export
2019-08-16 absl-team Googletest export
2019-08-16 misterg Googletest export
2019-08-16 misterg Googletest export
2019-08-16 misterg Googletest export
2019-08-15 misterg Googletest export
2019-08-15 absl-team Googletest export
2019-08-12 absl-team Googletest export
2019-08-09 absl-team Googletest export
2019-08-09 absl-team Googletest export
2019-08-13 krystian.kuzniarek remove custom implementations of std::is_same
2019-08-14 krystian.kuzniarek remove a custom implementation of std::is_reference
2019-08-11 adam.f.badura Use -Wa,-mbig-obj for Cygwin/MinGW always
2019-08-11 krystian.kuzniarek remove an outdated comment
2019-08-08 krystian.kuzniarek remove a dead metafunction
2019-08-07 contact Update Bazel on Windows
2019-08-07 contact Prepare for Bazel incompatible changes

Roll third_party/re2/ 67bce690d..be0e1305d (15 commits)

https://github.com/google/re2/compare/67bce690decd...be0e1305d264

$ git log 67bce690d..be0e1305d --date=short --no-merges --format='%ad %ae %s'
2019-08-19 junyer Add Clang 9 to the Travis CI matrix.
2019-08-19 junyer Don't assume that iterators are just pointers.
2019-08-18 junyer No, it was right before. Try the /cygdrive form.
2019-08-18 junyer Try under 'C:\Program Files (x86)' instead. Sigh.
2019-08-18 junyer Ensure that CMake is in the path on Windows.
2019-08-18 junyer Comment on why we pin to Visual Studio 2015.
2019-08-18 junyer Attempt to avoid VCVARSALL.BAT breakage entirely.
2019-08-18 junyer Attempt to address VCVARSALL.BAT breakage. Sigh.
2019-08-18 junyer Argh. Try a different flag.
2019-08-18 junyer Try to upgrade Bazel harder on Windows.
2019-08-18 junyer Upgrade Bazel before trying to build with it.
2019-08-18 junyer Switch to Starlark for C++ rules.
2019-08-15 junyer Configure Kokoro to run CMake builds on Ubuntu.
2019-08-15 junyer Configure CMake to require version 3.5.1, which is what Xenial has.
2019-08-15 junyer Upgrade Travis CI from Trusty to Xenial.

Roll third_party/spirv-tools/ f701237f2..bc62722b8 (8 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/f701237f2d88...bc62722b80a6

$ git log f701237f2..bc62722b8 --date=short --no-merges --format='%ad %ae %s'
2019-08-18 stevenperron Handle overflow in wrap-opkill (#2801)
2019-08-16 stevenperron More handle overflow in sroa (#2800)
2019-08-16 greg Instrument: Add support for Buffer Device Address extension (#2792)
2019-08-15 toomas.remmelg Update remquo validation to match the OpenCL Extended Instruction Set Specification (#2791)
2019-08-15 jaebaek Use ascii code based characters (#2796)
2019-08-14 jaebaek Change the way to include header (#2795)
2019-08-14 alanbaker Fix validation of constant matrices (#2794)
2019-08-14 stevenperron Replace OpKill With function call. (#2790)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools