### PR TITLE
Revert "Add spvc compiler to returned result"

### DIFF
--- a/libshaderc_spvc/CMakeLists.txt
+++ b/libshaderc_spvc/CMakeLists.txt
@@ -62,7 +62,6 @@ set(SPVC_LIBS
   spirv-cross-glsl
   spirv-cross-hlsl
   spirv-cross-msl
-  spirv-cross-reflect
 )
 
 target_link_libraries(shaderc_spvc PRIVATE ${SPVC_LIBS})
@@ -70,7 +69,7 @@ target_link_libraries(shaderc_spvc_shared PRIVATE ${SPVC_LIBS})
 
 shaderc_add_tests(
   TEST_PREFIX shaderc
-  LINK_LIBS shaderc_spvc ${SPVC_LIBS}
+  LINK_LIBS shaderc_spvc
   INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${SPIRV-Cross_SOURCE_DIR}/..
   TEST_NAMES
     spvc
@@ -80,7 +79,7 @@ shaderc_add_tests(
 
 shaderc_add_tests(
   TEST_PREFIX shaderc_shared
-  LINK_LIBS shaderc_spvc_shared ${SPVC_LIBS} SPIRV-Tools SPIRV-Tools-opt
+  LINK_LIBS shaderc_spvc_shared SPIRV-Tools SPIRV-Tools-opt
   INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${SPIRV-Cross_SOURCE_DIR}/..
   TEST_NAMES
     spvc
@@ -109,7 +108,7 @@ endif(SHADERC_ENABLE_INSTALL)
 
 shaderc_add_tests(
   TEST_PREFIX shaderc_spvc_combined
-  LINK_LIBS shaderc_spvc_combined ${SPVC_LIBS} ${CMAKE_THREAD_LIBS_INIT} shaderc_util
+  LINK_LIBS shaderc_spvc_combined ${CMAKE_THREAD_LIBS_INIT} shaderc_util
   INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${spirv-tools_SOURCE_DIR}/include
   TEST_NAMES
     spvc

--- a/libshaderc_spvc/src/common_shaders_for_test.h
+++ b/libshaderc_spvc/src/common_shaders_for_test.h
@@ -99,10 +99,6 @@ const uint32_t kWebGPUShaderBinary[] = {
     0x00000004, 0x000100FD, 0x00010038,
 };
 
-const char* kInvalidShader = "";
-
-const uint32_t kInvalidShaderBinary[] = {0x07230203};
-
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -289,16 +289,8 @@ shaderc_spvc_compilation_result_t shaderc_spvc_compile_into_vulkan(
     return result;
   }
 
-  // No actual generation since output for this compile method is the binary
-  // SPIR-V, but need to produce a compiler so that reflection can be performed
-  result = spvc_private::generate_vulkan_shader(result->binary_output.data(),
-                                                result->binary_output.size(),
-                                                options, result);
-  if (result->status != shaderc_compilation_status_success) {
-    result->messages.append(
-        "Unable to generate compiler for reflection of Vulkan shader.\n");
-  }
-
+  // No generation step since output for this compile method is the binary
+  // SPIR-V.
   return result;
 }
 

--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -177,15 +177,14 @@ shaderc_spvc_compilation_result_t generate_glsl_shader(
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result) {
-  spirv_cross::CompilerGLSL* compiler =
-      new (std::nothrow) spirv_cross::CompilerGLSL(source, source_len);
+  std::unique_ptr<spirv_cross::CompilerGLSL> compiler(
+      new (std::nothrow) spirv_cross::CompilerGLSL(source, source_len));
   if (!compiler) {
     result->messages.append(
         "Unable to initialize SPIRV-Cross GLSL compiler.\n");
     result->status = shaderc_compilation_status_compilation_error;
     return result;
   }
-  result->compiler.reset(compiler);
 
   if (options->glsl.version == 0) {
     // no version requested, was one detected in source?
@@ -217,7 +216,6 @@ shaderc_spvc_compilation_result_t generate_glsl_shader(
 
     if (stage_count != 1) {
       result->status = shaderc_compilation_status_compilation_error;
-      result->compiler.reset();
       if (stage_count == 0) {
         result->messages.append("There is no entry point with name: " +
                                 options->entry_point);
@@ -277,11 +275,10 @@ shaderc_spvc_compilation_result_t generate_glsl_shader(
 
   compiler->set_common_options(options->glsl);
 
-  result = generate_shader(compiler, result);
+  result = generate_shader(compiler.get(), result);
   if (result->status != shaderc_compilation_status_success) {
     result->messages.append("Compilation failed.  Partial source:\n");
     result->messages.append(compiler->get_partial_source());
-    result->compiler.reset();
   }
 
   return result;
@@ -291,24 +288,22 @@ shaderc_spvc_compilation_result_t generate_hlsl_shader(
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result) {
-  spirv_cross::CompilerHLSL* compiler =
-      new (std::nothrow) spirv_cross::CompilerHLSL(source, source_len);
+  std::unique_ptr<spirv_cross::CompilerHLSL> compiler(
+      new (std::nothrow) spirv_cross::CompilerHLSL(source, source_len));
   if (!compiler) {
     result->messages.append(
         "Unable to initialize SPIRV-Cross HLSL compiler.\n");
     result->status = shaderc_compilation_status_compilation_error;
     return result;
   }
-  result->compiler.reset(compiler);
 
   compiler->set_common_options(options->glsl);
   compiler->set_hlsl_options(options->hlsl);
 
-  result = generate_shader(compiler, result);
+  result = generate_shader(compiler.get(), result);
   if (result->status != shaderc_compilation_status_success) {
     result->messages.append("Compilation failed.  Partial source:\n");
     result->messages.append(compiler->get_partial_source());
-    result->compiler.reset();
   }
 
   return result;
@@ -318,44 +313,24 @@ shaderc_spvc_compilation_result_t generate_msl_shader(
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result) {
-  spirv_cross::CompilerMSL* compiler =
-      new (std::nothrow) spirv_cross::CompilerMSL(source, source_len);
+  std::unique_ptr<spirv_cross::CompilerMSL> compiler(
+      new (std::nothrow) spirv_cross::CompilerMSL(source, source_len));
   if (!compiler) {
     result->messages.append("Unable to initialize SPIRV-Cross MSL compiler.\n");
     result->status = shaderc_compilation_status_compilation_error;
     return result;
   }
-  result->compiler.reset(compiler);
 
   compiler->set_common_options(options->glsl);
   compiler->set_msl_options(options->msl);
   for (auto i : options->msl_discrete_descriptor_sets)
     compiler->add_discrete_descriptor_set(i);
 
-  result = generate_shader(compiler, result);
+  result = generate_shader(compiler.get(), result);
   if (result->status != shaderc_compilation_status_success) {
     result->messages.append("Compilation failed.  Partial source:\n");
     result->messages.append(compiler->get_partial_source());
-    result->compiler.reset();
   }
-
-  return result;
-}
-
-shaderc_spvc_compilation_result_t generate_vulkan_shader(
-    const uint32_t* source, size_t source_len,
-    shaderc_spvc_compile_options_t options,
-    shaderc_spvc_compilation_result_t result) {
-  spirv_cross::CompilerReflection* compiler =
-      new (std::nothrow) spirv_cross::CompilerReflection(source, source_len);
-  if (!compiler) {
-    result->messages.append(
-        "Unable to initialize SPIRV-Cross reflection "
-        "compiler.\n");
-    result->status = shaderc_compilation_status_compilation_error;
-    return result;
-  }
-  result->compiler.reset(compiler);
 
   return result;
 }

--- a/libshaderc_spvc/src/spvc_private.h
+++ b/libshaderc_spvc/src/spvc_private.h
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 #include <cstdint>
-#include <spirv_glsl.hpp>
-#include <spirv_hlsl.hpp>
-#include <spirv_msl.hpp>
-#include <spirv_reflect.hpp>
 #include <string>
 #include <vector>
 
-#include "spirv-tools/libspirv.hpp"
 #include "spvc/spvc.h"
+#include <spirv_glsl.hpp>
+#include <spirv_hlsl.hpp>
+#include <spirv_msl.hpp>
+#include "spirv-tools/libspirv.hpp"
 
 // GLSL version produced when none specified nor detected from source.
 #define DEFAULT_GLSL_VERSION 450
@@ -35,7 +34,6 @@ struct shaderc_spvc_compilation_result {
   std::string messages;
   shaderc_compilation_status status =
       shaderc_compilation_status_null_result_object;
-  std::unique_ptr<spirv_cross::Compiler> compiler;
 };
 
 struct shaderc_spvc_compile_options {
@@ -116,14 +114,6 @@ shaderc_spvc_compilation_result_t generate_hlsl_shader(
 // Handles correctly setting up the SPIRV-Cross compiler based on the options
 // and then envoking it.
 shaderc_spvc_compilation_result_t generate_msl_shader(
-    const uint32_t* source, size_t source_len,
-    shaderc_spvc_compile_options_t options,
-    shaderc_spvc_compilation_result_t result);
-
-// Given a Vulkan SPIR-V shader and set of options, generate a Vulkan shader.
-// Is a No-op from the perspective of converting the shader, but setup a
-// SPIRV-Cross compiler to be used for reflection later.
-shaderc_spvc_compilation_result_t generate_vulkan_shader(
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result);

--- a/libshaderc_spvc/src/spvc_test.cc
+++ b/libshaderc_spvc/src/spvc_test.cc
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "spvc/spvc.h"
-
 #include <gtest/gtest.h>
-
 #include <thread>
 
 #include "common_shaders_for_test.h"
-#include "spvc_private.h"
+#include "spvc/spvc.h"
 
 namespace {
 
@@ -54,7 +51,7 @@ TEST(Init, MultipleThreadsCalling) {
 }
 #endif
 
-TEST(Compile, ValidShaderIntoGlslPasses) {
+TEST(Compile, Glsl) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -65,32 +62,13 @@ TEST(Compile, ValidShaderIntoGlslPasses) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
-  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, InvalidShaderIntoGlslPasses) {
-  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
-  shaderc_spvc_compile_options_t options =
-      shaderc_spvc_compile_options_initialize();
-
-  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_glsl(
-      compiler, kInvalidShaderBinary,
-      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
-  ASSERT_NE(nullptr, result);
-  EXPECT_NE(shaderc_compilation_status_success,
-            shaderc_spvc_result_get_status(result));
-  EXPECT_EQ(result->compiler.get(), nullptr);
-
-  shaderc_spvc_result_release(result);
-  shaderc_spvc_compile_options_release(options);
-  shaderc_spvc_compiler_release(compiler);
-}
-
-TEST(Compile, ValidShaderIntoHlslPasses) {
+TEST(Compile, Hlsl) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -101,32 +79,13 @@ TEST(Compile, ValidShaderIntoHlslPasses) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
-  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, InvalidShaderIntoHlslPasses) {
-  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
-  shaderc_spvc_compile_options_t options =
-      shaderc_spvc_compile_options_initialize();
-
-  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_hlsl(
-      compiler, kInvalidShaderBinary,
-      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
-  ASSERT_NE(nullptr, result);
-  EXPECT_NE(shaderc_compilation_status_success,
-            shaderc_spvc_result_get_status(result));
-  EXPECT_EQ(result->compiler.get(), nullptr);
-
-  shaderc_spvc_result_release(result);
-  shaderc_spvc_compile_options_release(options);
-  shaderc_spvc_compiler_release(compiler);
-}
-
-TEST(Compile, ValidShaderIntoMslPasses) {
+TEST(Compile, Msl) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -137,32 +96,13 @@ TEST(Compile, ValidShaderIntoMslPasses) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
-  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, InvalidShaderIntoMslPasses) {
-  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
-  shaderc_spvc_compile_options_t options =
-      shaderc_spvc_compile_options_initialize();
-
-  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_msl(
-      compiler, kInvalidShaderBinary,
-      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
-  ASSERT_NE(nullptr, result);
-  EXPECT_NE(shaderc_compilation_status_success,
-            shaderc_spvc_result_get_status(result));
-  EXPECT_EQ(result->compiler.get(), nullptr);
-
-  shaderc_spvc_result_release(result);
-  shaderc_spvc_compile_options_release(options);
-  shaderc_spvc_compiler_release(compiler);
-}
-
-TEST(Compile, ValidShaderIntoVulkanPasses) {
+TEST(Compile, Vulkan) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -173,29 +113,10 @@ TEST(Compile, ValidShaderIntoVulkanPasses) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
-  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, InvalidShaderIntoVulkanPasses) {
-  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
-  shaderc_spvc_compile_options_t options =
-      shaderc_spvc_compile_options_initialize();
-
-  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_vulkan(
-      compiler, kInvalidShaderBinary,
-      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
-  ASSERT_NE(nullptr, result);
-  EXPECT_NE(shaderc_compilation_status_success,
-            shaderc_spvc_result_get_status(result));
-  EXPECT_EQ(result->compiler.get(), nullptr);
-
-  shaderc_spvc_result_release(result);
-  shaderc_spvc_compile_options_release(options);
-  shaderc_spvc_compiler_release(compiler);
-}
-
-}  // namespace
+}  // anonymous namespace

--- a/libshaderc_spvc/src/spvc_webgpu_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_test.cc
@@ -18,11 +18,10 @@
 
 #include "common_shaders_for_test.h"
 #include "spvc/spvc.h"
-#include "spvc_private.h"
 
 namespace {
 
-TEST(Compile, ValidShaderIntoGlslPasses) {
+TEST(Compile, Glsl) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -38,14 +37,13 @@ TEST(Compile, ValidShaderIntoGlslPasses) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
-  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, ValidShaderIntoHlslPasses) {
+TEST(Compile, Hlsl) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -61,14 +59,13 @@ TEST(Compile, ValidShaderIntoHlslPasses) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
-  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, ValidShaderIntoMslPasses) {
+TEST(Compile, Msl) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -84,14 +81,13 @@ TEST(Compile, ValidShaderIntoMslPasses) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
-  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, ValidShaderIntoVulkanPasses) {
+TEST(Compile, Vulkan) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -107,7 +103,6 @@ TEST(Compile, ValidShaderIntoVulkanPasses) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
-  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);


### PR DESCRIPTION
Reverts google/shaderc#821

This is needed because this PR exposed multiple issues related to spirv_cross inclusion. Specific exceptions can be included via header usage and issues with importing the reflect classes. I am going to roll this back, and investigate locally.