### PR TITLE
Improve testing .asm., .nocompat., and .vk. chases

### DIFF
--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -156,8 +156,13 @@ shaders/tesc/water_tess.tesc,False
 shaders/tesc/water_tess.tesc,True
 shaders/vert/basic.vert,False
 shaders/vert/basic.vert,True
+shaders/vulkan/comp/buffer-reference.nocompat.vk.comp,True
 shaders/vulkan/comp/buffer-reference.nocompat.vk.comp.vk,True
+shaders/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp,False
+shaders/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp,True
 shaders/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp.vk,False
 shaders/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp.vk,True
+shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag,False
+shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag,True
 shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag.vk,False
 shaders/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag.vk,True

--- a/spvc/test/run_spirv_cross_tests.py
+++ b/spvc/test/run_spirv_cross_tests.py
@@ -230,7 +230,6 @@ def test_glsl(test_env, shader, filename, optimize):
 
     output = input_shader + filename
     if '.vk.' in filename or '.asm.' in filename:
-        output = input_shader + filename
         status, _ = test_env.run_spvc(
             input_shader, output, flags + ['--vulkan-semantics'])
     else:


### PR DESCRIPTION
.nocompat. indicates that the test is known to be bad for GLSL, and is
skipped in the spirv-cross tests. Skipping these tests removes about
600 cases from the test runs.

.vk. indicates this is a Vulkan test case and .vk. indicates that this
is a SPIR-V based one. Passing in the same flags that the spriv-cross
tests use and handling that the output file will now have a .vk
appended.

Fixes #627