### PR TITLE
Remove unsetting compiler check variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,14 +38,12 @@ include(CheckCXXCompilerFlag)
 # These flags are not supported on Windows and some older version of GCC
 # that our bots use.
 # Warning about implicit fallthrough in switch blocks
-unset(COMPILER_SUPPORTS_FALLTHROUGH_WARNING CACHE)
 check_cxx_compiler_flag(-Wimplicit-fallthrough COMPILER_SUPPORTS_FALLTHROUGH_WARNING)
 if (COMPILER_SUPPORTS_FALLTHROUGH_WARNING)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wimplicit-fallthrough")
 endif()
 
 # Warning about extra semi-colons
-unset(COMPILER_SUPPORTS_EXTRA_SEMI_WARNING CACHE)
 check_cxx_compiler_flag(-Wextra-semi COMPILER_SUPPORTS_EXTRA_SEMI_WARNING)
 if (COMPILER_SUPPORTS_EXTRA_SEMI_WARNING)
     add_compile_options("-Wextra-semi")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -84,7 +84,6 @@ if (SHADERC_ENABLE_SPVC)
       set(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS ${DISABLE_EXCEPTIONS} CACHE BOOL "tell SPIRV-Cross not to throw" FORCE)
 
       # Add -fPIC to SPIRV-Cross build, if supported
-      unset(COMPILER_SUPPORTS_PIC CACHE)
       check_cxx_compiler_flag(-fPIC COMPILER_SUPPORTS_PIC)
       if (COMPILER_SUPPORTS_PIC)
         set(CXX_BACK ${CMAKE_CXX_FLAGS})


### PR DESCRIPTION
This does not appear to be standard practice. The results of these
checks would only change if the compiler itself changes, so checking
it on every run is unnecessary.

Fixes #773