### PR TITLE
Rolling 5 dependencies & expectation files

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
-  'glslang_revision': '834ee546f93d33a80fb2dea6fdef6764f8730b75',
-  'googletest_revision': 'f966ed158177f2ed6ff2c402effb16f7f00ca40b',
-  're2_revision': 'ab12219ba56a47200385673446b5d371548c25db',
+  'glslang_revision': 'b131630e7c749a5dc19faa458024260c71fb170f',
+  'googletest_revision': 'ba33a8876c3eda4cb8def8e0e90f45930ef8c54f',
+  're2_revision': 'eecfdbf1701dd7ebad2f28b9965ca09e0bfb45b0',
   'spirv_headers_revision': 'af64a9e826bf5bb5fcd2434dd71be1e41e922563',
-  'spirv_tools_revision': 'e8c3f9b0b463c24eab839c82332344ccaddfa19d',
-  'spirv_cross_revision': 'ff1897ae0e1fc1e37c604933694477f335ca8e44',
+  'spirv_tools_revision': '7e2cba6a52415ee478d0e6e56c8699a6fe4a5b03',
+  'spirv_cross_revision': '00189b19a5da553c668290a051604209586b2139',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -17,6 +17,7 @@ shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-3.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-5.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding.asm.comp,False
 shaders-msl-no-opt/asm/packing/packed-vector-extract-insert.asm.comp,False
+shaders-msl-no-opt/packing/array-of-vec3.comp,False
 shaders-msl-no-opt/packing/matrix-2x3-scalar.comp,False
 shaders-msl-no-opt/packing/matrix-3x2-scalar.comp,False
 shaders-msl-no-opt/packing/matrix-3x3-scalar.comp,False
@@ -69,6 +70,8 @@ shaders-msl/frag/shadow-compare-global-alias.invalid.frag,False
 shaders-msl/frag/shadow-compare-global-alias.invalid.frag,True
 shaders-msl/frag/subgroup-builtins.msl22.frag,False
 shaders-msl/frag/subgroup-builtins.msl22.frag,True
+shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,False
+shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,True
 shaders-msl/legacy/vert/transpose.legacy.vert,False
 shaders-msl/legacy/vert/transpose.legacy.vert,True
 shaders-msl/tesc/water_tess.tesc,False
@@ -81,6 +84,8 @@ shaders-msl/vert/copy.flatten.vert,False
 shaders-msl/vert/copy.flatten.vert,True
 shaders-msl/vert/dynamic.flatten.vert,False
 shaders-msl/vert/dynamic.flatten.vert,True
+shaders-msl/vert/float-math.invariant-float-math.vert,False
+shaders-msl/vert/float-math.invariant-float-math.vert,True
 shaders-msl/vert/functions.vert,False
 shaders-msl/vert/functions.vert,True
 shaders-msl/vert/leaf-function.capture.vert,False
@@ -121,6 +126,7 @@ shaders-reflection/vert/read-from-row-major-array.vert,False
 shaders-reflection/vert/texture_buffer.vert,False
 shaders/asm/extended-debug-extinst.invalid.asm.comp,False
 shaders/asm/extended-debug-extinst.invalid.asm.comp,True
+shaders/asm/frag/complex-name-workarounds.asm.frag,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False

--- a/spvc/test/unconfirmed_invalids
+++ b/spvc/test/unconfirmed_invalids
@@ -7,6 +7,7 @@ shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-3.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-5.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding.asm.comp,False
 shaders-msl-no-opt/asm/packing/packed-vector-extract-insert.asm.comp,False
+shaders-msl-no-opt/packing/array-of-vec3.comp,False
 shaders-msl-no-opt/packing/matrix-2x3-scalar.comp,False
 shaders-msl-no-opt/packing/matrix-3x2-scalar.comp,False
 shaders-msl-no-opt/packing/matrix-3x3-scalar.comp,False


### PR DESCRIPTION
Roll third_party/glslang/ 834ee546f..b131630e7 (16 commits)

https://github.com/KhronosGroup/glslang/compare/834ee546f93d...b131630e7c74

