### PR TITLE
Add in shaderc_features.gni to support build time flags

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/shaderc.gni")
+import("shaderc_features.gni")
 
 glslang_dir = shaderc_glslang_dir
 spirv_tools_dir = shaderc_spirv_tools_dir

--- a/shaderc_features.gni
+++ b/shaderc_features.gni
@@ -1,20 +1,18 @@
-# Copyright 2018 The Shaderc Authors. All rights reserved.
-# 
+# Copyright 2019 The Shaderc Authors. All rights reserved.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# These are variables that are overridable by projects that include shaderc.
-
-# The path to shaderc dependencies.
-shaderc_glslang_dir = "//third_party/glslang"
-shaderc_spirv_tools_dir = "//third_party/spirv-tools"
-shaderc_spirv_headers_dir = "//third_party/spirv-headers"
+declare_args() {
+  # Enables using the parsing built into spvc instead spirv-cross
+  shaderc_enable_spvc_parser = false
+}


### PR DESCRIPTION
This will allow downstream embedders to use the default values for
flags.

The build override dirs have been left in place, since users need to
define them for their repo layout.