### PR TITLE
Rolling 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
-  'glslang_revision': '7bc047326e06961c59b785f827026947d81c7f02',
-  'googletest_revision': 'dc1ca9ae4c206434e450ed4ff535ca7c20c79e3c',
-  're2_revision': '5bd613749fd530b576b890283bfb6bc6ea6246cb',
-  'spirv_headers_revision': '842ec90674627ed2ffef609e3cd79d1562eded01',
-  'spirv_tools_revision': '9eb1c9a4c45099c23098d97c5a6a8b35a45a8f25',
+  'glslang_revision': '4b97a1108114107a8082a55e9e0721a40f9536d3',
+  'googletest_revision': 'cd17fa2abda2a2e4111cdabd62a87aea16835014',
+  're2_revision': '266119da0a8328ecb18fbd31398100d2ec230619',
+  'spirv_headers_revision': 'b252a50953ac4375cb1864e94f4b0234db9d215d',
+  'spirv_tools_revision': 'df15a4a3cbda6bde5e4bbd43492e17ac7752cd68',
   'spirv_cross_revision': 'e5d3a6655e13870a6f38f40bd88cc662b14e3cdf',
 }
 


### PR DESCRIPTION
Roll third_party/glslang/ 7bc047326..4b97a1108 (5 commits)

https://github.com/KhronosGroup/glslang/compare/7bc047326e06...4b97a1108114

$ git log 7bc047326..4b97a1108 --date=short --no-merges --format='%ad %ae %s'
2019-10-06 dj2 single line
2019-10-03 dj2 Update appveyor and travis files
2019-10-03 dj2 Move install directory for SPIRV/ folder.
2019-09-29 cepheus HLSL: Fix #1912: add attribute syntax for nonreadable/nonwritable
2019-09-27 cepheus HLSL: Fix #1912: add attribute syntax for overriding image formats.

Roll third_party/googletest/ dc1ca9ae4..cd17fa2ab (8 commits)

https://github.com/google/googletest/compare/dc1ca9ae4c20...cd17fa2abda2

$ git log dc1ca9ae4..cd17fa2ab --date=short --no-merges --format='%ad %ae %s'
2019-10-05 soap Add documentation for pkg-config in cross-compilation settings
2019-10-05 soap Revert "Use pcfiledir for prefix in pkgconfig file"
2019-10-03 misterg Googletest export
2019-10-03 absl-team Googletest export
2019-10-02 absl-team Googletest export
2019-09-29 misterg Googletest export
2019-10-01 ant35rookie Fix typo in documents
2019-08-16 pbarker Add many missing override keywords

Roll third_party/re2/ 5bd613749..266119da0 (2 commits)

https://github.com/google/re2/compare/5bd613749fd5...266119da0a83

$ git log 5bd613749..266119da0 --date=short --no-merges --format='%ad %ae %s'
2019-10-09 junyer Tidy up the ersatz benchmark library.
2019-10-07 junyer Move pod_array.h and sparse_{array,set}.h from util/ to re2/.

Roll third_party/spirv-headers/ 842ec9067..b252a5095 (1 commit)

https://github.com/KhronosGroup/SPIRV-Headers/compare/842ec9067462...b252a50953ac

$ git log 842ec9067..b252a5095 --date=short --no-merges --format='%ad %ae %s'
2019-09-24 lukasz.gotszald add cmake option SPIRV_HEADERS_SKIP_INSTALL

Roll third_party/spirv-tools/ 9eb1c9a4c..df15a4a3c (15 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/9eb1c9a4c450...df15a4a3cbda

$ git log 9eb1c9a4c..df15a4a3c --date=short --no-merges --format='%ad %ae %s'
2019-10-09 cwallez CMake: Add support for building with emscripten (#2948)
2019-10-09 stevenperron Update CHANGES
2019-10-08 stevenperron Link cfg and dominator analysis in the context (#2946)
2019-10-08 afdx spirv-fuzz: add transformation and pass to construct composites (#2941)
2019-10-08 paulthomson reduce: improve remove unref instr pass (#2945)
2019-10-08 afdx spirv-fuzz: add disabled test to document known issue (#2942)
2019-10-08 afdx spirv-fuzz: Add fuzzer pass to change selection controls (#2944)
2019-10-07 jeremy-lunarg Enable OpTypeCooperativeMatrix specialization (#2927)
2019-10-04 stevenperron Handle OpKill better (#2933)
2019-10-04 greg Generate null pointer by converting uint64 zero to pointer. (#2935)
2019-10-03 afdx spirv-fuzz: option to convert shader into a form that renders red (#2934)
2019-10-03 32110296+AaronHaganAMD Add SPV_KHR_shader_clock validation (#2879)
2019-10-03 paulthomson reduce/fuzz: improve command line args (#2932)
2019-10-02 alanbaker Validate physical storage buffer restrictions (#2930)
2019-10-01 paulthomson fuzz: add shrinker-temp-file-prefix (#2928)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools