### PR TITLE
Rolling 2 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
-  'glslang_revision': 'caca1d1cc46e15814d337498196fe02706d0feb3',
+  'glslang_revision': '973d0e538292c85b7baf9bb5aaf755894429f76a',
   'googletest_revision': 'f2fb48c3b3d79a75a88a99fba6576b25d42ec528',
   're2_revision': '5bd613749fd530b576b890283bfb6bc6ea6246cb',
   'spirv_headers_revision': '601d738723ac381741311c6c98c36d6170be14a2',
-  'spirv_tools_revision': '08fcf8a4abdc7131033e25694be8cb71f5cf1c0e',
+  'spirv_tools_revision': 'f62ee4a4a1a1e38c91e29d4cf1e2195b51551b80',
   'spirv_cross_revision': '5431e1da2dc11123750f39a5ba4e5a8c117a0773',
 }
 


### PR DESCRIPTION
Roll third_party/glslang/ caca1d1cc..973d0e538 (3 commits)

https://github.com/KhronosGroup/glslang/compare/caca1d1cc46e...973d0e538292

$ git log caca1d1cc..973d0e538 --date=short --no-merges --format='%ad %ae %s'
2019-09-20 cepheus GLSL/SPV: Fix #1900: Drop const on literal when doing an object copy.
2019-09-17 kainino use custom es6 modularization instead of MODULARIZE=1
2019-09-17 kainino Separate GLSLANG_WEB (min-size build) and Emscripten options

Roll third_party/spirv-tools/ 08fcf8a4a..f62ee4a4a (8 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/08fcf8a4abdc...f62ee4a4a1a1

$ git log 08fcf8a4a..f62ee4a4a --date=short --no-merges --format='%ad %ae %s'
2019-09-23 dneto Update DEPS: effcee, re2, googletest (#2881)
2019-09-23 dneto Add method comment for opt::Function::WhileEachInst (#2867)
2019-09-20 stevenperron Use OpReturn* in wrap-opkill (#2886)
2019-09-20 afdx Fix to CMakeLists for spirv-fuzz tests (#2888)
2019-09-20 afdx Allow validation during spirv-fuzz replay (#2873)
2019-09-20 afdx Disable long-running fuzzer tests by default (#2887)
2019-09-19 stevenperron Revert "Use OpReturn* in wrap-opkill"
2019-09-19 stevenperron Use OpReturn* in wrap-opkill

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools