### PR TITLE
Android.mk: Install all necessary headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ third_party/spirv-tools/
 third_party/spirv-headers/
 third_party/spirv-cross/
 android_test/libs
+android_test/include
 .DS_Store


### PR DESCRIPTION
Also ignore android_test/include, as that is updated during
test builds.

Fixes https://github.com/android/ndk/issues/1105