### PR TITLE
Force Glslang to support HLSL in its interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Shaderc into.
 
 The rest of this section describes how to build Shaderc from sources.
 
+Note: Shaderc assumes Glslang supports HLSL compilation.  The instructions
+below assume you're building Glslang from sources, and in a subtree
+of `shaderc/third_party`.  In that scenario, Glslang's HLSL support
+is automatically enabled.  Shaderc also can be built using a Glslang
+from outside the `shaderc/third_party` tree.  In that case you must
+ensure that that external Glslang is built with HLSL functionality.
+See Glslang's `ENABLE_HLSL` CMake setting.)
+
 1) Check out the source code:
 
 ```sh

--- a/glslc/test/option_dash_fhlsl_offsets.py
+++ b/glslc/test/option_dash_fhlsl_offsets.py
@@ -19,6 +19,7 @@ from placeholder import FileShader
 
 # A GLSL shader with uniforms without explicit bindings.
 GLSL_SHADER = """#version 450
+  layout(set=0, binding=0)
   buffer B { float x; vec3 y; } my_ssbo;
   void main() {
     my_ssbo.x = 1.0;

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -293,6 +293,7 @@ const char kShaderWithUniformsWithoutBindings[] =
 // A GLSL vertex shader with a weirdly packed block.
 const char kGlslShaderWeirdPacking[] =
     R"(#version 450
+       layout(set=0, binding=0)
        buffer B { float x; vec3 foo; } my_ssbo;
        void main() { my_ssbo.x = 1.0; })";
 

--- a/libshaderc_util/CMakeLists.txt
+++ b/libshaderc_util/CMakeLists.txt
@@ -26,6 +26,9 @@ add_library(shaderc_util STATIC
 shaderc_default_compile_options(shaderc_util)
 target_include_directories(shaderc_util
   PUBLIC include PRIVATE ${glslang_SOURCE_DIR})
+# We use parts of Glslang's HLSL compilation interface, which
+# now requires this preprocessor definition.
+add_definitions(-DENABLE_HLSL)
 
 find_package(Threads)
 target_link_libraries(shaderc_util PRIVATE

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -119,6 +119,7 @@ const char kGlslVertShaderNoExplicitLocation[] =
 // A GLSL vertex shader with a weirdly packed block.
 const char kGlslShaderWeirdPacking[] =
     R"(#version 450
+       layout(set = 0, binding = 0)
        buffer B { float x; vec3 foo; } my_ssbo;
        void main() { my_ssbo.x = 1.0; })";
 


### PR DESCRIPTION
Fixes a compilation problem introduced by recent
Glslang changes to optionally build into a very small
GLSL-only binary.

Also fix test cases to have set and binding layout qualifiers on
buffers when compiling for Vulkan.  This rule is now enforced by
Glslang.