### PR TITLE
Roll spirv-cross ahead and update known_failures to fix build breakage

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -10,7 +10,7 @@ vars = {
   're2_revision': '5bd613749fd530b576b890283bfb6bc6ea6246cb',
   'spirv_headers_revision': '842ec90674627ed2ffef609e3cd79d1562eded01',
   'spirv_tools_revision': '9eb1c9a4c45099c23098d97c5a6a8b35a45a8f25',
-  'spirv_cross_revision': '5431e1da2dc11123750f39a5ba4e5a8c117a0773',
+  'spirv_cross_revision': 'e5d3a6655e13870a6f38f40bd88cc662b14e3cdf',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -101,6 +101,7 @@ shaders-reflection/asm/op-source-none-uav-1.asm.comp,False
 shaders-reflection/asm/op-source-none-uav-2.asm.comp,False
 shaders-reflection/comp/struct-layout.comp,False
 shaders-reflection/comp/struct-packing.comp,False
+shaders-reflection/comp/workgroup-size-spec-constant.comp,False
 shaders-reflection/frag/combined-texture-sampler-shadow.vk.frag,False
 shaders-reflection/frag/combined-texture-sampler.vk.frag,False
 shaders-reflection/frag/image-load-store-uint-coord.asm.frag,False


### PR DESCRIPTION
Roll third_party/spirv-cross/ 5431e1da2..e5d3a6655 (8 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/5431e1da2dc1...e5d3a6655e13

$ git log 5431e1da2..e5d3a6655 --date=short --no-merges --format='%ad %ae %s'
2019-10-07 rharrison Update SPV_VERSION from 1.4 to 1.5
2019-10-07 post Workaround MSVC issue.
2019-10-07 post Do not consider aliased struct types if the master is not a block.
2019-10-07 post Run format_all.sh.
2019-10-04 post Do not value compare JSON files for regression purposes.
2019-10-04 post Reflect: Deal with workgroup size being specialization constants.
2019-10-03 frank.richter reference: Update to include workgroup_size
2019-10-03 frank.richter reflection: Write workgroup_size to JSON for compute shaders

Created with:
  roll-dep third_party/spirv-cross

Fixes #830