### PR TITLE
Android.mk: Fix detection of spirv-headers directory

### DIFF
--- a/third_party/Android.mk
+++ b/third_party/Android.mk
@@ -13,7 +13,7 @@ ifeq ($(SPVTOOLS_LOCAL_PATH),)
 endif
 ifeq ($(SPVHEADERS_LOCAL_PATH),)
    # Use the third party dir if it exists.
-   ifneq ($(wildcard $(THIRD_PARTY_PATH)/spirv-headers/include/spirv/spirv.xml),)
+   ifneq ($(wildcard $(THIRD_PARTY_PATH)/spirv-headers/include/spirv/spir-v.xml),)
      SPVHEADERS_LOCAL_PATH:=$(THIRD_PARTY_PATH)/spirv-headers
    else
      # Let SPIRV-Tools find its own headers and hope for the best.


### PR DESCRIPTION
This is needed to fix building according to instructions at
https://developer.android.com/ndk/guides/graphics/shader-compilers#Getting%20The%20Latest