### PR TITLE
Rolling 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
-  'glslang_revision': '973d0e538292c85b7baf9bb5aaf755894429f76a',
-  'googletest_revision': 'f2fb48c3b3d79a75a88a99fba6576b25d42ec528',
+  'glslang_revision': '7bc047326e06961c59b785f827026947d81c7f02',
+  'googletest_revision': 'dc1ca9ae4c206434e450ed4ff535ca7c20c79e3c',
   're2_revision': '5bd613749fd530b576b890283bfb6bc6ea6246cb',
-  'spirv_headers_revision': '601d738723ac381741311c6c98c36d6170be14a2',
-  'spirv_tools_revision': 'f62ee4a4a1a1e38c91e29d4cf1e2195b51551b80',
+  'spirv_headers_revision': '842ec90674627ed2ffef609e3cd79d1562eded01',
+  'spirv_tools_revision': '9eb1c9a4c45099c23098d97c5a6a8b35a45a8f25',
   'spirv_cross_revision': '5431e1da2dc11123750f39a5ba4e5a8c117a0773',
 }
 


### PR DESCRIPTION
Roll third_party/glslang/ 973d0e538..7bc047326 (1 commit)

https://github.com/KhronosGroup/glslang/compare/973d0e538292...7bc047326e06

$ git log 973d0e538..7bc047326 --date=short --no-merges --format='%ad %ae %s'
2019-09-18 laddoc Reflection will crash when the VS input symbol defines the same name with FS output symbol

Roll third_party/googletest/ f2fb48c3b..dc1ca9ae4 (7 commits)

https://github.com/google/googletest/compare/f2fb48c3b3d7...dc1ca9ae4c20

$ git log f2fb48c3b..dc1ca9ae4 --date=short --no-merges --format='%ad %ae %s'
2019-09-29 misterg Googletest export
2019-09-27 misterg Googletest export
2019-09-25 absl-team Googletest export
2019-09-25 absl-team Googletest export
2019-09-24 absl-team Googletest export
2019-09-19 absl-team Googletest export
2019-09-27 gennadiycivil Bump llvm version to 4 so brew can work again

Roll third_party/spirv-headers/ 601d73872..842ec9067 (4 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/601d738723ac...842ec9067462

$ git log 601d73872..842ec9067 --date=short --no-merges --format='%ad %ae %s'
2019-09-24 ehsannas Improve the doc on using Bazel.
2019-09-24 rex.xu Bump the SPIR-V version to 1.5
2019-09-23 ehsannas Update documentation.
2019-09-18 ehsannas Add a Bazel build file.

Roll third_party/spirv-tools/ f62ee4a4a..9eb1c9a4c (22 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/f62ee4a4a1a1...9eb1c9a4c450

$ git log f62ee4a4a..9eb1c9a4c --date=short --no-merges --format='%ad %ae %s'
2019-10-01 stevenperron Add continue construct analysis to struct cfg analysis (#2922)
2019-09-27 stevenperron Record trailing line dbg instructions (#2926)
2019-09-27 rharrison Add removing references to debug instructions when removing them (#2923)
2019-09-27 paulthomson spirv-fuzz: allow interestingness script arguments (#2925)
2019-09-27 ehsannas Add Kokoro bots for building with Bazel. (#2914)
2019-09-27 alanbaker Refactor the InstructionPass (#2924)
2019-09-26 afdx spirv-fuzz: do not allow a dead break to target an unreachable block (#2917)
2019-09-26 afdx spirv-fuzz: preserve some analyses when permuting blocks (#2918)
2019-09-25 alanbaker Only allow previously declared forward refs in structs (#2920)
2019-09-25 stevenperron Handle id overflow in wrap-opkill (#2916)
2019-09-25 afdx spirv-fuzz: do not replace struct indices with synonyms (#2915)
2019-09-25 afdx spirv-fuzz: Fixes to preconditions for adding dead break/continue edges (#2904)
2019-09-25 afdx spirv-fuzz: do not replace a pointer argument to a function call with a synonym (#2901)
2019-09-25 afdx spirv-fuzz: do not replace boolean constant argument to OpPhi instruction (#2903)
2019-09-24 alanbaker Remove validate_datarules.cpp (#2911)
2019-09-24 stevenperron Handle extract with no indexes (#2910)
2019-09-24 ehsannas Add Bazel build configuration. (#2891)
2019-09-24 stevenperron Handle id overflow in convert local access chains (#2908)
2019-09-24 dsinclair Add OpCopyMemory test to SVA. (#2885)
2019-09-23 dsinclair Add missing GN dependency (#2899)
2019-09-23 afdx Employ the "swarm testing" idea in spirv-fuzz (#2890)
2019-09-23 afdx Fix operand index in spirv-fuzz (#2895)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools