### PR TITLE
Remove deprecated API elements

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -35,9 +35,6 @@ typedef enum {
 // An opaque handle to an object that manages all compiler state.
 typedef struct shaderc_spvc_context* shaderc_spvc_context_t;
 
-// DEPRECATED: Old name for opaque state handle.
-typedef shaderc_spvc_context_t shaderc_spvc_compiler_t;
-
 // Create a spvc state handle.  A return of NULL indicates that there was an
 // error. Any function operating on a *_context_t must offer the basic
 // thread-safety guarantee.
@@ -48,16 +45,9 @@ typedef shaderc_spvc_context_t shaderc_spvc_compiler_t;
 // argument.
 SHADERC_EXPORT shaderc_spvc_context_t shaderc_spvc_context_create(void);
 
-// DEPRECATED: Old function for creating state opaque handle.
-SHADERC_EXPORT shaderc_spvc_compiler_t shaderc_spvc_compiler_initialize(void);
-
 // Release resources.  After this the handle cannot be used.
 SHADERC_EXPORT void shaderc_spvc_context_destroy(
     shaderc_spvc_context_t context);
-
-// DEPRECATED: Old function for destroying state opaque handle.
-SHADERC_EXPORT void shaderc_spvc_compiler_release(
-    shaderc_spvc_compiler_t compiler);
 
 // An opaque handle to an object that manages options to a single compilation
 // result.
@@ -70,10 +60,6 @@ typedef struct shaderc_spvc_compile_options* shaderc_spvc_compile_options_t;
 SHADERC_EXPORT shaderc_spvc_compile_options_t
 shaderc_spvc_compile_options_create(void);
 
-// DEPRECATED: Old function for creating options opaque handle.
-SHADERC_EXPORT shaderc_spvc_compile_options_t
-shaderc_spvc_compile_options_initialize(void);
-
 // Returns a copy of the given options.
 // If NULL is passed as the parameter the call is the same as
 // shaderc_spvc_compile_options_init.
@@ -85,10 +71,6 @@ shaderc_spvc_compile_options_clone(
 // option object in any future calls. It is safe to pass
 // NULL to this function, and doing such will have no effect.
 SHADERC_EXPORT void shaderc_spvc_compile_options_destroy(
-    shaderc_spvc_compile_options_t options);
-
-// DEPRECATED: Old function for destroying options opaque handle.
-SHADERC_EXPORT void shaderc_spvc_compile_options_release(
     shaderc_spvc_compile_options_t options);
 
 // Sets the entry point.
@@ -265,10 +247,6 @@ shaderc_spvc_compile_into_vulkan(const shaderc_spvc_context_t context,
 // Destroys the resources held by the result object. It is invalid to use the
 // result object for any further operations.
 SHADERC_EXPORT void shaderc_spvc_result_destroy(
-    shaderc_spvc_compilation_result_t result);
-
-// DEPRECATED: Old function for destroying the result object.
-SHADERC_EXPORT void shaderc_spvc_result_release(
     shaderc_spvc_compilation_result_t result);
 
 // Returns the compilation status, indicating whether the compilation succeeded,

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -331,9 +331,6 @@ class Context {
   shaderc_spvc_context_t state_;
 };
 
-// DEPRECATED: Old version of Context.
-class Compiler : public Context {};
-
 }  // namespace shaderc_spvc
 
 #endif  // SHADERC_SPVC_HPP_

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -23,10 +23,6 @@ shaderc_spvc_compile_options_t shaderc_spvc_compile_options_create() {
   return options;
 }
 
-shaderc_spvc_compile_options_t shaderc_spvc_compile_options_initialize(void) {
-  return shaderc_spvc_compile_options_create();
-}
-
 shaderc_spvc_compile_options_t shaderc_spvc_compile_options_clone(
     shaderc_spvc_compile_options_t options) {
   if (options) return new (std::nothrow) shaderc_spvc_compile_options(*options);
@@ -36,11 +32,6 @@ shaderc_spvc_compile_options_t shaderc_spvc_compile_options_clone(
 void shaderc_spvc_compile_options_destroy(
     shaderc_spvc_compile_options_t options) {
   if (options) delete options;
-}
-
-void shaderc_spvc_compile_options_release(
-    shaderc_spvc_compile_options_t options) {
-  shaderc_spvc_compile_options_destroy(options);
 }
 
 void shaderc_spvc_compile_options_set_source_env(
@@ -209,16 +200,8 @@ shaderc_spvc_context_t shaderc_spvc_context_create() {
   return new (std::nothrow) shaderc_spvc_context;
 }
 
-shaderc_spvc_compiler_t shaderc_spvc_compiler_initialize(void) {
-  return shaderc_spvc_context_create();
-}
-
 void shaderc_spvc_context_destroy(shaderc_spvc_context_t context) {
   if (context) delete context;
-}
-
-void shaderc_spvc_compiler_release(shaderc_spvc_compiler_t compiler) {
-  shaderc_spvc_context_destroy(compiler);
 }
 
 shaderc_spvc_compilation_result_t shaderc_spvc_compile_into_glsl(
@@ -359,8 +342,4 @@ shaderc_compilation_status shaderc_spvc_result_get_status(
 
 void shaderc_spvc_result_destroy(shaderc_spvc_compilation_result_t result) {
   if (result) delete result;
-}
-
-void shaderc_spvc_result_release(shaderc_spvc_compilation_result_t result) {
-  shaderc_spvc_result_destroy(result);
 }

--- a/libshaderc_spvc/src/spvc_cpp_test.cc
+++ b/libshaderc_spvc/src/spvc_cpp_test.cc
@@ -24,10 +24,10 @@ using shaderc_spvc::Context;
 namespace {
 
 TEST(Compile, Glsl) {
-  Context compiler;
+  Context context;
   CompileOptions options;
 
-  CompilationResult result = compiler.CompileSpvToGlsl(
+  CompilationResult result = context.CompileSpvToGlsl(
       kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
       options);
   EXPECT_EQ(shaderc_compilation_status_success, result.GetCompilationStatus());
@@ -36,10 +36,10 @@ TEST(Compile, Glsl) {
 }
 
 TEST(Compile, Hlsl) {
-  Context compiler;
+  Context context;
   CompileOptions options;
 
-  CompilationResult result = compiler.CompileSpvToHlsl(
+  CompilationResult result = context.CompileSpvToHlsl(
       kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
       options);
   EXPECT_EQ(shaderc_compilation_status_success, result.GetCompilationStatus());
@@ -48,10 +48,10 @@ TEST(Compile, Hlsl) {
 }
 
 TEST(Compile, Msl) {
-  Context compiler;
+  Context context;
   CompileOptions options;
 
-  CompilationResult result = compiler.CompileSpvToMsl(
+  CompilationResult result = context.CompileSpvToMsl(
       kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
       options);
   EXPECT_EQ(shaderc_compilation_status_success, result.GetCompilationStatus());
@@ -60,10 +60,10 @@ TEST(Compile, Msl) {
 }
 
 TEST(Compile, Vulkan) {
-  Context compiler;
+  Context context;
   CompileOptions options;
 
-  CompilationResult result = compiler.CompileSpvToVulkan(
+  CompilationResult result = context.CompileSpvToVulkan(
       kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
       options);
   EXPECT_EQ(shaderc_compilation_status_success, result.GetCompilationStatus());

--- a/libshaderc_spvc/src/spvc_webgpu_cpp_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_cpp_test.cc
@@ -24,14 +24,14 @@ using shaderc_spvc::Context;
 namespace {
 
 TEST(Compile, Glsl) {
-  Context compiler;
+  Context context;
   CompileOptions options;
   options.SetSourceEnvironment(shaderc_target_env_webgpu,
                                shaderc_env_version_webgpu);
   options.SetTargetEnvironment(shaderc_target_env_vulkan,
                                shaderc_env_version_vulkan_1_1);
 
-  CompilationResult result = compiler.CompileSpvToGlsl(
+  CompilationResult result = context.CompileSpvToGlsl(
       kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
       options);
   EXPECT_EQ(shaderc_compilation_status_success, result.GetCompilationStatus());
@@ -40,14 +40,14 @@ TEST(Compile, Glsl) {
 }
 
 TEST(Compile, Hlsl) {
-  Context compiler;
+  Context context;
   CompileOptions options;
   options.SetSourceEnvironment(shaderc_target_env_webgpu,
                                shaderc_env_version_webgpu);
   options.SetTargetEnvironment(shaderc_target_env_vulkan,
                                shaderc_env_version_vulkan_1_1);
 
-  CompilationResult result = compiler.CompileSpvToHlsl(
+  CompilationResult result = context.CompileSpvToHlsl(
       kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
       options);
   EXPECT_EQ(shaderc_compilation_status_success, result.GetCompilationStatus());
@@ -56,14 +56,14 @@ TEST(Compile, Hlsl) {
 }
 
 TEST(Compile, Msl) {
-  Context compiler;
+  Context context;
   CompileOptions options;
   options.SetSourceEnvironment(shaderc_target_env_webgpu,
                                shaderc_env_version_webgpu);
   options.SetTargetEnvironment(shaderc_target_env_vulkan,
                                shaderc_env_version_vulkan_1_1);
 
-  CompilationResult result = compiler.CompileSpvToMsl(
+  CompilationResult result = context.CompileSpvToMsl(
       kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
       options);
   EXPECT_EQ(shaderc_compilation_status_success, result.GetCompilationStatus());
@@ -72,14 +72,14 @@ TEST(Compile, Msl) {
 }
 
 TEST(Compile, Vulkan) {
-  Context compiler;
+  Context context;
   CompileOptions options;
   options.SetSourceEnvironment(shaderc_target_env_webgpu,
                                shaderc_env_version_webgpu);
   options.SetTargetEnvironment(shaderc_target_env_vulkan,
                                shaderc_env_version_vulkan_1_1);
 
-  CompilationResult result = compiler.CompileSpvToVulkan(
+  CompilationResult result = context.CompileSpvToVulkan(
       kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
       options);
   EXPECT_EQ(shaderc_compilation_status_success, result.GetCompilationStatus());

--- a/spvc/src/main.cc
+++ b/spvc/src/main.cc
@@ -121,7 +121,7 @@ bool ReadFile(const std::string& path, std::vector<uint32_t>* out) {
 }  // anonymous namespace
 
 int main(int argc, char** argv) {
-  shaderc_spvc::Context compiler;
+  shaderc_spvc::Context context;
   shaderc_spvc::CompileOptions options;
   std::vector<uint32_t> input;
   std::vector<uint32_t> msl_discrete_descriptor;
@@ -321,17 +321,17 @@ int main(int argc, char** argv) {
 
   shaderc_spvc::CompilationResult result;
   if (output_language == "glsl") {
-    result = compiler.CompileSpvToGlsl((const uint32_t*)input.data(),
-                                       input.size(), options);
-  } else if (output_language == "msl") {
-    result = compiler.CompileSpvToMsl((const uint32_t*)input.data(),
+    result = context.CompileSpvToGlsl((const uint32_t*)input.data(),
                                       input.size(), options);
+  } else if (output_language == "msl") {
+    result = context.CompileSpvToMsl((const uint32_t*)input.data(),
+                                     input.size(), options);
   } else if (output_language == "hlsl") {
-    result = compiler.CompileSpvToHlsl((const uint32_t*)input.data(),
-                                       input.size(), options);
+    result = context.CompileSpvToHlsl((const uint32_t*)input.data(),
+                                      input.size(), options);
   } else if (output_language == "vulkan") {
-    result = compiler.CompileSpvToVulkan((const uint32_t*)input.data(),
-                                         input.size(), options);
+    result = context.CompileSpvToVulkan((const uint32_t*)input.data(),
+                                        input.size(), options);
   }
 
   auto status = result.GetCompilationStatus();


### PR DESCRIPTION
Dawn, the only known consumer of this API, has migrated away from
using these functions/classes/types.