### PR TITLE
Rolling 6 dependencies and update known_failures

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,13 +4,13 @@ vars = {
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
 
-  'effcee_revision' : '6527fb25482ee16f0ae8c735d1d0c33f7d5f220a',
-  'glslang_revision': '664ad418f8455159fb066e9e27d159f191f976a9',
-  'googletest_revision': '3f05f651ae3621db58468153e32016bc1397800b',
+  'effcee_revision' : 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
+  'glslang_revision': 'caca1d1cc46e15814d337498196fe02706d0feb3',
+  'googletest_revision': 'f2fb48c3b3d79a75a88a99fba6576b25d42ec528',
   're2_revision': '5bd613749fd530b576b890283bfb6bc6ea6246cb',
-  'spirv_headers_revision': '38cafab379e5d16137cb97a485b9385191039b92',
-  'spirv_tools_revision': '76261e2a7df1fda011a5edd7a894c42b4fa6af95',
-  'spirv_cross_revision': 'b32a1b415043f5ae368e90af7a585770ecd5546e',
+  'spirv_headers_revision': '601d738723ac381741311c6c98c36d6170be14a2',
+  'spirv_tools_revision': '08fcf8a4abdc7131033e25694be8cb71f5cf1c0e',
+  'spirv_cross_revision': '5431e1da2dc11123750f39a5ba4e5a8c117a0773',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -1,4 +1,5 @@
 shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag,False
+shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders-hlsl/asm/frag/line-directive.line.asm.frag,False
 shaders-hlsl/asm/frag/line-directive.line.asm.frag,True
 shaders-hlsl/comp/num-workgroups-alone.comp,False
@@ -12,6 +13,7 @@ shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
 shaders-hlsl/vert/basic.vert,False
 shaders-hlsl/vert/basic.vert,True
 shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag,False
+shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-3.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-5.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding.asm.comp,False
@@ -37,6 +39,8 @@ shaders-msl/comp/basic.dispatchbase.msl11.comp,False
 shaders-msl/comp/basic.dispatchbase.msl11.comp,True
 shaders-msl/comp/basic.dynamic-buffer.msl2.comp,False
 shaders-msl/comp/basic.dynamic-buffer.msl2.comp,True
+shaders-msl/comp/basic.dynamic-buffer.msl2.invalid.comp,False
+shaders-msl/comp/basic.dynamic-buffer.msl2.invalid.comp,True
 shaders-msl/comp/int64.invalid.msl22.comp,False
 shaders-msl/comp/int64.invalid.msl22.comp,True
 shaders-msl/desktop-only/vert/basic.desktop.sso.vert,False
@@ -93,7 +97,6 @@ shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp,False
 shaders-msl/vulkan/comp/struct-packing-scalar.nocompat.invalid.vk.comp,True
 shaders-msl/vulkan/frag/basic.multiview.nocompat.vk.frag,False
 shaders-msl/vulkan/frag/basic.multiview.nocompat.vk.frag,True
-shaders-msl/vulkan/frag/demote-to-helper.vk.nocompat.msl21.invalid.frag,True
 shaders-msl/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag,False
 shaders-msl/vulkan/frag/scalar-block-layout-ubo-std430.vk.nocompat.invalid.frag,True
 shaders-msl/vulkan/vert/device-group.multiview.viewfromdev.nocompat.vk.vert,False


### PR DESCRIPTION
Roll third_party/effcee/ 6527fb254..cd25ec17e (2 commits)

https://github.com/google/effcee/compare/6527fb25482e...cd25ec17e938

$ git log 6527fb254..cd25ec17e --date=short --no-merges --format='%ad %ae %s'
2019-09-18 dneto Start v2019.1-dev
2019-09-18 dneto Finalize v2019.0

Roll third_party/glslang/ 664ad418f..caca1d1cc (12 commits)

https://github.com/KhronosGroup/glslang/compare/664ad418f845...caca1d1cc46e

$ git log 664ad418f..caca1d1cc --date=short --no-merges --format='%ad %ae %s'
2019-09-17 cepheus SPV_KHR_physical_storage_buffer/SPV: Add GL_EXT_buffer_reference_uvec2
2019-09-16 digit Fix Fuchsia build.
2019-09-18 cepheus README: Fix WASM typos.
2019-09-18 cepheus HLSL: Fix #1903 Catch 0-argument case to constructors.
2019-09-08 jbolz Add GL_EXT_shader_subgroup_extended_types support
2019-08-28 cepheus GLSL: Only require constant for subgroupBroadcast when SPV < 1.5.
2019-08-18 cepheus SPV: Support SPIR-V 1.5; five extensions no longer need OpExtension.
2019-09-09 laddoc Add flags for local size values ( compute shader )
2019-09-13 cepheus SPV 1.5: Switch to the 1.5 header, for SPIR-V 1.5.
2019-09-11 dsinclair Comment out params instead of removing
2019-09-10 dsinclair Remove unused params
2019-09-09 rex.xu Fix incorrect function prototypes of 64-bit findLSB/findMSB

Roll third_party/googletest/ 3f05f651a..f2fb48c3b (9 commits)

https://github.com/google/googletest/compare/3f05f651ae36...f2fb48c3b3d7

$ git log 3f05f651a..f2fb48c3b --date=short --no-merges --format='%ad %ae %s'
2019-09-16 krystian.kuzniarek Googletest export
2019-09-13 misterg Googletest export
2019-09-12 hgsilverman Googletest export
2019-09-11 absl-team Googletest export
2019-09-10 absl-team Googletest export
2019-09-09 absl-team Googletest export
2019-09-06 absl-team Googletest export
2019-09-06 absl-team Googletest export
2019-08-12 krystian.kuzniarek restore mistakenly removed iffs in their explicit form

Roll third_party/spirv-cross/ b32a1b415..5431e1da2 (7 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/b32a1b415043...5431e1da2dc1

$ git log b32a1b415..5431e1da2 --date=short --no-merges --format='%ad %ae %s'
2019-09-19 post Update SPIR-V headers.
2019-09-19 post MSL: Fix 16-bit integer literals.
2019-09-18 rharrison Update external/ to SPIR-V 1.5
2019-09-18 post CMake: Add option to force -fPIC.
2019-09-17 post Fix -Wshorten-64-to-32 warnings.
2019-09-16 post CMake: Add option to skip installation targets.
2019-09-12 post Consider discard and demote as impure statements.

Roll third_party/spirv-headers/ 38cafab37..601d73872 (2 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/38cafab379e5...601d738723ac

$ git log 38cafab37..601d73872 --date=short --no-merges --format='%ad %ae %s'
2019-09-18 cepheus Add SPV_KHR_physical_storage_buffer.
2019-09-13 cepheus SPIR-V 1.5.

Roll third_party/spirv-tools/ 76261e2a7..08fcf8a4a (28 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/76261e2a7df1...08fcf8a4abdc

$ git log 76261e2a7..08fcf8a4a --date=short --no-merges --format='%ad %ae %s'
2019-09-19 ehsannas Fix header include syntax. (#2882)
2019-09-19 stevenperron Handle OpConstantNull in copy-prop-arrays. (#2870)
2019-09-19 dneto Fix comment typo found by protobufs linter (#2884)
2019-09-19 dsinclair Move docs into docs/ folder (#2872)
2019-09-18 dsinclair Add WebGPU SPIR-V Assembler in JavaScript. (#2876)
2019-09-18 dneto Android.mk: Add dependency from optimizer file to amd-shader-ballot-insts.inc (#2883)
2019-09-18 dneto Update SPIRV-Headers in DEPS (#2880)
2019-09-18 afdx  Fix detection of blocks bypassed by new edge (#2874)
2019-09-18 afdx Fix CMake issue related to spirv-fuzz (#2877)
2019-09-18 afdx Add fuzzer pass to replace ids with synonyms (#2857)
2019-09-18 alanbaker Relaxed bitcast with pointers (#2878)
2019-09-17 52076061+digit-google Fix Fuchsia build. (#2868)
2019-09-16 raun.krisch Adding valilidation checks for OpEntryPoint duplicate names and execution mode (#2862)
2019-09-16 alanbaker Extra resource interface validation (#2864)
2019-09-13 alanbaker Split capability tests (#2866)
2019-09-13 alanbaker SPIRV-Tools support for SPIR-V 1.5 (#2865)
2019-09-11 afdx Add fuzzer pass to copy objects (#2853)
2019-09-11 rharrison Handle another case where creating a constant can fail (#2854)
2019-09-11 stevenperron Don't inline function containing OpKill (#2842)
2019-09-11 stevenperron Handle id overflow in wrap op kill. (#2851)
2019-09-11 dneto Assembler: Can't set an ID in instruction without result ID (#2852)
2019-09-10 zoddicus Handle creating a new constant failing gracefully (#2848)
2019-09-10 afdx Rework management of probabilities in spirv-fuzz (#2839)
2019-09-10 afdx Fix add-dead-break and add-dead-continue passes to respect dominance (#2838)
2019-09-10 stevenperron Handle id overflow in the ssa rewriter. (#2845)
2019-09-09 stevenperron Handle id overflow in the constant manager. (#2844)
2019-09-09 alanbaker Add generic builtin validation of target (#2843)
2019-09-09 stevenperron Don't register duplicate decoration in validator. (#2841)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools