### PR TITLE
Add spvc compiler to returned result

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -136,7 +136,10 @@ component("libshaderc_spvc") {
     ":shaderc_util_public",
   ]
 
-  defines = [ "SHADERC_IMPLEMENTATION" ]
+  defines = [
+    "SHADERC_IMPLEMENTATION",
+    "SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS"
+  ]
   if (shaderc_enable_spvc_parser) {
     defines += [ "SHADERC_ENABLE_SPVC_PARSER=1" ]
   }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,13 @@ include(cmake/setup_build.cmake)
 include(cmake/utils.cmake)
 include(CheckCXXCompilerFlag)
 
+set(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS ${DISABLE_EXCEPTIONS} CACHE BOOL "Coupling SPIRV-Cross exception conversion to DISABLE_EXCEPTIONS" FORCE)
+if(DISABLE_EXCEPTIONS)
+  # Need to set additional values here, since some of the wrapped code occurs in
+  # .h/.hpp files, so maybe included outside of the library.
+ add_definitions(-DSPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
+endif()
+
 # These flags are not supported on Windows and some older version of GCC
 # that our bots use.
 # Warning about implicit fallthrough in switch blocks

--- a/libshaderc_spvc/CMakeLists.txt
+++ b/libshaderc_spvc/CMakeLists.txt
@@ -1,9 +1,18 @@
 project(libshaderc)
 
+find_package(Threads)
+
 set(SPIRV_TOOLS "SPIRV-Tools")
-# Even though shaderc.hpp is a headers-only library, adding
-# a dependency here will force clients of the library to rebuild
-# when it changes.
+set(SPVC_LIBS
+  ${CMAKE_THREAD_LIBS_INIT}
+  SPIRV-Tools
+  SPIRV-Tools-opt
+  spirv-cross-glsl
+  spirv-cross-hlsl
+  spirv-cross-msl
+  spirv-cross-reflect
+)
+
 set(SPVC_SOURCES
   include/spvc/spvc.h
   include/spvc/spvc.hpp
@@ -29,13 +38,13 @@ target_include_directories(shaderc_spvc
   ${spirv-tools_SOURCE_DIR}/include
   ${spirv-tools_SOURCE_DIR}/
   ${CMAKE_CURRENT_BINARY_DIR}/../third_party/spirv-tools/)
+target_link_libraries(shaderc_spvc PRIVATE ${SPVC_LIBS})
 
 if(SHADERC_ENABLE_SPVC_PARSER)
   target_compile_definitions(shaderc_spvc
       PRIVATE SHADERC_ENABLE_SPVC_PARSER=1
   )
 endif()
-
 
 add_library(shaderc_spvc_shared SHARED ${SPVC_SOURCES})
 add_dependencies(shaderc_spvc_shared ${SPIRV_TOOLS}-shared)
@@ -46,8 +55,13 @@ target_include_directories(shaderc_spvc_shared
   ${shaderc_SOURCE_DIR}/libshaderc_util/include
   ${spirv-tools_SOURCE_DIR}/include
   ${spirv-tools_SOURCE_DIR}/
-  ${SPIRV-Cross_SOURCE_DIR}/..
   ${CMAKE_CURRENT_BINARY_DIR}/../third_party/spirv-tools/)
+target_link_libraries(shaderc_spvc_shared PRIVATE ${SPVC_LIBS})
+set_target_properties(shaderc_spvc_shared PROPERTIES SOVERSION 1)
+target_compile_definitions(shaderc_spvc_shared
+    PRIVATE SHADERC_IMPLEMENTATION
+    PUBLIC SHADERC_SHAREDLIB
+)
 
 if(SHADERC_ENABLE_SPVC_PARSER)
   target_compile_definitions(shaderc_spvc_shared
@@ -61,13 +75,6 @@ else()
       PUBLIC SHADERC_SHAREDLIB
   )
 endif()
-
-if (DISABLE_EXCEPTIONS)
-  target_compile_definitions(shaderc_spvc PRIVATE SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
-  target_compile_definitions(shaderc_spvc_shared PRIVATE SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS)
-endif (DISABLE_EXCEPTIONS)
-
-set_target_properties(shaderc_spvc_shared PROPERTIES SOVERSION 1)
 
 if(SHADERC_ENABLE_INSTALL)
   install(
@@ -83,22 +90,9 @@ if(SHADERC_ENABLE_INSTALL)
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif(SHADERC_ENABLE_INSTALL)
 
-find_package(Threads)
-set(SPVC_LIBS
-  ${CMAKE_THREAD_LIBS_INIT}
-  SPIRV-Tools
-  SPIRV-Tools-opt
-  spirv-cross-glsl
-  spirv-cross-hlsl
-  spirv-cross-msl
-)
-
-target_link_libraries(shaderc_spvc PRIVATE ${SPVC_LIBS})
-target_link_libraries(shaderc_spvc_shared PRIVATE ${SPVC_LIBS})
-
 shaderc_add_tests(
   TEST_PREFIX shaderc
-  LINK_LIBS shaderc_spvc
+  LINK_LIBS shaderc_spvc ${SPVC_LIBS}
   INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${SPIRV-Cross_SOURCE_DIR}/..
   TEST_NAMES
     spvc
@@ -108,7 +102,7 @@ shaderc_add_tests(
 
 shaderc_add_tests(
   TEST_PREFIX shaderc_shared
-  LINK_LIBS shaderc_spvc_shared SPIRV-Tools SPIRV-Tools-opt
+  LINK_LIBS shaderc_spvc_shared ${SPVC_LIBS} SPIRV-Tools SPIRV-Tools-opt
   INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${SPIRV-Cross_SOURCE_DIR}/..
   TEST_NAMES
     spvc
@@ -137,7 +131,7 @@ endif(SHADERC_ENABLE_INSTALL)
 
 shaderc_add_tests(
   TEST_PREFIX shaderc_spvc_combined
-  LINK_LIBS shaderc_spvc_combined ${CMAKE_THREAD_LIBS_INIT} shaderc_util
+  LINK_LIBS shaderc_spvc_combined ${SPVC_LIBS} ${CMAKE_THREAD_LIBS_INIT} shaderc_util
   INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${spirv-tools_SOURCE_DIR}/include
   TEST_NAMES
     spvc

--- a/libshaderc_spvc/src/common_shaders_for_test.h
+++ b/libshaderc_spvc/src/common_shaders_for_test.h
@@ -99,6 +99,10 @@ const uint32_t kWebGPUShaderBinary[] = {
     0x00000004, 0x000100FD, 0x00010038,
 };
 
+const char* kInvalidShader = "";
+
+const uint32_t kInvalidShaderBinary[] = {0x07230203};
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -294,8 +294,16 @@ shaderc_spvc_compilation_result_t shaderc_spvc_compile_into_vulkan(
     return result;
   }
 
-  // No generation step since output for this compile method is the binary
-  // SPIR-V.
+  // No actual generation since output for this compile method is the binary
+  // SPIR-V, but need to produce a compiler so that reflection can be performed
+  result = spvc_private::generate_vulkan_shader(result->binary_output.data(),
+                                                result->binary_output.size(),
+                                                options, result);
+  if (result->status != shaderc_compilation_status_success) {
+    result->messages.append(
+        "Unable to generate compiler for reflection of Vulkan shader.\n");
+  }
+
   return result;
 }
 

--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -180,14 +180,15 @@ shaderc_spvc_compilation_result_t generate_glsl_shader(
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result) {
-  std::unique_ptr<spirv_cross::CompilerGLSL> compiler(
-      new (std::nothrow) spirv_cross::CompilerGLSL(source, source_len));
+  spirv_cross::CompilerGLSL* compiler =
+      new (std::nothrow) spirv_cross::CompilerGLSL(source, source_len);
   if (!compiler) {
     result->messages.append(
         "Unable to initialize SPIRV-Cross GLSL compiler.\n");
     result->status = shaderc_compilation_status_compilation_error;
     return result;
   }
+  result->compiler.reset(compiler);
 
   if (options->glsl.version == 0) {
     // no version requested, was one detected in source?
@@ -219,6 +220,7 @@ shaderc_spvc_compilation_result_t generate_glsl_shader(
 
     if (stage_count != 1) {
       result->status = shaderc_compilation_status_compilation_error;
+      result->compiler.reset();
       if (stage_count == 0) {
         result->messages.append("There is no entry point with name: " +
                                 options->entry_point);
@@ -278,10 +280,11 @@ shaderc_spvc_compilation_result_t generate_glsl_shader(
 
   compiler->set_common_options(options->glsl);
 
-  result = generate_shader(compiler.get(), result);
+  result = generate_shader(compiler, result);
   if (result->status != shaderc_compilation_status_success) {
     result->messages.append("Compilation failed.  Partial source:\n");
     result->messages.append(compiler->get_partial_source());
+    result->compiler.reset();
   }
 
   return result;
@@ -291,7 +294,7 @@ shaderc_spvc_compilation_result_t generate_hlsl_shader(
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result) {
-  std::unique_ptr<spirv_cross::CompilerHLSL> compiler;
+  spirv_cross::CompilerHLSL* compiler;
 
 // spvc IR generation is under development, for now run spirv-cross
 // compiler(SHADERC_ENABLE_SPVC_PARSER is OFF by default)
@@ -319,15 +322,15 @@ shaderc_spvc_compilation_result_t generate_hlsl_shader(
   }
   // TODO (sarahM0): replace this error message with following when spvc IR
   // generation is complete:
-  // compiler.reset(new spirv_cross::CompilerHLSL(ir));
+  // compiler = new (std::nothrow) spirv_cross::CompilerHLSL(ir);
   result->messages.append(
       "Expected failure due to incomplete spvc IR generation "
       "implementation.\n");
   result->status = shaderc_compilation_status_compilation_error;
   return result;
 #else
-  compiler.reset(new (std::nothrow)
-                     spirv_cross::CompilerHLSL(source, source_len));
+  compiler = new (std::nothrow)
+                     spirv_cross::CompilerHLSL(source, source_len);
 #endif
 
   if (!compiler) {
@@ -336,14 +339,16 @@ shaderc_spvc_compilation_result_t generate_hlsl_shader(
     result->status = shaderc_compilation_status_compilation_error;
     return result;
   }
+  result->compiler.reset(compiler);
 
   compiler->set_common_options(options->glsl);
   compiler->set_hlsl_options(options->hlsl);
 
-  result = generate_shader(compiler.get(), result);
+  result = generate_shader(compiler, result);
   if (result->status != shaderc_compilation_status_success) {
     result->messages.append("Compilation failed.  Partial source:\n");
     result->messages.append(compiler->get_partial_source());
+    result->compiler.reset();
   }
 
   return result;
@@ -353,26 +358,46 @@ shaderc_spvc_compilation_result_t generate_msl_shader(
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result) {
-  std::unique_ptr<spirv_cross::CompilerMSL> compiler(
-      new (std::nothrow) spirv_cross::CompilerMSL(source, source_len));
+  spirv_cross::CompilerMSL* compiler =
+      new (std::nothrow) spirv_cross::CompilerMSL(source, source_len);
   if (!compiler) {
     result->messages.append("Unable to initialize SPIRV-Cross MSL compiler.\n");
     result->status = shaderc_compilation_status_compilation_error;
     return result;
   }
+  result->compiler.reset(compiler);
 
   compiler->set_common_options(options->glsl);
   compiler->set_msl_options(options->msl);
   for (auto i : options->msl_discrete_descriptor_sets)
     compiler->add_discrete_descriptor_set(i);
 
-  result = generate_shader(compiler.get(), result);
+  result = generate_shader(compiler, result);
   if (result->status != shaderc_compilation_status_success) {
     result->messages.append("Compilation failed.  Partial source:\n");
     result->messages.append(compiler->get_partial_source());
+    result->compiler.reset();
   }
 
   return result;
   }
+
+shaderc_spvc_compilation_result_t generate_vulkan_shader(
+    const uint32_t* source, size_t source_len,
+    shaderc_spvc_compile_options_t options,
+    shaderc_spvc_compilation_result_t result) {
+  spirv_cross::CompilerReflection* compiler =
+      new (std::nothrow) spirv_cross::CompilerReflection(source, source_len);
+  if (!compiler) {
+    result->messages.append(
+        "Unable to initialize SPIRV-Cross reflection "
+        "compiler.\n");
+    result->status = shaderc_compilation_status_compilation_error;
+    return result;
+  }
+  result->compiler.reset(compiler);
+
+  return result;
+}
 
 }  // namespace spvc_private

--- a/libshaderc_spvc/src/spvc_private.h
+++ b/libshaderc_spvc/src/spvc_private.h
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 #include <cstdint>
-#include <string>
-#include <vector>
-
-#include "spvc/spvc.h"
 #include <spirv_glsl.hpp>
 #include <spirv_hlsl.hpp>
 #include <spirv_msl.hpp>
+#include <spirv_reflect.hpp>
+#include <string>
+#include <vector>
+
 #include "spirv-tools/libspirv.hpp"
+#include "spvc/spvc.h"
 
 // GLSL version produced when none specified nor detected from source.
 #define DEFAULT_GLSL_VERSION 450
@@ -34,6 +35,7 @@ struct shaderc_spvc_compilation_result {
   std::string messages;
   shaderc_compilation_status status =
       shaderc_compilation_status_null_result_object;
+  std::unique_ptr<spirv_cross::Compiler> compiler;
 };
 
 struct shaderc_spvc_compile_options {
@@ -115,6 +117,14 @@ shaderc_spvc_compilation_result_t generate_hlsl_shader(
 // Handles correctly setting up the SPIRV-Cross compiler based on the options
 // and then envoking it.
 shaderc_spvc_compilation_result_t generate_msl_shader(
+    const uint32_t* source, size_t source_len,
+    shaderc_spvc_compile_options_t options,
+    shaderc_spvc_compilation_result_t result);
+
+// Given a Vulkan SPIR-V shader and set of options, generate a Vulkan shader.
+// Is a No-op from the perspective of converting the shader, but setup a
+// SPIRV-Cross compiler to be used for reflection later.
+shaderc_spvc_compilation_result_t generate_vulkan_shader(
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result);

--- a/libshaderc_spvc/src/spvc_test.cc
+++ b/libshaderc_spvc/src/spvc_test.cc
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "spvc/spvc.h"
+
 #include <gtest/gtest.h>
+
 #include <thread>
 
 #include "common_shaders_for_test.h"
-#include "spvc/spvc.h"
+#include "spvc_private.h"
 
 namespace {
 
@@ -51,7 +54,7 @@ TEST(Init, MultipleThreadsCalling) {
 }
 #endif
 
-TEST(Compile, Glsl) {
+TEST(Compile, ValidShaderIntoGlslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -62,13 +65,32 @@ TEST(Compile, Glsl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Hlsl) {
+TEST(Compile, InvalidShaderIntoGlslPasses) {
+  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
+  shaderc_spvc_compile_options_t options =
+      shaderc_spvc_compile_options_initialize();
+
+  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_glsl(
+      compiler, kInvalidShaderBinary,
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
+  ASSERT_NE(nullptr, result);
+  EXPECT_NE(shaderc_compilation_status_success,
+            shaderc_spvc_result_get_status(result));
+  EXPECT_EQ(result->compiler.get(), nullptr);
+
+  shaderc_spvc_result_release(result);
+  shaderc_spvc_compile_options_release(options);
+  shaderc_spvc_compiler_release(compiler);
+}
+
+TEST(Compile, ValidShaderIntoHlslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -79,13 +101,32 @@ TEST(Compile, Hlsl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Msl) {
+TEST(Compile, InvalidShaderIntoHlslPasses) {
+  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
+  shaderc_spvc_compile_options_t options =
+      shaderc_spvc_compile_options_initialize();
+
+  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_hlsl(
+      compiler, kInvalidShaderBinary,
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
+  ASSERT_NE(nullptr, result);
+  EXPECT_NE(shaderc_compilation_status_success,
+            shaderc_spvc_result_get_status(result));
+  EXPECT_EQ(result->compiler.get(), nullptr);
+
+  shaderc_spvc_result_release(result);
+  shaderc_spvc_compile_options_release(options);
+  shaderc_spvc_compiler_release(compiler);
+}
+
+TEST(Compile, ValidShaderIntoMslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -96,13 +137,32 @@ TEST(Compile, Msl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Vulkan) {
+TEST(Compile, InvalidShaderIntoMslPasses) {
+  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
+  shaderc_spvc_compile_options_t options =
+      shaderc_spvc_compile_options_initialize();
+
+  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_msl(
+      compiler, kInvalidShaderBinary,
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
+  ASSERT_NE(nullptr, result);
+  EXPECT_NE(shaderc_compilation_status_success,
+            shaderc_spvc_result_get_status(result));
+  EXPECT_EQ(result->compiler.get(), nullptr);
+
+  shaderc_spvc_result_release(result);
+  shaderc_spvc_compile_options_release(options);
+  shaderc_spvc_compiler_release(compiler);
+}
+
+TEST(Compile, ValidShaderIntoVulkanPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -113,10 +173,29 @@ TEST(Compile, Vulkan) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-}  // anonymous namespace
+TEST(Compile, InvalidShaderIntoVulkanPasses) {
+  shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
+  shaderc_spvc_compile_options_t options =
+      shaderc_spvc_compile_options_initialize();
+
+  shaderc_spvc_compilation_result_t result = shaderc_spvc_compile_into_vulkan(
+      compiler, kInvalidShaderBinary,
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options);
+  ASSERT_NE(nullptr, result);
+  EXPECT_NE(shaderc_compilation_status_success,
+            shaderc_spvc_result_get_status(result));
+  EXPECT_EQ(result->compiler.get(), nullptr);
+
+  shaderc_spvc_result_release(result);
+  shaderc_spvc_compile_options_release(options);
+  shaderc_spvc_compiler_release(compiler);
+}
+
+}  // namespace

--- a/libshaderc_spvc/src/spvc_webgpu_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_test.cc
@@ -18,10 +18,11 @@
 
 #include "common_shaders_for_test.h"
 #include "spvc/spvc.h"
+#include "spvc_private.h"
 
 namespace {
 
-TEST(Compile, Glsl) {
+TEST(Compile, ValidShaderIntoGlslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -37,13 +38,14 @@ TEST(Compile, Glsl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Hlsl) {
+TEST(Compile, ValidShaderIntoHlslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -59,13 +61,14 @@ TEST(Compile, Hlsl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Msl) {
+TEST(Compile, ValidShaderIntoMslPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -81,13 +84,14 @@ TEST(Compile, Msl) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);
   shaderc_spvc_compiler_release(compiler);
 }
 
-TEST(Compile, Vulkan) {
+TEST(Compile, ValidShaderIntoVulkanPasses) {
   shaderc_spvc_compiler_t compiler = shaderc_spvc_compiler_initialize();
   shaderc_spvc_compile_options_t options =
       shaderc_spvc_compile_options_initialize();
@@ -103,6 +107,7 @@ TEST(Compile, Vulkan) {
   ASSERT_NE(nullptr, result);
   EXPECT_EQ(shaderc_compilation_status_success,
             shaderc_spvc_result_get_status(result));
+  EXPECT_NE(result->compiler.get(), nullptr);
 
   shaderc_spvc_result_release(result);
   shaderc_spvc_compile_options_release(options);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -81,8 +81,6 @@ endif()
 if (SHADERC_ENABLE_SPVC)
   if (NOT TARGET spirv-cross-core)
     if (IS_DIRECTORY ${SHADERC_SPIRV_CROSS_DIR})
-      set(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS ${DISABLE_EXCEPTIONS} CACHE BOOL "tell SPIRV-Cross not to throw" FORCE)
-
       # Add -fPIC to SPIRV-Cross build, if supported
       check_cxx_compiler_flag(-fPIC COMPILER_SUPPORTS_PIC)
       if (COMPILER_SUPPORTS_PIC)


### PR DESCRIPTION
Re-landing 11d05cfd749b05337629eabb1a710c49c9bea612 with fixes

Retains the compiler used for generating the platform shader in the
result. This will allow future patches to build up the reflection API,
which will require having access to the compiler.

Part of #818, #819, and #820