### PR TITLE
Explicitly cast fuzzing data to avoid new GCC warning

### DIFF
--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -242,7 +242,7 @@ size_t shaderc_spvc_compile_options_set_for_fuzzing(
     shaderc_spvc_compile_options_t options, const uint8_t* data, size_t size) {
   if (!data || size < sizeof(*options)) return 0;
 
-  memcpy(options, data, sizeof(*options));
+  memcpy(static_cast<void*>(options), data, sizeof(*options));
   return sizeof(*options);
 }
 


### PR DESCRIPTION
-Wclass-memaccess warnings/errors is being triggered somewhat
 spuriously. Coercing the type to avoid this warning, since this
 should be valid.

Fixes #780