### PR TITLE
Use agreed upon include paths for spirv-cross

### DIFF
--- a/libshaderc_spvc/src/spvc_private.h
+++ b/libshaderc_spvc/src/spvc_private.h
@@ -17,9 +17,9 @@
 #include <vector>
 
 #include "shaderc/spvc.h"
-#include "spirv-cross/spirv_glsl.hpp"
-#include "spirv-cross/spirv_hlsl.hpp"
-#include "spirv-cross/spirv_msl.hpp"
+#include <spirv_glsl.hpp>
+#include <spirv_hlsl.hpp>
+#include <spirv_msl.hpp>
 #include "spirv-tools/libspirv.hpp"
 
 // GLSL version produced when none specified nor detected from source.


### PR DESCRIPTION
All other projects using spirv-cross include it using <spirv_msl.hpp>
for example. Follow that convention so we can more easily integrate with
other projects.