### PR TITLE
Rolling 4 dependencies and update known_failures

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '6527fb25482ee16f0ae8c735d1d0c33f7d5f220a',
-  'glslang_revision': '56f61ccceffab3225da20c4751cf03a5884431c2',
-  'googletest_revision': '565f1b848215b77c3732bca345fe76a0431d8b34',
+  'glslang_revision': '664ad418f8455159fb066e9e27d159f191f976a9',
+  'googletest_revision': '3f05f651ae3621db58468153e32016bc1397800b',
   're2_revision': '5bd613749fd530b576b890283bfb6bc6ea6246cb',
   'spirv_headers_revision': '38cafab379e5d16137cb97a485b9385191039b92',
-  'spirv_tools_revision': 'b54d950298001ad689b404b6871a4136d63b3489',
-  'spirv_cross_revision': 'a06997a6a496662c49fefc02bb2421d391b45309',
+  'spirv_tools_revision': '76261e2a7df1fda011a5edd7a894c42b4fa6af95',
+  'spirv_cross_revision': 'b32a1b415043f5ae368e90af7a585770ecd5546e',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -35,6 +35,8 @@ shaders-msl/comp/basic.dispatchbase.comp,False
 shaders-msl/comp/basic.dispatchbase.comp,True
 shaders-msl/comp/basic.dispatchbase.msl11.comp,False
 shaders-msl/comp/basic.dispatchbase.msl11.comp,True
+shaders-msl/comp/basic.dynamic-buffer.msl2.comp,False
+shaders-msl/comp/basic.dynamic-buffer.msl2.comp,True
 shaders-msl/comp/int64.invalid.msl22.comp,False
 shaders-msl/comp/int64.invalid.msl22.comp,True
 shaders-msl/desktop-only/vert/basic.desktop.sso.vert,False


### PR DESCRIPTION
Roll third_party/glslang/ 56f61ccce..664ad418f (2 commits)

https://github.com/KhronosGroup/glslang/compare/56f61ccceffa...664ad418f845

$ git log 56f61ccce..664ad418f --date=short --no-merges --format='%ad %ae %s'
2019-09-05 cepheus Fix #1879: Check for valid variable before checking for unsized arrays.
2019-09-04 greg Update spirv-tools and spriv-headers known good.

Roll third_party/googletest/ 565f1b848..3f05f651a (3 commits)

https://github.com/google/googletest/compare/565f1b848215...3f05f651ae36

$ git log 565f1b848..3f05f651a --date=short --no-merges --format='%ad %ae %s'
2019-09-05 absl-team Googletest export
2019-09-05 absl-team Googletest export
2019-08-29 krystian.kuzniarek Googletest export

Roll third_party/spirv-cross/ a06997a6a..b32a1b415 (16 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/a06997a6a496...b32a1b415043

$ git log a06997a6a..b32a1b415 --date=short --no-merges --format='%ad %ae %s'
2019-09-06 wadetb MSL: Fix array copies to/from interpolators
2019-09-06 post Run format_all.sh.
2019-09-05 post Refactor into stronger types in public API.
2019-09-06 post Add dynamic offsets to C API.
2019-09-06 post Fix some issues on certain compilers.
2019-09-05 cdavis MSL: Support dynamic offsets for buffers in argument buffers.
2019-09-04 cdavis MSL: Force storage images on iOS to use discrete descriptors.
2019-09-05 lifeng.pan Fix ParsedIR::mark_used_as_array_length(uint32_t id)
2019-09-04 post Add test case for interlocks in control flow.
2019-09-04 post Make sure not to propagate loads outside interlock region.
2019-09-04 post Add interlock test for split functions doing begin/end.
2019-09-04 post Deal with complex interlock cases in GLSL.
2019-09-04 post Add test shader for simple case of interlocked callstack.
2019-09-04 post Deal with call stacks when analyzing access.
2019-09-04 post Analyze complex cases for fragment interlocks.
2019-08-04 cdavis Support the SPV_EXT_fragment_shader_interlock extension.

Roll third_party/spirv-tools/ b54d95029..76261e2a7 (10 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/b54d95029800...76261e2a7df1

$ git log b54d95029..76261e2a7 --date=short --no-merges --format='%ad %ae %s'
2019-09-06 stevenperron Replace CubeFaceCoord and CubeFaceIndexAMD (#2840)
2019-09-05 stevenperron Fold Min, Max, and Clamp instructions. (#2836)
2019-09-05 stevenperron Replace uses of SPV_AMD_shader_trinary_minmax extension (#2835)
2019-09-04 zoddicus For WebGPU<->Vulkan optimization, set correct execution environment (#2834)
2019-09-04 40687079+rumblehhh Export SPIRV-Tools targets on installation (#2785)
2019-09-04 jmadill GN: Add Chromium GoogleTest deps. (#2832)
2019-09-03 stevenperron Upadate CHANGES
2019-09-03 greg Instrument: Be sure Float16 capability on when generating float16 null (#2831)
2019-09-03 greg Add --relax-float-ops and --convert-relaxed-to-half (#2808)
2019-09-03 jmadill GN: Make SPIRV-Tools target use public_deps. (#2828)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools