### PR TITLE
Rolling 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,13 +4,13 @@ vars = {
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
 
-  'effcee_revision' : 'cd25ec17e9382f99a895b9ef53ff3c277464d07d',
-  'glslang_revision': 'b131630e7c749a5dc19faa458024260c71fb170f',
-  'googletest_revision': 'ba33a8876c3eda4cb8def8e0e90f45930ef8c54f',
+  'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
+  'glslang_revision': '90cecb52067a665a444914f8696d6a42fcbd4ebf',
+  'googletest_revision': 'e8a82dc7ede61c4af3b9d75aa0e953b8cecfc8bb',
   're2_revision': 'eecfdbf1701dd7ebad2f28b9965ca09e0bfb45b0',
   'spirv_headers_revision': 'af64a9e826bf5bb5fcd2434dd71be1e41e922563',
-  'spirv_tools_revision': '7e2cba6a52415ee478d0e6e56c8699a6fe4a5b03',
-  'spirv_cross_revision': '00189b19a5da553c668290a051604209586b2139',
+  'spirv_tools_revision': 'f1e5cd73f658abcc23ee96d78f2dc27c4b7028c1',
+  'spirv_cross_revision': '24f209eb9306eb1ae184c0cd95afce279d696045',
 }
 
 deps = {

--- a/glslc/test/assembly.py
+++ b/glslc/test/assembly.py
@@ -21,7 +21,7 @@ def assembly_comments():
     return """
     ; SPIR-V
     ; Version: 1.0
-    ; Generator: Google Shaderc over Glslang; 7
+    ; Generator: Google Shaderc over Glslang; 8
     ; Bound: 6
     ; Schema: 0"""
 

--- a/glslc/test/expect.py
+++ b/glslc/test/expect.py
@@ -174,7 +174,7 @@ class CorrectBinaryLengthAndPreamble(GlslCTest):
             return False, 'Incorrect SPV binary: wrong version number'
         # Shaderc-over-Glslang (0x000d....) or
         # SPIRV-Tools (0x0007....) generator number
-        if read_word(preamble, 2, little_endian) != 0x000d0007 and \
+        if read_word(preamble, 2, little_endian) != 0x000d0008 and \
                 read_word(preamble, 2, little_endian) != 0x00070000:
             return False, ('Incorrect SPV binary: wrong generator magic '
                            'number')

--- a/glslc/test/option_dash_cap_O.py
+++ b/glslc/test/option_dash_cap_O.py
@@ -23,7 +23,7 @@ EMPTY_SHADER_IN_CWD = Directory('.', [File('shader.vert', MINIMAL_SHADER)])
 ASSEMBLY_WITH_DEBUG_SOURCE = [
     '; SPIR-V\n',
     '; Version: 1.0\n',
-    '; Generator: Google Shaderc over Glslang; 7\n',
+    '; Generator: Google Shaderc over Glslang; 8\n',
     '; Bound: 7\n',
     '; Schema: 0\n',
     '               OpCapability Shader\n',
@@ -51,7 +51,7 @@ ASSEMBLY_WITH_DEBUG_SOURCE = [
 ASSEMBLY_WITH_DEBUG = [
     '; SPIR-V\n',
     '; Version: 1.0\n',
-    '; Generator: Google Shaderc over Glslang; 7\n',
+    '; Generator: Google Shaderc over Glslang; 8\n',
     '; Bound: 6\n',
     '; Schema: 0\n',
     '               OpCapability Shader\n',
@@ -72,7 +72,7 @@ ASSEMBLY_WITH_DEBUG = [
 ASSEMBLY_WITHOUT_DEBUG = [
     '; SPIR-V\n',
     '; Version: 1.0\n',
-    '; Generator: Google Shaderc over Glslang; 7\n',
+    '; Generator: Google Shaderc over Glslang; 8\n',
     '; Bound: 6\n',
     '; Schema: 0\n',
     '               OpCapability Shader\n',

--- a/libshaderc/src/common_shaders_for_test.h
+++ b/libshaderc/src/common_shaders_for_test.h
@@ -233,7 +233,7 @@ const char kVertexOnlyShaderWithInvalidPragma[] =
 const char* kMinimalShaderDisassemblySubstrings[] = {
     "; SPIR-V\n"
     "; Version: 1.0\n"
-    "; Generator: Google Shaderc over Glslang; 7\n"
+    "; Generator: Google Shaderc over Glslang; 8\n"
     "; Bound:",
 
     "               OpCapability Shader\n",
@@ -245,7 +245,7 @@ const char* kMinimalShaderDisassemblySubstrings[] = {
 const char* kMinimalShaderDebugInfoDisassemblySubstrings[] = {
     "; SPIR-V\n"
     "; Version: 1.0\n"
-    "; Generator: Google Shaderc over Glslang; 7\n"
+    "; Generator: Google Shaderc over Glslang; 8\n"
     "; Bound:",
 
     "               OpCapability Shader\n",
@@ -257,7 +257,7 @@ const char* kMinimalShaderDebugInfoDisassemblySubstrings[] = {
 const char kMinimalShaderAssembly[] = R"(
     ; SPIR-V
     ; Version: 1.0
-    ; Generator: Google Shaderc over Glslang; 7
+    ; Generator: Google Shaderc over Glslang; 8
     ; Bound: 6
     ; Schema: 0
 

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -8,6 +8,9 @@ shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
 shaders-hlsl/vert/basic.vert,False
 shaders-hlsl/vert/basic.vert,True
+shaders-msl-no-opt/comp/loop.comp,False
+shaders-msl-no-opt/comp/return.comp,False
+shaders-msl-no-opt/vert/functions_nested.vert,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,True
 shaders-msl/asm/frag/line-directive.line.asm.frag,False
@@ -68,12 +71,15 @@ shaders-msl/vert/leaf-function.capture.vert,False
 shaders-msl/vert/leaf-function.capture.vert,True
 shaders-msl/vert/out_block.vert,False
 shaders-msl/vert/out_block.vert,True
+shaders-msl/vert/packed_matrix.vert,False
 shaders-msl/vert/pointsize.vert,False
 shaders-msl/vert/pointsize.vert,True
 shaders-msl/vert/sign-int-types.vert,False
 shaders-msl/vert/sign-int-types.vert,True
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,True
+shaders-no-opt/comp/loop.comp,False
+shaders-no-opt/comp/return.comp,False
 shaders-reflection/asm/aliased-entry-point-names.asm.multi,False
 shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp,False


### PR DESCRIPTION
Updated expectations file & tests for glslang 8

Roll third_party/effcee/ cd25ec17e..98980e2b7 (2 commits)

https://github.com/google/effcee/compare/cd25ec17e938...98980e2b7854

$ git log cd25ec17e..98980e2b7 --date=short --no-merges --format='%ad %ae %s'
2019-10-30 dneto Travis-CI: macOS: Run brew update first
2019-10-30 dneto Add namespace to make_unique to avoid potential collisions

Roll third_party/glslang/ b131630e7..90cecb520 (7 commits)

https://github.com/KhronosGroup/glslang/compare/b131630e7c74...90cecb52067a

$ git log b131630e7..90cecb520 --date=short --no-merges --format='%ad %ae %s'
2019-11-03 cepheus Tests: Add more test results for the previous generator version bump.
2019-11-02 cepheus Bump up the generator version, which is exposed in SPV test results.
2019-11-03 sk Fix warning: size_t->int implicit cast
2019-11-02 jmadill Add a couple missing headers to the GN build.
2019-11-01 cepheus Bump version.
2019-10-21 dneto SPIR-V: Aggressively prune unreachable merge, continue target
2019-10-25 sk Add option ENABLE_CTEST to skip testing

Roll third_party/googletest/ ba33a8876..e8a82dc7e (5 commits)

https://github.com/google/googletest/compare/ba33a8876c3e...e8a82dc7ede6

$ git log ba33a8876..e8a82dc7e --date=short --no-merges --format='%ad %ae %s'
2019-10-31 absl-team Googletest export
2019-10-30 absl-team Googletest export
2019-10-30 misterg Googletest export
2019-09-10 krystian.kuzniarek remove BiggestInt
2019-10-23 joshdcannon Revert "Merge pull request #2498 from thejcannon:noexcept_spec"

Roll third_party/spirv-cross/ 00189b19a..24f209eb9 (6 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/00189b19a5da...24f209eb9306

$ git log 00189b19a..24f209eb9 --date=short --no-merges --format='%ad %ae %s'
2019-11-04 post Add spvc_type_get_base_type_id.
2019-11-04 post C API: Add missing boolean options.
2019-11-04 post GLSL: Fix issue with array-of-array inputs in tess.
2019-11-01 dmalyshau Avoid including stdexcept in no-exception environment
2019-11-01 lehoangq Updated BUILD.gn's license to APACHE.
2019-10-31 lehoangq Added BUILD.gn file to be used by Chromium's ANGLE project

Roll third_party/spirv-tools/ 7e2cba6a5..f1e5cd73f (6 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/7e2cba6a5241...f1e5cd73f658

$ git log 7e2cba6a5..f1e5cd73f --date=short --no-merges --format='%ad %ae %s'
2019-11-01 afdx spirv-fuzz: improvements to representation of data synonym facts (#3006)
2019-11-01 stevenperron Add iOS as a supported platform (#3001)
2019-11-01 rharrison Reset pointers before iterating in fuzzer to avoid double free (#3003)
2019-10-30 dneto Fix some clang-tidy issues in graphics_robust_access_pass (#2998)
2019-10-30 stevenperron Add description of wrap-opkill. (#3000)
2019-10-30 kubak [opt] Do not compare optimized binary with an invalidated buffer (#2999)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools