### PR TITLE
Rolling 5 dependencies and update known_failures & known_invalids

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,11 +6,11 @@ vars = {
 
   'effcee_revision' : 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
   'glslang_revision': 'a959deb00750826fb087171d663947df550a3339',
-  'googletest_revision': 'cd17fa2abda2a2e4111cdabd62a87aea16835014',
-  're2_revision': '266119da0a8328ecb18fbd31398100d2ec230619',
-  'spirv_headers_revision': 'b252a50953ac4375cb1864e94f4b0234db9d215d',
-  'spirv_tools_revision': 'df15a4a3cbda6bde5e4bbd43492e17ac7752cd68',
-  'spirv_cross_revision': 'e5d3a6655e13870a6f38f40bd88cc662b14e3cdf',
+  'googletest_revision': 'bdc29d5dc19dd802907ea37a80ce5dc9afe0898d',
+  're2_revision': 'ab12219ba56a47200385673446b5d371548c25db',
+  'spirv_headers_revision': 'af64a9e826bf5bb5fcd2434dd71be1e41e922563',
+  'spirv_tools_revision': '2ca4fcfdc20039dccae05e92641378cbc080da85',
+  'spirv_cross_revision': 'a92668bc118a7660e7e2689b74e642508a2a2737',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -59,6 +59,8 @@ shaders-msl/frag/barycentric-nv.msl22.frag,False
 shaders-msl/frag/barycentric-nv.msl22.frag,True
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,False
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,True
+shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,False
+shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,True
 shaders-msl/frag/image-query-lod.msl22.frag,False
 shaders-msl/frag/image-query-lod.msl22.frag,True
 shaders-msl/frag/shadow-compare-global-alias.invalid.frag,False
@@ -89,6 +91,8 @@ shaders-msl/vert/sign-int-types.vert,False
 shaders-msl/vert/sign-int-types.vert,True
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,True
+shaders-no-opt/asm/frag/for-loop-dedicated-merge-block-inverted.asm.frag,False
+shaders-no-opt/asm/frag/for-loop-dedicated-merge-block-non-inverted.asm.frag,False
 shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders-reflection/asm/aliased-entry-point-names.asm.multi,False
 shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp,False

--- a/spvc/test/known_invalids
+++ b/spvc/test/known_invalids
@@ -1,3 +1,5 @@
-shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag,False
-shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag,False
 shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag,False
+shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag,False
+shaders-no-opt/asm/frag/for-loop-dedicated-merge-block-inverted.asm.frag,False
+shaders-no-opt/asm/frag/for-loop-dedicated-merge-block-non-inverted.asm.frag,False
+shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.frag,False


### PR DESCRIPTION
Roll third_party/googletest/ cd17fa2ab..bdc29d5dc (19 commits)

https://github.com/google/googletest/compare/cd17fa2abda2...bdc29d5dc19d

$ git log cd17fa2ab..bdc29d5dc --date=short --no-merges --format='%ad %ae %s'
2019-10-16 absl-team Googletest export
2019-10-11 misterg Googletest export
2019-10-10 absl-team Googletest export
2019-10-10 absl-team Googletest export
2019-10-10 chrisjohnsonmail chore:  update version
2019-10-10 joshdcannon Made noexcept condition more exciting
2019-10-09 absl-team Googletest export
2019-10-09 zeb Mention Cornichon as a related open source project
2019-10-07 joshdcannon Use declval in noexcept expression
2019-10-07 joshdcannon Switch to free function to avoid GCC bug
2019-10-07 joshdcannon Avoid comma operator
2019-10-07 joshdcannon Fix spacing
2019-10-07 joshdcannon Use the verbatim noexcept spec in MOCKED_METHOD
2019-10-07 joshdcannon Use FormatFileLocation for streaming file and line
2019-08-22 krystian.kuzniarek mention the existing support for wide strings in string matchers
2019-09-16 krystian.kuzniarek square away the stuff that hasn't been merged in a manual review
2019-09-07 krystian.kuzniarek square away the stuff that hasn't been merged in a manual review
2019-08-22 krystian.kuzniarek change usings
2019-09-10 krystian.kuzniarek remove GTEST_HAS_STD_STRING

Roll third_party/re2/ 266119da0..ab12219ba (14 commits)

https://github.com/google/re2/compare/266119da0a83...ab12219ba56a

$ git log 266119da0..ab12219ba --date=short --no-merges --format='%ad %ae %s'
2019-10-13 junyer Fix the regexp_benchmark build with GNU make.
2019-10-11 junyer Oops, wrap a couple of lines.
2019-10-11 junyer Read flags using the GetFlag() style.
2019-10-11 junyer Make flags use the DEFINE_FLAG() style.
2019-10-11 junyer Remove a condition from exhaustive1_test.cc that is no longer needed.
2019-10-11 junyer Move util/flags.h into the testing target.
2019-10-11 junyer Don't declare testing::TempDir() in dump.cc itself.
2019-10-11 junyer Split out the fake testing::MallocCounter into its own file.
2019-10-11 junyer Remove the fake test_tmpdir flag in favour of testing::TempDir().
2019-10-10 junyer Remove the comment on NumCPUs().
2019-10-10 junyer Call .range(0) explicitly rather than just .range().
2019-10-10 junyer Move NumCPUs() into regexp_benchmark.cc.
2019-10-10 junyer Migrate to the new benchmark API.
2019-10-10 junyer Implement the new benchmark API as a layer over the old benchmark API.

Roll third_party/spirv-cross/ e5d3a6655..a92668bc1 (8 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/e5d3a6655e13...a92668bc118a

$ git log e5d3a6655..a92668bc1 --date=short --no-merges --format='%ad %ae %s'
2019-10-17 post Fix OpVectorExtractDynamic with spec constant op index.
2019-10-16 post Travis: Update PATH for Python3 on Windows.
2019-10-14 post MSL: Add opt-in support for huge IABs.
2019-10-14 post HLSL: Fix unrolled S/G LE/LT/GE/GT opcodes.
2019-10-14 post GLSL: Deal correctly with bitwidth on integer compares.
2019-10-14 post HLSL: Partially implement Unordered compare.
2019-10-14 post GLSL: Support unordered floating point compare.
2019-10-11 post MSL: Fix regression with OpCompositeConstruct from std140 float[].

Roll third_party/spirv-headers/ b252a5095..af64a9e82 (2 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/b252a50953ac...af64a9e826bf

$ git log b252a5095..af64a9e82 --date=short --no-merges --format='%ad %ae %s'
2019-10-15 cepheus Versioning: Complete the versioning change in recent commits.
2019-10-14 nicolai.haehnle buildHeaders: update version to SPIR-V 1.5

Roll third_party/spirv-tools/ df15a4a3c..2ca4fcfdc (18 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/df15a4a3cbda...2ca4fcfdc200

$ git log df15a4a3c..2ca4fcfdc --date=short --no-merges --format='%ad %ae %s'
2019-10-17 rharrison Add fuzzer for spirv-dis call path (#2977)
2019-10-17 rharrison Check binary->code existence before destroying (#2979)
2019-10-17 akb825 Improved CMake install step. (#2963)
2019-10-16 kubak Support constant-folding UConvert and SConvert (#2960)
2019-10-16 rharrison Add fuzzer for spirv-as call path (#2976)
2019-10-15 afdx spirv-fuzz: Refactor 'copy object' and 'construct composite' transformations (#2966)
2019-10-15 dneto Update SPIR-V binary header test for SPIR-V 1.5 (#2967)
2019-10-14 afdx spirv-fuzz: Refactor 'split blocks' to identify instructions differently (#2961)
2019-10-11 alanbaker Validate that selections are structured (#2962)
2019-10-11 afdx spirv-fuzz: Rework id descriptors (#2959)
2019-10-11 afdx spirv-fuzz: Add fuzzer pass to add NoContraction decorations (#2950)
2019-10-11 afdx spirv-fuzz: Add fuzzer pass to change function controls (#2951)
2019-10-10 paulthomson reduce: add large tests and fix (#2947)
2019-10-10 afdx spirv-fuzz: Add fuzzer pass to change loop controls (#2949)
2019-10-10 afdx Fixed include paths and order according to Google style. (#2957)
2019-10-09 ehsannas Use a longer timeout for Bazel tests. (#2956)
2019-10-09 rharrison Remove non-existent files from BUILD.gn (#2955)
2019-10-09 alanbaker Disable scope validation for OpReadClockKHR (#2953)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools