### PR TITLE
Split spvc shader generation into initialize and compile phases

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -216,37 +216,63 @@ SHADERC_EXPORT size_t shaderc_spvc_compile_options_set_for_fuzzing(
     shaderc_spvc_compile_options_t options, const uint8_t* data, size_t size);
 
 // An opaque handle to the results of a call to any
-// shaderc_spvc_compile_into_*() function.
+// shaderc_spvc_*_compile_*() function.
 typedef struct shaderc_spvc_compilation_result*
     shaderc_spvc_compilation_result_t;
 
-// Takes SPIR-V as a sequence of 32-bit words, validates it, then compiles to
-// GLSL.
+// Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
+// internal compiler for translating to GLSL and performing reflection.
+SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_initialize_for_glsl(
+    const shaderc_spvc_context_t context, const uint32_t* source,
+    size_t source_len, shaderc_spvc_compile_options_t options);
+
+// DEPRECATED
 SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_compile_into_glsl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result);
 
-// Takes SPIR-V as a sequence of 32-bit words, validates it, then compiles to
-// HLSL.
+// Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
+// internal compiler for translating to HLSL and performing reflection.
+SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_initialize_for_hlsl(
+    const shaderc_spvc_context_t context, const uint32_t* source,
+    size_t source_len, shaderc_spvc_compile_options_t options);
+
+// DEPRECATED
 SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_compile_into_hlsl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result);
 
-// Takes SPIR-V as a sequence of 32-bit words, validates it, then compiles to
-// MSL.
+// Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
+// internal compiler for translating to MSL and performing reflection.
+SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_initialize_for_msl(
+    const shaderc_spvc_context_t context, const uint32_t* source,
+    size_t source_len, shaderc_spvc_compile_options_t options);
+
+// DEPRECATED
 SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_compile_into_msl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result);
 
-// Takes SPIR-V as a sequence of 32-bit words, validates it, then compiles to
-// Vullkan specific SPIR-V.
+// Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
+// internal compiler for translating to Vulkan and performing reflection.
+SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_initialize_for_vulkan(
+    const shaderc_spvc_context_t context, const uint32_t* source,
+    size_t source_len, shaderc_spvc_compile_options_t options);
+
+// DEPRECATED
 SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_compile_into_vulkan(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options,
     shaderc_spvc_compilation_result_t result);
+
+// Given an initialized compiler, generates a shader of the appropriate
+// language.
+SHADERC_EXPORT shaderc_compilation_status
+shaderc_spvc_compile_shader(const shaderc_spvc_context_t context,
+                            shaderc_spvc_compilation_result_t result);
 
 // The following functions, operating on shaderc_spvc_compilation_result_t
 // objects, offer only the basic thread-safety guarantee.

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -290,7 +290,15 @@ class Context {
     return shaderc_spvc_context_get_messages(context_.get());
   }
 
-  // Compiles the given source SPIR-V to GLSL.
+  // Initializes state for compiling SPIR-V to GLSL.
+  shaderc_compilation_status InitializeForGlsl(
+      const uint32_t* source, size_t source_len,
+      const CompileOptions& options) const {
+    return shaderc_spvc_initialize_for_glsl(context_.get(), source, source_len,
+                                            options.options_.get());
+  }
+
+  // DEPRECATED
   shaderc_compilation_status CompileSpvToGlsl(const uint32_t* source,
                                               size_t source_len,
                                               const CompileOptions& options,
@@ -300,7 +308,15 @@ class Context {
                                           result->result_.get());
   }
 
-  // Compiles the given source SPIR-V to HLSL.
+  // Initializes state for compiling SPIR-V to HLSL.
+  shaderc_compilation_status InitializeForHlsl(
+      const uint32_t* source, size_t source_len,
+      const CompileOptions& options) const {
+    return shaderc_spvc_initialize_for_hlsl(context_.get(), source, source_len,
+                                            options.options_.get());
+  }
+
+  // DEPRECATED
   shaderc_compilation_status CompileSpvToHlsl(const uint32_t* source,
                                               size_t source_len,
                                               const CompileOptions& options,
@@ -310,7 +326,15 @@ class Context {
                                           result->result_.get());
   }
 
-  // Compiles the given source SPIR-V to MSL.
+  // Initializes state for compiling SPIR-V to MSL.
+  shaderc_compilation_status InitializeForMsl(
+      const uint32_t* source, size_t source_len,
+      const CompileOptions& options) const {
+    return shaderc_spvc_initialize_for_msl(context_.get(), source, source_len,
+                                           options.options_.get());
+  }
+
+  // DEPRECATED
   shaderc_compilation_status CompileSpvToMsl(const uint32_t* source,
                                              size_t source_len,
                                              const CompileOptions& options,
@@ -320,13 +344,26 @@ class Context {
                                          result->result_.get());
   }
 
-  // Compiles the given source SPIR-V to Vulkan.
+  // Initializes state for compiling SPIR-V to Vulkan.
+  shaderc_compilation_status InitializeForVulkan(
+      const uint32_t* source, size_t source_len,
+      const CompileOptions& options) const {
+    return shaderc_spvc_initialize_for_vulkan(
+        context_.get(), source, source_len, options.options_.get());
+  }
+
+  // DEPRECATED
   shaderc_compilation_status CompileSpvToVulkan(
       const uint32_t* source, size_t source_len, const CompileOptions& options,
       CompilationResult* result) const {
     return shaderc_spvc_compile_into_vulkan(context_.get(), source, source_len,
                                             options.options_.get(),
                                             result->result_.get());
+  }
+
+  // After initialization compile the shader to desired language.
+  shaderc_compilation_status CompileShader(CompilationResult* result) {
+    return shaderc_spvc_compile_shader(context_.get(), result->result_.get());
   }
 
  private:

--- a/libshaderc_spvc/src/spvc_cpp_test.cc
+++ b/libshaderc_spvc/src/spvc_cpp_test.cc
@@ -31,36 +31,48 @@ class CompileTest : public testing::Test {
 };
 
 TEST_F(CompileTest, Glsl) {
-  shaderc_compilation_status status = context_.CompileSpvToGlsl(
+  shaderc_compilation_status status = context_.InitializeForGlsl(
       kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
-      options_, &result_);
+      options_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
+
+  status = context_.CompileShader(&result_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(0, result_.GetStringOutput().size());
   EXPECT_EQ(0, result_.GetBinaryOutput().size());
 }
 
 TEST_F(CompileTest, Hlsl) {
-  shaderc_compilation_status status = context_.CompileSpvToHlsl(
+  shaderc_compilation_status status = context_.InitializeForHlsl(
       kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
-      options_, &result_);
+      options_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
+
+  status = context_.CompileShader(&result_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(0, result_.GetStringOutput().size());
   EXPECT_EQ(0, result_.GetBinaryOutput().size());
 }
 
 TEST_F(CompileTest, Msl) {
-  shaderc_compilation_status status = context_.CompileSpvToMsl(
+  shaderc_compilation_status status = context_.InitializeForMsl(
       kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
-      options_, &result_);
+      options_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
+
+  status = context_.CompileShader(&result_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(0, result_.GetStringOutput().size());
   EXPECT_EQ(0, result_.GetBinaryOutput().size());
 }
 
 TEST_F(CompileTest, Vulkan) {
-  shaderc_compilation_status status = context_.CompileSpvToVulkan(
+  shaderc_compilation_status status = context_.InitializeForVulkan(
       kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
-      options_, &result_);
+      options_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
+
+  status = context_.CompileShader(&result_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_EQ(0, result_.GetStringOutput().size());
   EXPECT_NE(0, result_.GetBinaryOutput().size());

--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -172,16 +172,15 @@ shaderc_compilation_status generate_shader(
   }
 }
 
-shaderc_compilation_status generate_glsl_shader(
+shaderc_compilation_status generate_glsl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options,
-    shaderc_spvc_compilation_result_t result) {
+    size_t source_len, shaderc_spvc_compile_options_t options) {
   spirv_cross::CompilerGLSL* cross_compiler;
-  shaderc_compilation_status status;
 // spvc IR generation is under development, for now run spirv-cross
 // compiler(SHADERC_ENABLE_SPVC_PARSER is OFF by default)
 // TODO (sarahM0): change the default to spvc IR generation when it's done
 #if SHADERC_ENABLE_SPVC_PARSER
+  shaderc_compilation_status status;
   spirv_cross::ParsedIR ir;
   status = generate_spvcir(context, &ir, source, source_len, options);
   if (status != shaderc_compilation_status_success) {
@@ -294,27 +293,18 @@ shaderc_compilation_status generate_glsl_shader(
 
   cross_compiler->set_common_options(options->glsl);
 
-  status = generate_shader(cross_compiler, result);
-  if (status != shaderc_compilation_status_success) {
-    context->messages.append("Compilation failed.  Partial source:\n");
-    context->messages.append(cross_compiler->get_partial_source());
-    context->cross_compiler.reset();
-    return status;
-  }
-
   return shaderc_compilation_status_success;
 }
 
-shaderc_compilation_status generate_hlsl_shader(
+shaderc_compilation_status generate_hlsl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options,
-    shaderc_spvc_compilation_result_t result) {
+    size_t source_len, shaderc_spvc_compile_options_t options) {
   spirv_cross::CompilerHLSL* cross_compiler;
-  shaderc_compilation_status status;
 // spvc IR generation is under development, for now run spirv-cross
 // compiler(SHADERC_ENABLE_SPVC_PARSER is OFF by default)
 // TODO (sarahM0): change the default to spvc IR generation when it's done
 #if SHADERC_ENABLE_SPVC_PARSER
+  shaderc_compilation_status status;
   spirv_cross::ParsedIR ir;
   status = generate_spvcir(context, &ir, source, source_len, options);
   if (status != shaderc_compilation_status_success) {
@@ -340,28 +330,18 @@ shaderc_compilation_status generate_hlsl_shader(
   cross_compiler->set_common_options(options->glsl);
   cross_compiler->set_hlsl_options(options->hlsl);
 
-  status = generate_shader(cross_compiler, result);
-  if (status != shaderc_compilation_status_success) {
-    context->messages.append("Compilation failed.  Partial source:\n");
-    context->messages.append(cross_compiler->get_partial_source());
-    context->cross_compiler.reset();
-    return status;
-  }
-
   return shaderc_compilation_status_success;
 }
 
-shaderc_compilation_status generate_msl_shader(
+shaderc_compilation_status generate_msl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options,
-    shaderc_spvc_compilation_result_t result) {
+    size_t source_len, shaderc_spvc_compile_options_t options) {
   spirv_cross::CompilerMSL* cross_compiler;
-  shaderc_compilation_status status;
-
 // spvc IR generation is under development, for now run spirv-cross
 // compiler(SHADERC_ENABLE_SPVC_PARSER is OFF by default)
 // TODO (sarahM0): change the default to spvc IR generation when it's done
 #if SHADERC_ENABLE_SPVC_PARSER
+  shaderc_compilation_status status;
   spirv_cross::ParsedIR ir;
   status = generate_spvcir(context, &ir, source, source_len, options);
   if (status != shaderc_compilation_status_success) {
@@ -389,21 +369,12 @@ shaderc_compilation_status generate_msl_shader(
   for (auto i : options->msl_discrete_descriptor_sets)
     cross_compiler->add_discrete_descriptor_set(i);
 
-  status = generate_shader(cross_compiler, result);
-  if (status != shaderc_compilation_status_success) {
-    context->messages.append("Compilation failed.  Partial source:\n");
-    context->messages.append(cross_compiler->get_partial_source());
-    context->cross_compiler.reset();
-    return status;
-  }
-
   return shaderc_compilation_status_success;
 }
 
-shaderc_compilation_status generate_vulkan_shader(
+shaderc_compilation_status generate_vulkan_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options,
-    shaderc_spvc_compilation_result_t result) {
+    size_t source_len, shaderc_spvc_compile_options_t options) {
   spirv_cross::CompilerReflection* cross_compiler;
 
 // spvc IR generation is under development, for now run spirv-cross

--- a/libshaderc_spvc/src/spvc_private.h
+++ b/libshaderc_spvc/src/spvc_private.h
@@ -26,9 +26,19 @@
 // GLSL version produced when none specified nor detected from source.
 #define DEFAULT_GLSL_VERSION 450
 
+typedef enum {
+  SPVC_TARGET_LANG_UNKNOWN,
+  SPVC_TARGET_LANG_GLSL,
+  SPVC_TARGET_LANG_HLSL,
+  SPVC_TARGET_LANG_MSL,
+  SPVC_TARGET_LANG_VULKAN,
+} spvc_target_lang;
+
 struct shaderc_spvc_context {
   std::unique_ptr<spirv_cross::Compiler> cross_compiler;
   std::string messages;
+  spvc_target_lang target_lang = SPVC_TARGET_LANG_UNKNOWN;
+  std::vector<uint32_t> intermediate_shader;
 };
 
 struct shaderc_spvc_compile_options {
@@ -95,37 +105,29 @@ shaderc_compilation_status validate_and_translate_spirv(
 shaderc_compilation_status generate_shader(
     spirv_cross::Compiler* compiler, shaderc_spvc_compilation_result_t result);
 
-// Given a Vulkan SPIR-V shader and set of options generate a GLSL shader.
-// Handles correctly setting up the SPIRV-Cross compiler based on the options
-// and then envoking it.
-shaderc_compilation_status generate_glsl_shader(
+// Given a Vulkan SPIR-V shader and set of options, create a compiler for
+// generating a GLSL shader and performing reflection.
+shaderc_compilation_status generate_glsl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options,
-    shaderc_spvc_compilation_result_t result);
+    size_t source_len, shaderc_spvc_compile_options_t options);
 
-// Given a Vulkan SPIR-V shader and set of options generate a HLSL shader.
-// Handles correctly setting up the SPIRV-Cross compiler based on the options
-// and then envoking it.
-shaderc_compilation_status generate_hlsl_shader(
+// Given a Vulkan SPIR-V shader and set of options, create a compiler for
+// generating a HLSL shader and performing reflection.
+shaderc_compilation_status generate_hlsl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options,
-    shaderc_spvc_compilation_result_t result);
+    size_t source_len, shaderc_spvc_compile_options_t options);
 
-// Given a Vulkan SPIR-V shader and set of options generate a MSL shader.
-// Handles correctly setting up the SPIRV-Cross compiler based on the options
-// and then envoking it.
-shaderc_compilation_status generate_msl_shader(
+// Given a Vulkan SPIR-V shader and set of options, create a compiler for
+// generating a MSL shader and performing reflection.
+shaderc_compilation_status generate_msl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options,
-    shaderc_spvc_compilation_result_t result);
+    size_t source_len, shaderc_spvc_compile_options_t options);
 
-// Given a Vulkan SPIR-V shader and set of options, generate a Vulkan shader.
-// Is a No-op from the perspective of converting the shader, but setup a
-// SPIRV-Cross compiler to be used for reflection later.
-shaderc_compilation_status generate_vulkan_shader(
+// Given a Vulkan SPIR-V shader and set of options, create a compiler for
+// generating performing reflection.
+shaderc_compilation_status generate_vulkan_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options,
-    shaderc_spvc_compilation_result_t result);
+    size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Given a pointer to an SPIRV-Cross IR (with initialized spirv field), Invokes
 // spirv-opt to generate a SPIRV-Cross IR (ie. populate empty fields of the

--- a/libshaderc_spvc/src/spvc_test.cc
+++ b/libshaderc_spvc/src/spvc_test.cc
@@ -71,65 +71,77 @@ TEST(Init, MultipleThreadsCalling) {
 #endif
 
 TEST_F(CompileTest, ValidShaderIntoGlslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_compile_into_glsl(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_glsl(
       context_, kSmokeShaderBinary,
-      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(context_->cross_compiler.get(), nullptr);
+
+  status = shaderc_spvc_compile_shader(context_, result_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
 }
 
 TEST_F(CompileTest, InvalidShaderIntoGlslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_compile_into_glsl(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_glsl(
       context_, kInvalidShaderBinary,
-      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_NE(shaderc_compilation_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 
 TEST_F(CompileTest, ValidShaderIntoHlslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_compile_into_hlsl(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_hlsl(
       context_, kSmokeShaderBinary,
-      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(context_->cross_compiler.get(), nullptr);
+
+  status = shaderc_spvc_compile_shader(context_, result_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
 }
 
 TEST_F(CompileTest, InvalidShaderIntoHlslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_compile_into_hlsl(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_hlsl(
       context_, kInvalidShaderBinary,
-      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_NE(shaderc_compilation_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 
 TEST_F(CompileTest, ValidShaderIntoMslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_compile_into_msl(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_msl(
       context_, kSmokeShaderBinary,
-      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(context_->cross_compiler.get(), nullptr);
+
+  status = shaderc_spvc_compile_shader(context_, result_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
 }
 
 TEST_F(CompileTest, InvalidShaderIntoMslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_compile_into_msl(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_msl(
       context_, kInvalidShaderBinary,
-      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_NE(shaderc_compilation_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 
 TEST_F(CompileTest, ValidShaderIntoVulkanPasses) {
-  shaderc_compilation_status status = shaderc_spvc_compile_into_vulkan(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_vulkan(
       context_, kSmokeShaderBinary,
-      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(context_->cross_compiler.get(), nullptr);
+
+  status = shaderc_spvc_compile_shader(context_, result_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
 }
 
 TEST_F(CompileTest, InvalidShaderIntoVulkanPasses) {
-  shaderc_compilation_status status = shaderc_spvc_compile_into_vulkan(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_vulkan(
       context_, kInvalidShaderBinary,
-      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_NE(shaderc_compilation_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }

--- a/libshaderc_spvc/src/spvc_webgpu_cpp_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_cpp_test.cc
@@ -25,62 +25,61 @@ namespace {
 
 class CompileTest : public testing::Test {
  public:
+  void SetUp() override {
+    options_.SetSourceEnvironment(shaderc_target_env_webgpu,
+                                  shaderc_env_version_webgpu);
+    options_.SetTargetEnvironment(shaderc_target_env_vulkan,
+                                  shaderc_env_version_vulkan_1_1);
+  }
+
   Context context_;
   CompileOptions options_;
   CompilationResult result_;
 };
 
 TEST_F(CompileTest, Glsl) {
-  options_.SetSourceEnvironment(shaderc_target_env_webgpu,
-                                shaderc_env_version_webgpu);
-  options_.SetTargetEnvironment(shaderc_target_env_vulkan,
-                                shaderc_env_version_vulkan_1_1);
-
-  shaderc_compilation_status status = context_.CompileSpvToGlsl(
+  shaderc_compilation_status status = context_.InitializeForGlsl(
       kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
-      options_, &result_);
+      options_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
+
+  status = context_.CompileShader(&result_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(0, result_.GetStringOutput().size());
   EXPECT_EQ(0, result_.GetBinaryOutput().size());
 }
 
 TEST_F(CompileTest, Hlsl) {
-  options_.SetSourceEnvironment(shaderc_target_env_webgpu,
-                                shaderc_env_version_webgpu);
-  options_.SetTargetEnvironment(shaderc_target_env_vulkan,
-                                shaderc_env_version_vulkan_1_1);
-
-  shaderc_compilation_status status = context_.CompileSpvToHlsl(
+  shaderc_compilation_status status = context_.InitializeForHlsl(
       kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
-      options_, &result_);
+      options_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
+
+  status = context_.CompileShader(&result_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(0, result_.GetStringOutput().size());
   EXPECT_EQ(0, result_.GetBinaryOutput().size());
 }
 
 TEST_F(CompileTest, Msl) {
-  options_.SetSourceEnvironment(shaderc_target_env_webgpu,
-                                shaderc_env_version_webgpu);
-  options_.SetTargetEnvironment(shaderc_target_env_vulkan,
-                                shaderc_env_version_vulkan_1_1);
-
-  shaderc_compilation_status status = context_.CompileSpvToMsl(
+  shaderc_compilation_status status = context_.InitializeForMsl(
       kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
-      options_, &result_);
+      options_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
+
+  status = context_.CompileShader(&result_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(0, result_.GetStringOutput().size());
   EXPECT_EQ(0, result_.GetBinaryOutput().size());
 }
 
 TEST_F(CompileTest, Vulkan) {
-  options_.SetSourceEnvironment(shaderc_target_env_webgpu,
-                                shaderc_env_version_webgpu);
-  options_.SetTargetEnvironment(shaderc_target_env_vulkan,
-                                shaderc_env_version_vulkan_1_1);
-
-  shaderc_compilation_status status = context_.CompileSpvToVulkan(
+  shaderc_compilation_status status = context_.InitializeForVulkan(
       kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
-      options_, &result_);
+      options_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
+
+  status = context_.CompileShader(&result_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_EQ(0, result_.GetStringOutput().size());
   EXPECT_NE(0, result_.GetBinaryOutput().size());

--- a/libshaderc_spvc/src/spvc_webgpu_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_test.cc
@@ -28,6 +28,11 @@ class CompileTest : public testing::Test {
     context_ = shaderc_spvc_context_create();
     options_ = shaderc_spvc_compile_options_create();
     result_ = shaderc_spvc_result_create();
+
+    shaderc_spvc_compile_options_set_source_env(
+        options_, shaderc_target_env_webgpu, shaderc_env_version_webgpu);
+    shaderc_spvc_compile_options_set_target_env(
+        options_, shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_1);
   }
 
   void TearDown() override {
@@ -42,55 +47,47 @@ class CompileTest : public testing::Test {
 };
 
 TEST_F(CompileTest, ValidShaderIntoGlslPasses) {
-  shaderc_spvc_compile_options_set_source_env(
-      options_, shaderc_target_env_webgpu, shaderc_env_version_webgpu);
-  shaderc_spvc_compile_options_set_target_env(
-      options_, shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_1);
-
-  shaderc_compilation_status status = shaderc_spvc_compile_into_glsl(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_glsl(
       context_, kWebGPUShaderBinary,
-      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(context_->cross_compiler.get(), nullptr);
+
+  status = shaderc_spvc_compile_shader(context_, result_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
 }
 
 TEST_F(CompileTest, ValidShaderIntoHlslPasses) {
-  shaderc_spvc_compile_options_set_source_env(
-      options_, shaderc_target_env_webgpu, shaderc_env_version_webgpu);
-  shaderc_spvc_compile_options_set_target_env(
-      options_, shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_1);
-
-  shaderc_compilation_status status = shaderc_spvc_compile_into_hlsl(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_hlsl(
       context_, kWebGPUShaderBinary,
-      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(context_->cross_compiler.get(), nullptr);
+
+  status = shaderc_spvc_compile_shader(context_, result_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
 }
 
 TEST_F(CompileTest, ValidShaderIntoMslPasses) {
-  shaderc_spvc_compile_options_set_source_env(
-      options_, shaderc_target_env_webgpu, shaderc_env_version_webgpu);
-  shaderc_spvc_compile_options_set_target_env(
-      options_, shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_1);
-
-  shaderc_compilation_status status = shaderc_spvc_compile_into_msl(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_msl(
       context_, kWebGPUShaderBinary,
-      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(context_->cross_compiler.get(), nullptr);
+
+  status = shaderc_spvc_compile_shader(context_, result_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
 }
 
 TEST_F(CompileTest, ValidShaderIntoVulkanPasses) {
-  shaderc_spvc_compile_options_set_source_env(
-      options_, shaderc_target_env_webgpu, shaderc_env_version_webgpu);
-  shaderc_spvc_compile_options_set_target_env(
-      options_, shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_1);
-
-  shaderc_compilation_status status = shaderc_spvc_compile_into_vulkan(
+  shaderc_compilation_status status = shaderc_spvc_initialize_for_vulkan(
       context_, kWebGPUShaderBinary,
-      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_, result_);
+      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
   EXPECT_EQ(shaderc_compilation_status_success, status);
   EXPECT_NE(context_->cross_compiler.get(), nullptr);
+
+  status = shaderc_spvc_compile_shader(context_, result_);
+  EXPECT_EQ(shaderc_compilation_status_success, status);
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
The current API does all of the validation, IR generation, and cross
compile in a single operation. Third party users, specifically Dawn,
want to be able to insert their own commands between the IR generation
and compilation stages. Thus the API is being broken up into two
commands, an initialization command that validates input and generates
the IR, and a compile command that actually performs the cross
compile.

Fixes #863