### PR TITLE
Add spvc compiler to returned result

### DIFF
--- a/libshaderc_spvc/CMakeLists.txt
+++ b/libshaderc_spvc/CMakeLists.txt
@@ -62,6 +62,7 @@ set(SPVC_LIBS
   spirv-cross-glsl
   spirv-cross-hlsl
   spirv-cross-msl
+  spirv-cross-reflect
 )
 
 target_link_libraries(shaderc_spvc PRIVATE ${SPVC_LIBS})
@@ -69,7 +70,7 @@ target_link_libraries(shaderc_spvc_shared PRIVATE ${SPVC_LIBS})
 
 shaderc_add_tests(
   TEST_PREFIX shaderc
-  LINK_LIBS shaderc_spvc
+  LINK_LIBS shaderc_spvc ${SPVC_LIBS}
   INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${SPIRV-Cross_SOURCE_DIR}/..
   TEST_NAMES
     spvc
@@ -79,7 +80,7 @@ shaderc_add_tests(
 
 shaderc_add_tests(
   TEST_PREFIX shaderc_shared
-  LINK_LIBS shaderc_spvc_shared SPIRV-Tools SPIRV-Tools-opt
+  LINK_LIBS shaderc_spvc_shared ${SPVC_LIBS} SPIRV-Tools SPIRV-Tools-opt
   INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${SPIRV-Cross_SOURCE_DIR}/..
   TEST_NAMES
     spvc
@@ -108,7 +109,7 @@ endif(SHADERC_ENABLE_INSTALL)
 
 shaderc_add_tests(
   TEST_PREFIX shaderc_spvc_combined
-  LINK_LIBS shaderc_spvc_combined ${CMAKE_THREAD_LIBS_INIT} shaderc_util
+  LINK_LIBS shaderc_spvc_combined ${SPVC_LIBS} ${CMAKE_THREAD_LIBS_INIT} shaderc_util
   INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${spirv-tools_SOURCE_DIR}/include
   TEST_NAMES
     spvc

--- a/libshaderc_spvc/src/common_shaders_for_test.h
+++ b/libshaderc_spvc/src/common_shaders_for_test.h
@@ -99,6 +99,10 @@ const uint32_t kWebGPUShaderBinary[] = {
     0x00000004, 0x000100FD, 0x00010038,
 };
 
+const char* kInvalidShader = "";
+
+const uint32_t kInvalidShaderBinary[] = {0x07230203};
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -289,8 +289,16 @@ shaderc_spvc_compilation_result_t shaderc_spvc_compile_into_vulkan(
     return result;
   }
 
-  // No generation step since output for this compile method is the binary
-  // SPIR-V.
+  // No actual generation since output for this compile method is the binary
+  // SPIR-V, but need to produce a compiler so that reflection can be performed
+  result = spvc_private::generate_vulkan_shader(result->binary_output.data(),
+                                                result->binary_output.size(),
+                                                options, result);
+  if (result->status != shaderc_compilation_status_success) {
+    result->messages.append(
+        "Unable to generate compiler for reflection of Vulkan shader.\n");
+  }
+
   return result;
 }
 

--- a/libshaderc_spvc/src/spvc_private.h
+++ b/libshaderc_spvc/src/spvc_private.h
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 #include <cstdint>
-#include <string>
-#include <vector>
-
-#include "spvc/spvc.h"
 #include <spirv_glsl.hpp>
 #include <spirv_hlsl.hpp>
 #include <spirv_msl.hpp>
+#include <spirv_reflect.hpp>
+#include <string>
+#include <vector>
+
 #include "spirv-tools/libspirv.hpp"
+#include "spvc/spvc.h"
 
 // GLSL version produced when none specified nor detected from source.
 #define DEFAULT_GLSL_VERSION 450
@@ -34,6 +35,7 @@ struct shaderc_spvc_compilation_result {
   std::string messages;
   shaderc_compilation_status status =
       shaderc_compilation_status_null_result_object;
+  std::unique_ptr<spirv_cross::Compiler> compiler;
 };
 
 struct shaderc_spvc_compile_options {
@@ -114,6 +116,14 @@ shaderc_spvc_compilation_result_t generate_hlsl_shader(
 // Handles correctly setting up the SPIRV-Cross compiler based on the options
 // and then envoking it.
 shaderc_spvc_compilation_result_t generate_msl_shader(
+    const uint32_t* source, size_t source_len,
+    shaderc_spvc_compile_options_t options,
+    shaderc_spvc_compilation_result_t result);
+
+// Given a Vulkan SPIR-V shader and set of options, generate a Vulkan shader.
+// Is a No-op from the perspective of converting the shader, but setup a
+// SPIRV-Cross compiler to be used for reflection later.
+shaderc_spvc_compilation_result_t generate_vulkan_shader(
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result);

--- a/libshaderc_spvc/src/spvc_test.cc
+++ b/libshaderc_spvc/src/spvc_test.cc
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "spvc/spvc.h"
+
 #include <gtest/gtest.h>
+
 #include <thread>
 
 #include "common_shaders_for_test.h"
-#include "spvc/spvc.h"
+#include "spvc_private.h"
 
 namespace {
 
@@ -51,7 +54,7 @@ TEST(Init, MultipleThreadsCalling) {
 }
 #endif
 
-TEST(Compile, Glsl) {
+TEST(Compile, ValidShaderIntoGlslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -62,13 +65,32 @@ TEST(Compile, Glsl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Hlsl) {
+TEST(Compile, InvalidShaderIntoGlslPasses) {
+  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
+  shaderc_spvc_compile_options_t options =
+      shaderc_spvc_compile_options_initialize();
+
+  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_glsl(
+      compiler, kInvalidShaderBinary,
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
+  ASSERT_NE(nullptr, result);
+  EXPECT_NE(shaderc_compilation_status_success,
+            shaderc_spvc_result_get_status(result));
+  EXPECT_EQ(result->compiler.get(), nullptr);
+
+  shaderc_spvc_result_release(result);
+  shaderc_spvc_compile_options_release(options);
+  shaderc_spvc_compiler_release(compiler);
+}
+
+TEST(Compile, ValidShaderIntoHlslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -79,13 +101,32 @@ TEST(Compile, Hlsl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Msl) {
+TEST(Compile, InvalidShaderIntoHlslPasses) {
+  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
+  shaderc_spvc_compile_options_t options =
+      shaderc_spvc_compile_options_initialize();
+
+  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_hlsl(
+      compiler, kInvalidShaderBinary,
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
+  ASSERT_NE(nullptr, result);
+  EXPECT_NE(shaderc_compilation_status_success,
+            shaderc_spvc_result_get_status(result));
+  EXPECT_EQ(result->compiler.get(), nullptr);
+
+  shaderc_spvc_result_release(result);
+  shaderc_spvc_compile_options_release(options);
+  shaderc_spvc_compiler_release(compiler);
+}
+
+TEST(Compile, ValidShaderIntoMslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -96,13 +137,32 @@ TEST(Compile, Msl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Vulkan) {
+TEST(Compile, InvalidShaderIntoMslPasses) {
+  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
+  shaderc_spvc_compile_options_t options =
+      shaderc_spvc_compile_options_initialize();
+
+  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_msl(
+      compiler, kInvalidShaderBinary,
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
+  ASSERT_NE(nullptr, result);
+  EXPECT_NE(shaderc_compilation_status_success,
+            shaderc_spvc_result_get_status(result));
+  EXPECT_EQ(result->compiler.get(), nullptr);
+
+  shaderc_spvc_result_release(result);
+  shaderc_spvc_compile_options_release(options);
+  shaderc_spvc_compiler_release(compiler);
+}
+
+TEST(Compile, ValidShaderIntoVulkanPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -113,10 +173,29 @@ TEST(Compile, Vulkan) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-}  // anonymous namespace
+TEST(Compile, InvalidShaderIntoVulkanPasses) {
+  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
+  shaderc_spvc_compile_options_t options =
+      shaderc_spvc_compile_options_initialize();
+
+  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_vulkan(
+      compiler, kInvalidShaderBinary,
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
+  ASSERT_NE(nullptr, result);
+  EXPECT_NE(shaderc_compilation_status_success,
+            shaderc_spvc_result_get_status(result));
+  EXPECT_EQ(result->compiler.get(), nullptr);
+
+  shaderc_spvc_result_release(result);
+  shaderc_spvc_compile_options_release(options);
+  shaderc_spvc_compiler_release(compiler);
+}
+
+}  // namespace

--- a/libshaderc_spvc/src/spvc_webgpu_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_test.cc
@@ -18,10 +18,11 @@
 
 #include "common_shaders_for_test.h"
 #include "spvc/spvc.h"
+#include "spvc_private.h"
 
 namespace {
 
-TEST(Compile, Glsl) {
+TEST(Compile, ValidShaderIntoGlslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -37,13 +38,14 @@ TEST(Compile, Glsl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Hlsl) {
+TEST(Compile, ValidShaderIntoHlslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -59,13 +61,14 @@ TEST(Compile, Hlsl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Msl) {
+TEST(Compile, ValidShaderIntoMslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -81,13 +84,14 @@ TEST(Compile, Msl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Vulkan) {
+TEST(Compile, ValidShaderIntoVulkanPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -103,6 +107,7 @@ TEST(Compile, Vulkan) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);


### PR DESCRIPTION
Retains the compiler used for generating the platform shader in the
result. This will allow future patches to build up the reflection API,
which will require having access to the compiler.

Part of #818, #819, and #820