### PR TITLE
Pass in source not target env into spirv-opt

### DIFF
--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -97,7 +97,7 @@ shaderc_spvc_compilation_result_t translate_spirv(
     return result;
   }
 
-  spvtools::Optimizer opt(target_env);
+  spvtools::Optimizer opt(source_env);
   opt.SetMessageConsumer(std::bind(
       consume_spirv_tools_message, result, std::placeholders::_1,
       std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));


### PR DESCRIPTION
The environment should be the same as the source binary, not the
outputted binary.

Fixes #798