### PR TITLE
Rolling 4 dependencies, small script fix and updating expectation files

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
-  'glslang_revision': 'a959deb00750826fb087171d663947df550a3339',
-  'googletest_revision': 'bdc29d5dc19dd802907ea37a80ce5dc9afe0898d',
+  'glslang_revision': '834ee546f93d33a80fb2dea6fdef6764f8730b75',
+  'googletest_revision': 'f966ed158177f2ed6ff2c402effb16f7f00ca40b',
   're2_revision': 'ab12219ba56a47200385673446b5d371548c25db',
   'spirv_headers_revision': 'af64a9e826bf5bb5fcd2434dd71be1e41e922563',
-  'spirv_tools_revision': '2ca4fcfdc20039dccae05e92641378cbc080da85',
-  'spirv_cross_revision': 'a92668bc118a7660e7e2689b74e642508a2a2737',
+  'spirv_tools_revision': 'e8c3f9b0b463c24eab839c82332344ccaddfa19d',
+  'spirv_cross_revision': 'ff1897ae0e1fc1e37c604933694477f335ca8e44',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -7,6 +7,7 @@ shaders-hlsl/comp/num-workgroups-with-builtins.comp,False
 shaders-hlsl/comp/num-workgroups-with-builtins.comp,True
 shaders-hlsl/frag/constant-buffer-array.invalid.sm51.frag,False
 shaders-hlsl/frag/constant-buffer-array.invalid.sm51.frag,True
+shaders-hlsl/frag/fp16.invalid.desktop.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
 shaders-hlsl/vert/basic.vert,False
@@ -59,6 +60,7 @@ shaders-msl/frag/barycentric-nv.msl22.frag,False
 shaders-msl/frag/barycentric-nv.msl22.frag,True
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,False
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,True
+shaders-msl/frag/fp16.desktop.invalid.frag,False
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,False
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,True
 shaders-msl/frag/image-query-lod.msl22.frag,False
@@ -124,6 +126,8 @@ shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
 shaders/asm/frag/line-directive.line.asm.frag,False
 shaders/asm/frag/line-directive.line.asm.frag,True
+shaders/desktop-only/frag/fp16.invalid.desktop.frag,False
+shaders/desktop-only/frag/fp16.invalid.desktop.frag,True
 shaders/desktop-only/vert/basic.desktop.sso.vert,False
 shaders/desktop-only/vert/basic.desktop.sso.vert,True
 shaders/flatten/array.flatten.vert,False

--- a/spvc/test/run_spirv_cross_tests.py
+++ b/spvc/test/run_spirv_cross_tests.py
@@ -594,7 +594,7 @@ def main():
 
     for invalid in successes_without_validation:
         if invalid not in successes:
-            if invalid not in unconfirmed_invalids:
+            if invalid not in unconfirmed_invalids and invalid not in known_invalids:
                 unexpected_invalids.append(invalid)
 
     test_env.log_unexpected(unexpected_successes, 'success')

--- a/spvc/test/unconfirmed_invalids
+++ b/spvc/test/unconfirmed_invalids
@@ -1,6 +1,7 @@
 shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders-hlsl/frag/constant-buffer-array.invalid.sm51.frag,False
 shaders-hlsl/frag/constant-buffer-array.invalid.sm51.frag,True
+shaders-hlsl/frag/fp16.invalid.desktop.frag,False
 shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-3.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-5.asm.comp,False
@@ -17,11 +18,14 @@ shaders-msl-no-opt/packing/struct-packing.comp,False
 shaders-msl/asm/frag/min-max-clamp.invalid.asm.frag,False
 shaders-msl/frag/16bit-constants.invalid.frag,False
 shaders-msl/frag/16bit-constants.invalid.frag,True
+shaders-msl/frag/fp16.desktop.invalid.frag,False
 shaders-msl/frag/shadow-compare-global-alias.invalid.frag,False
 shaders-msl/frag/shadow-compare-global-alias.invalid.frag,True
 shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders/asm/extended-debug-extinst.invalid.asm.comp,False
 shaders/asm/extended-debug-extinst.invalid.asm.comp,True
+shaders/desktop-only/frag/fp16.invalid.desktop.frag,False
+shaders/desktop-only/frag/fp16.invalid.desktop.frag,True
 shaders/flatten/multi-dimensional.desktop.invalid.flatten_dim.frag,False
 shaders/flatten/multi-dimensional.desktop.invalid.flatten_dim.frag,True
 shaders/frag/16bit-constants.invalid.frag,False


### PR DESCRIPTION
Roll third_party/glslang/ a959deb00..834ee546f (1 commit)

https://github.com/KhronosGroup/glslang/compare/a959deb00750...834ee546f93d

$ git log a959deb00..834ee546f --date=short --no-merges --format='%ad %ae %s'
2019-10-17 jbolz Only apply volatile semantics to atomics when using Vulkan Memory Model

Roll third_party/googletest/ bdc29d5dc..f966ed158 (4 commits)

https://github.com/google/googletest/compare/bdc29d5dc19d...f966ed158177

$ git log bdc29d5dc..f966ed158 --date=short --no-merges --format='%ad %ae %s'
2019-10-18 misterg Googletest export
2019-10-17 absl-team Googletest export
2019-10-17 absl-team Googletest export
2019-10-09 robert Add more override keywords

Roll third_party/spirv-cross/ a92668bc1..ff1897ae0 (1 commit)

https://github.com/KhronosGroup/SPIRV-Cross/compare/a92668bc118a...ff1897ae0e1f

$ git log a92668bc1..ff1897ae0 --date=short --no-merges --format='%ad %ae %s'
2019-10-21 post CFG: Compute actual immediate dominators.

Roll third_party/spirv-tools/ 2ca4fcfdc..e8c3f9b0b (5 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/2ca4fcfdc200...e8c3f9b0b463

$ git log 2ca4fcfdc..e8c3f9b0b --date=short --no-merges --format='%ad %ae %s'
2019-10-18 chris Ensure timestamp does not vary with timezone. (#2982)
2019-10-18 stevenperron Keep NOPs when comparing with original binary (#2931)
2019-10-18 alanbaker Check that derivatives operate on 32-bit values (#2983)
2019-10-17 rharrison Check text->str before destroying (#2981)
2019-10-17 kubak Disallow use of OpCompositeExtract/OpCompositeInsert with no indices (#2980)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools