### PR TITLE
Add --emit-line-drective option

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -88,6 +88,8 @@ SHADERC_EXPORT void shaderc_spvc_compile_options_set_remove_unused_variables(
 SHADERC_EXPORT void shaderc_spvc_compile_options_set_robust_buffer_access_pass(
     shaderc_spvc_compile_options_t options, bool b);
 
+SHADERC_EXPORT  void shaderc_spvc_compile_options_set_emit_line_directives(
+    shaderc_spvc_compile_options_t options, bool b);
 // Sets the source shader environment, affecting which warnings or errors will
 // be issued during validation.
 // Default value for environment is Vulkan 1.0.

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -137,6 +137,9 @@ class CompileOptions {
   void SetRobustBufferAccessPass(bool b){
     shaderc_spvc_compile_options_set_robust_buffer_access_pass(options_, b);
   }
+  void SetEmitLineDirectives(bool b){
+    shaderc_spvc_compile_options_set_emit_line_directives(options_, b);
+  }
   // If true, Vulkan GLSL features are used instead of GL-compatible features.
   void SetVulkanSemantics(bool b) {
     shaderc_spvc_compile_options_set_vulkan_semantics(options_, b);

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -61,6 +61,11 @@ void shaderc_spvc_compile_options_set_robust_buffer_access_pass(
   options->robust_buffer_access_pass = b;
 }
 
+void shaderc_spvc_compile_options_set_emit_line_directives(
+  shaderc_spvc_compile_options_t options, bool b){
+  options->glsl.emit_line_directives = b;
+}
+
 void shaderc_spvc_compile_options_set_vulkan_semantics(
     shaderc_spvc_compile_options_t options, bool b) {
   options->glsl.vulkan_semantics = b;

--- a/libshaderc_spvc/src/spvcir_pass.cc
+++ b/libshaderc_spvc/src/spvcir_pass.cc
@@ -32,7 +32,7 @@ SpvcIrPass::SpvcIrPass(spirv_cross::ParsedIR *ir) {
 
 Pass::Status SpvcIrPass::Process() {
   get_module()->ForEachInst(
-      [this](Instruction *inst) { GenerateSpirvCrossIR(inst); });
+      [this](Instruction *inst) { GenerateSpirvCrossIR(inst); }, true);
 
   assert(!current_function_ && "Function was not terminated.");
   assert(!current_block_ && "Block Was not terminated");

--- a/spvc/src/main.cc
+++ b/spvc/src/main.cc
@@ -86,6 +86,7 @@ Options:
   --msl-domain-lower-left
   --msl-argument-buffers
   --msl-discrete-descriptor-set=<number>
+  --emit-line-directives
   --hlsl-enable-compat
   --shader-model=<model>
 )";
@@ -240,6 +241,8 @@ int main(int argc, char** argv) {
         return 1;
       }
       msl_discrete_descriptor.push_back(descriptor_num);
+    } else if (arg == "--emit-line-directives") {
+      options.SetEmitLineDirectives(true);
     } else if (arg.starts_with("--shader-model=")) {
       string_piece shader_model_str;
       shaderc_util::GetOptionArgument(argc, argv, &i,

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -1,5 +1,3 @@
-shaders-hlsl/asm/frag/line-directive.line.asm.frag,False
-shaders-hlsl/asm/frag/line-directive.line.asm.frag,True
 shaders-hlsl/comp/num-workgroups-alone.comp,False
 shaders-hlsl/comp/num-workgroups-alone.comp,True
 shaders-hlsl/comp/num-workgroups-with-builtins.comp,False
@@ -10,8 +8,6 @@ shaders-hlsl/vert/basic.vert,False
 shaders-hlsl/vert/basic.vert,True
 shaders-msl/asm/comp/multiple-entry.asm.comp,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,True
-shaders-msl/asm/frag/line-directive.line.asm.frag,False
-shaders-msl/asm/frag/line-directive.line.asm.frag,True
 shaders-msl/asm/frag/min-lod.msl22.asm.frag,False
 shaders-msl/asm/frag/min-lod.msl22.asm.frag,True
 shaders-msl/comp/basic.dispatchbase.comp,False
@@ -101,8 +97,6 @@ shaders/asm/frag/complex-name-workarounds.asm.frag,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
-shaders/asm/frag/line-directive.line.asm.frag,False
-shaders/asm/frag/line-directive.line.asm.frag,True
 shaders/desktop-only/vert/basic.desktop.sso.vert,False
 shaders/desktop-only/vert/basic.desktop.sso.vert,True
 shaders/flatten/array.flatten.vert,False

--- a/spvc/test/run_spirv_cross_tests.py
+++ b/spvc/test/run_spirv_cross_tests.py
@@ -236,7 +236,8 @@ def test_glsl(test_env, shader, filename, optimize):
         flags.append('--glsl-emit-push-constant-as-ubo')
     if '.sso.' in filename:
         flags.append('--separate-shader-objects')
-
+    if '.line' in filename:
+        flags.append('--emit-line-directives')
     output = input_shader + filename
     if '.vk.' in filename:
         status, _ = test_env.run_spvc(
@@ -342,6 +343,8 @@ def test_msl(test_env, shader, filename, optimize):
     if '.discrete.' in shader:
         flags.append('--msl-discrete-descriptor-set=2')
         flags.append('--msl-discrete-descriptor-set=3')
+    if '.line' in filename:
+        flags.append('--emit-line-directives')
 
     output = input_shader + filename
     status, _ = test_env.run_spvc(input_shader, output, flags)
@@ -388,10 +391,12 @@ def test_hlsl(test_env, shader, filename, optimize):
         test_env.log_failure(shader, optimize)
         return successes, failures
 
+    flags = ['--entry=main', '--language=hlsl']
+    if '.line' in filename:
+        flags.append('--emit-line-directives')
     # Run spvc to convert Vulkan to HLSL.
     output = input_shader + filename
-    status, _ = test_env.run_spvc(input_shader, output, ['--entry=main', '--language=hlsl',
-                                                         '--hlsl-enable-compat', '--shader-model=' + lookup(shader_models, filename)])
+    status, _ = test_env.run_spvc(input_shader, output, flags + ['--hlsl-enable-compat', '--shader-model=' + lookup(shader_models, filename)])
     if not status:
         remove_files(input_shader)
         failures.append((shader, optimize))


### PR DESCRIPTION
Add --emit-line-directive option to spvc test script
Setting "run_on_debug_line_insts" to true in ForEachInst to avoid skipping OpLine instructions while parsing in spvcir pass
Removing 6 tests from known_failure which succeed as a result of adding this option