$ git log 834ee546f..b131630e7 --date=short --no-merges --format='%ad %ae %s'
2019-10-24 greg Update spirv-tools known good.
2019-10-23 ehsannas Make  buildbot licenses consistent with the rest of the code
2019-10-23 52076061+digit-google BUILD.gn: Fix fuchsia build (#1944)
2019-10-21 cepheus Web: Reclaim more space and make all work w/wo GLSLANG_WEB.
2019-10-18 cepheus Web: Add basic atomics for SSBOs.
2019-10-17 cepheus Web: Add SSBOs and a few other missing compute features.
2019-10-10 cepheus Web: Add compute stage.
2019-10-08 cepheus Web: Add separate texture/sampler, exclude *CubeArray*.
2019-10-22 47668180+tsuoranta Enable generation of compile_commands.json (#1938)
2019-10-21 dexcelstraun7 Fix the exports of glslang-default-resource-limits (#1942)
2019-10-18 ehsannas Run tests on Windows too.
2019-10-18 ehsannas Fix build scripts.
2019-10-18 ehsannas More cleanups for Windows.
2019-10-17 ehsannas Add Kokoro bots for building using Bazel.
2019-10-17 ehsannas Make it work on Windows.
2019-10-16 ehsannas Add Bazel build configuration files.

Roll third_party/googletest/ f966ed158..ba33a8876 (39 commits)

https://github.com/google/googletest/compare/f966ed158177...ba33a8876c3e

$ git log f966ed158..ba33a8876 --date=short --no-merges --format='%ad %ae %s'
2019-10-29 misterg Googletest export
2019-10-28 hermas1132 Googletest export
2019-10-28 absl-team Googletest export
2019-10-28 absl-team Googletest export
2019-10-28 absl-team Googletest export
2019-10-28 absl-team Googletest export
2019-09-03 krystian.kuzniarek update CONTRIBUTORS
2019-08-08 krystian.kuzniarek move the pumping script to googlemock
2019-08-08 krystian.kuzniarek remove gtest-type-util.h.pump
2019-08-08 krystian.kuzniarek replace autogenerated TemplatesX classes by variadic ones
2019-08-08 krystian.kuzniarek replace autogenerated TypesX classes by variadic ones
2019-10-25 piotrwn1 variable names corrected (followed google coding style)
2019-10-25 piotrwn1 Apply 80chars limit
2019-10-24 piotrwn1 Tests simplified and names corrected (POD->scalar)
2019-10-23 absl-team Googletest export
2019-10-22 absl-team Googletest export
2019-10-23 piotrwn1 Added more tests to verify: ReturnRef not accept temporary
2019-10-22 piotrwn1 Added tests verifying that temporaries are accepted by ReturnRef
2019-10-22 absl-team Googletest export
2019-10-22 piotrwn1 Prevent using ReturnRef on reference to temporary
2019-10-21 absl-team Googletest export
2019-10-18 absl-team Googletest export
2019-10-19 41349879+cloudrex Remove extra space
2019-10-17 lesha [googletest] Output skip message
2019-10-11 joshdcannon Avoid recursive macros
2019-10-07 chrisjohnsonmail Update to distinguish prelease purpose of this fork.
2019-10-11 joshdcannon Removing extraneous parenthesis
2019-10-11 joshdcannon Evaluate and cat NARG in different macros
2019-08-29 chrisjohnsonmail Add ESP8266 configs to PlatformIO build
2019-08-28 chrisjohnsonmail feat: Add support for ESP8266 platform
2019-10-11 joshdcannon Removing extraneous test
2019-10-11 joshdcannon Replace compile-test with preprocessor test
2019-10-11 joshdcannon Fix preprocessor tests
2019-10-11 joshdcannon Add a compile test
2019-10-11 joshdcannon Workaround MSVC VA_ARGS weirdness
2019-10-11 krystian.kuzniarek clean-up broken paths for PlatformIO
2019-09-05 krystian.kuzniarek remove GTEST_ARRAY_SIZE_
2019-09-10 krystian.kuzniarek change includes in gtest-port.h
2019-09-10 krystian.kuzniarek remove a dead function

Roll third_party/re2/ ab12219ba..eecfdbf17 (3 commits)

https://github.com/google/re2/compare/ab12219ba56a...eecfdbf1701d

$ git log ab12219ba..eecfdbf17 --date=short --no-merges --format='%ad %ae %s'
2019-10-29 junyer Tweak some printed debugging for style.
2019-10-29 junyer Address the MSVC warnings that crept in recently.
2019-10-29 junyer Simplify parse_double_float() in util/pcre.cc.

Roll third_party/spirv-cross/ ff1897ae0..00189b19a (90 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/ff1897ae0e1f...00189b19a5da

$ git log ff1897ae0..00189b19a --date=short --no-merges --format='%ad %ae %s'
2019-10-29 post MSL: Add missing reference output.
2019-10-29 post Fix broken access tracking for OpFunctionCall results.
2019-10-28 post MSL: Avoid some fallthrough warnings.
2019-10-28 post Run format_all.sh.
2019-10-28 post MSL: Remove hacky workaround for patch constant passing.
2019-10-28 post MSL: Remove workaround for passing constant arrays to functions.
2019-10-28 post Remove another dead reference file.
2019-10-28 post Remove some more dead reference files.
2019-10-28 post Remove another dead reference file.
2019-10-28 post Remove dead reference file.
2019-10-28 post Hack some constants in UE4 tests.
2019-10-28 post MSL: Ensure stable output for access chain CFG workarounds.
2019-10-26 post MSL: Fix integer cast.
2019-10-26 post MSL: Declare arrays with proper type wrapper.
2019-10-26 post MSL: Deal with chained access chains for tessellation IO variables.
2019-10-26 post MSL: Declare struct type explicitly.
2019-10-26 post MSL: Fix array of array declaration.
2019-10-25 post MSL: Rewrite tessellation_access_chain.
2019-10-25 post MSL: Slight cleanup in emit_tessellation_access_chain.
2019-10-25 post MSL: Do not declare variables which will not be unflattened.
2019-10-25 post MSL: Report tess input array failures more accurately.
2019-10-25 post MSL: Revert hack with kBufferSizeBufferBinding
2019-10-25 post MSL: Remove stale code for TextureSwizzle.
2019-10-24 post GLSL: Minor nit, check flushed_phi_variables with count().
2019-10-24 post Clean up call to builtin_translates_to_nonarray.
2019-10-24 post Implement constant empty struct correctly on all backends.
2019-10-24 post MSL: Rewrite propagated depth comparison state handling.
2019-10-24 post MSL: Do read-only lookups of access_chain_children.
2019-10-24 post MSL: Remove stray allow_id_rewrite().
2019-10-24 post MSL: Do not declare array of UBO/SSBO as spvUnsafeArray<T>.
2019-10-24 bill.hollings MSL: Support option for treating 1D textures as 2D textures of height 1.
2019-10-24 bill.hollings MSL: Support option for treating 1D textures as 2D textures of height 1.
2019-10-24 post MSL: Enable proper value types for return and value-passing of arrays.
2019-10-24 post MSL: Be a little clearer how needs_base_vertex_idx is implemented.
2019-10-24 post MSL: Remove some dead code w.r.t. vertex/instance_idx.
2019-10-24 post MSL: Do not generate UnsafeArray<> for any array inside buffer objects.
2019-10-24 post MSL: Simplify framebuffer fetch implementation.
2019-10-24 post MSL: Fall back to GLSL path for non-invariant matrix multiply as well.
2019-10-24 post MSL: Fall back to GLSL path for non-invariant FP implementation.
2019-10-24 post MSL: Minor cleanups for texture atomic emulation.
2019-10-24 post MSL: Cleanup decoration forwarding for SampleMask.
2019-10-24 post MSL: Do not declare complex composite array in main for non-inlined.
2019-10-24 post Fix formatting in main.cpp.
2019-10-24 post Add new UE4 folders to CMake testing as well.
2019-10-23 lukas.hermanns Moved all UE4 test shaders into 'shaders-ue4/' folder.
2019-10-23 lukas.hermanns Removed 'argument_buffer_offset' and fixed packed matrix Metal output.
2019-10-22 lukas.hermanns Simplified overriding of 'access_chain_internal' function in CompilerMSL.
2019-10-21 lukas.hermanns Removed bounds checks in favor of SPIRV-Tools pass '--graphics-robust-access'
2019-10-09 lukas.hermanns Disabled spvUnsafeArray<> type for packed vectors and added test cases for those arrays.
2019-10-09 lukas.hermanns Added '--msl-invariant-float-math' option and new test case for it.
2019-09-27 lukas.hermanns Further updates for pull request #1162; also added two test cases for spvCubemapTo2DArrayFace function and added '--msl-framebuffer-fetch'/ '--msl-emulate-cube-array' compiler options.
2019-09-24 lukas.hermanns Update for pull request #1162 rev. 1
2019-09-23 lukas.hermanns Updates for pull request #1162
2019-09-19 lukas.hermanns Fixed false-positive optimization of builtin variables (may happen when 'spvOut' is emitted).
2019-09-18 lukas.hermanns Updated test shaders.
2019-09-18 lukas.hermanns Rearranged all 'UE Change' comments to match to project's coding style.
2019-09-17 lukas.hermanns Removed reference specifiers in 'spvFMul*' functions to avoid address specifiers.
2019-09-17 lukas.hermanns Updated reference Metal shaders.
2019-09-17 lukas.hermanns Avoid emitting 'spvUnsafeArray<>', 'spvFMul*', and 'spvFAdd' custom functions if they are not needed.
2019-09-17 lukas.hermanns Further adjustments to make Metal backend work again in UE4 on Mac.
2019-09-16 lukas.hermanns Renamed new test shaders to fit the naming convention in SPIRV-Cross.
2019-09-13 lukas.hermanns Added a new 'emulate_cube_array' option to SPIRV-Cross to cope with translating TextureCubeArray into texture2d_array for iOS where this type is not available. (Original Author: Mark Satterthwaite)
2019-09-13 lukas.hermanns Removed all '.DS_Store' files.
2019-09-13 lukas.hermanns Adjustments after rebase of ue4_dev branch.
2019-08-26 mark.satterthwaite OpImageTexelPointer needs to use an int coordinate type for GLSL, but not for MSL.
2019-08-26 mark.satterthwaite Remove obsolete memory barrier scope specification from Metal output, this API has been removed.
2019-08-14 mark.satterthwaite Add an option to SPIRV-Cross to enforce invariant floating point math to prevent different depth calculation between prepass & basepass when running on Metal 2.0 and earlier.
2019-08-14 mark.satterthwaite More fixes to handling packing & access elements in an array. Made in two parts. 1. Don't allow AccessChain operations to add duplicated swizzles when accessing packed arrays. 2. Only pack arrays when there is the proper amount of space between members in a struct, otherwise it will definitely be wrong.
2019-08-14 mark.satterthwaite Update the Metal shaders to account for changes in the shader compilation.
2019-08-14 mark.satterthwaite Fix texture swizzling.
2019-08-14 mark.satterthwaite The result of an AccessChain intrinsic in SPIRV can be referenced by multiple blocks but when they are loops that can result in compilation problems because the source variables might not be declared early enough. This forces us to hoist those variables high enough to make it work.
2019-08-14 mark.satterthwaite There are occasions where phi-variable copies are introduced for original variables which are fully declared, which coud result in the phi-variable never being declared and the shader not compiling, so declare the phi-variables when this happens. Change made in two parts.  1. Ensure that we declare phi-variable copies even if the original declaration isn't deferred. 2. Only flush phi variables once, avoids duplicate definitions.
2019-08-14 mark.satterthwaite When converting from HLSL the dxc SPIRV output often contains variables that are written through (e.g. a = b = c;) which seems to break the tracking of expressions in SPIRV-Cross, so don't reset everything once configured.
2019-08-14 mark.satterthwaite Provide the Metal bindings as part of the options structure as that is more convenient.
2019-08-14 mark.satterthwaite Slight modifications to IAB support for Metal output, so that the caller can specify an offset for the IAB start index, as for HLSL shaders UAVs need to occupy slots 0-7. The runtime support for SSBO robustness is also much simpler if the buffer size block is at index 0. Change made in two parts. 1. Allow the caller to specify the Metal translation should use argument buffers. 2. Move this to the front of IABs for convenience of the runtime.
2019-08-14 mark.satterthwaite Metal doesn't automatically enforce robust access to buffers unlike other APIs, so for storage-buffers, which become raw T* buffers in Metal, we need to fetch the buffer size and clamp the access to a valid index within the buffer ourselves. This is essential for shaders converted from HLSL which expects all resource access to be robust, though this implementation is technically different to the HLSL specification of return-0 for OOB reads, ignore OOB writes.
2019-08-14 mark.satterthwaite HLSL makes position calculations invariant by default to eliminate problems with depth-precision, Apple added a similar qualifier for Metal 2.1 that can and should be used in Vertex & Domain/TessEval shaders for the same effect.
2019-08-14 mark.satterthwaite When compiling from HLSL which pads and aligns float[]/float2[] within structures to float4[] we need to unpack the original type in Metal from the float4.
2019-08-14 mark.satterthwaite Fix conversion of the SampleMask intrinsic from SPIRV, where it is an array to Metal where it isn't.
2019-08-14 mark.satterthwaite Fixes to the generation of Metal tessellation shaders from SPIRV so that it works correctly in more complicated cases.     First, when generating from HLSL before invoking the code that comes from the HLSL patch-function a control-flow and full memory-barrier are required to ensure that all the temporary values in thread-local storage for the patch are available.     Second, the inputs to control and evaluation shaders must be properly forwarded from the global variables in SPIRV to the member variables in the relevant input structure.     Finally when arrays of interpolators are used for input or output we need to add an extra level of array indirection because Metal works at a different granularity than SPIRV.
2019-08-14 mark.satterthwaite Work-around HLSL using zero-based InstanceID and VertexID variables, but SPIRV, like Metal, includes BaseInstance & BaseVertex. Until this can be fixed in DXC, which is really the proper place to solve this, we can decrement InstanceID & VertexID when the source is HLSL. Made in two parts. 1. Handle HLSL-style 0-based vertex/instance index. 2. We zero-base the InstanceID & VertexID variables for HLSL emulation elsewhere, so don't do it twice.
2019-08-14 mark.satterthwaite On iOS sub-passes can be implemented using the frame-buffer fetch API which is much more efficient than binding the textures. Change was made in three parts. 1. Use Metal's native frame-buffer fetch API for subpass inputs. 2. Make sure that frame-buffer-fetch is only available on iOS. 3. Default to using Metal's native frame-buffer fetch for subpass inputs on iOS.
2019-08-14 mark.satterthwaite SPIRV doesn't distinguish depth textures from regular textures, but Metal does, so if we've ever seen a depth comparison operation we must ensure that the texture is specified as a depth-texture.
2019-08-14 mark.satterthwaite Emulate texture atomics in Metal by binding the underlying buffer that backs the resource to a separate binding point and using that for Metal's atomic operations. This will work with texture_buffer and texture2d created from an MTLBuffer, so is perfect for emulating HLSL atomics on RWBuffer and sufficient, but not ideal, for RWTexture2D with some restrictions (limited format support and can't be used for render-targets).
2019-08-14 mark.satterthwaite Support Metal 2.1's texture_buffer type which is the equivalent to HLSL's Buffer/RWBuffer, so doesn't require modifying buffer sizes to match alignments.
2019-08-13 mark.satterthwaite In order to use Metal shader libraries properly you have to ensure that you have no duplicated global symbol names for different entities, otherwise 'metallib' won't be able to combine multiple shaders into a single library. This is broken into two parts. 1. Constant arrays of non-primitive types (i.e. matrices) won't link properly into Metal libraries. 2. Metal helper functions must be static force-inline otherwise they will cause problems when linked together in a single Metallib.
2019-08-13 mark.satterthwaite Rework the way arrays are handled in Metal to remove the array copies as they are unnecessary from Metal 1.2. There were cases where copies were not being inserted and others appeared unncessary, using the template type should allow the 'metal' compiler to do the best possible optimisation. The changes are broken into three stages. 1. Allow Metal to use the array<T> template to make arrays a value type. 2. Force the use of C style array declaration for some cases which cannot be wrapped with a template. 3. Threadgroup arrays can't have a wrapper type. 4. Tweak the code to use unsafe_array in a few more places so that we can handle passing arrays of resources into the shader and then through shaders into sub-functions. 5. Handle packed matrix types inside arrays within structs. 6. Make sure that builtin arguments still retain their array qualifiers when used in leaf functions. 7. Fix declaration of array-of-array constants for Metal so we can use the array<T> template.
2019-08-13 mark.satterthwaite UE4 shader reference for those shaders that will compile without the changes.
2019-08-13 mark.satterthwaite Port the UE4 spirv shaders to ASM shaders that can be used in the test-rig - this will help show why the changes are required.
2019-08-13 mark.satterthwaite  Many interesting test cases for SPIRV-Cross taken from compiling UE4 shaders. These highlight the reasons for the various changes we've made.

Roll third_party/spirv-tools/ e8c3f9b0b..7e2cba6a5 (12 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/e8c3f9b0b463...7e2cba6a5241

$ git log e8c3f9b0b..7e2cba6a5 --date=short --no-merges --format='%ad %ae %s'
2019-10-29 bclayton utils/vscode: Change assembly file ext to .spvasm (#2995)
2019-10-28 bclayton utils: Add a vscode extension for SPIR-V disassembly files (#2987)
2019-10-28 greg Add two new simplifications. (#2984)
2019-10-28 afdx spirv-fuzz: Transformation to extract from a composite object (#2991)
2019-10-27 afdx spirv-fuzz: rename class, and fix bug related to dominance (#2990)
2019-10-25 afdx spirv-fuzz: Rework management of data synonyms (#2989)
2019-10-25 afdx spirv-fuzz: add class to represent equivalence relation (#2988)
2019-10-23 stevenperron Update DEPS (#2986)
2019-10-22 afdx spirv-fuzz: fuzzer pass to adjust memory access operands (#2968)
2019-10-22 greg Instrument: Add missing def-use analysis. (#2985)
2019-10-22 afdx spirv-fuzz: add missing functionality for matrix composites (#2974)
2019-10-21 stevenperron Update CHANGES

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools