### PR TITLE
Rolling 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': 'f34cdc70ca1b4e741a9ea5a906f86d3593623356',
-  'googletest_revision': 'd5707695cb020ace53dc35f30dd1c3f463daf98e',
+  'glslang_revision': 'f4d4668529f1dad0e475295456b601353fe7cf33',
+  'googletest_revision': '50cfbb726b26700d143ce5bb55c0b5e86de7a1e6',
   're2_revision': 'af3455996c0213fa030546eeba0cc44b947b1de8',
   'spirv_headers_revision': 'af64a9e826bf5bb5fcd2434dd71be1e41e922563',
-  'spirv_tools_revision': '57b4cb40b21dc9961145f71c293ed60310b80251',
-  'spirv_cross_revision': '0b95cbdea394753137537e41d55e6795e5d14dac',
+  'spirv_tools_revision': '0391d0823ebfd7c37c07a54b8726cc417183a95f',
+  'spirv_cross_revision': 'fd5aa3ad51ece55a1b51fe6bfb271db6844ae291',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ f34cdc70c..f4d466852 (2 commits)

https://github.com/KhronosGroup/glslang/compare/f34cdc70ca1b...f4d4668529f1

$ git log f34cdc70c..f4d466852 --date=short --no-merges --format='%ad %ae %s'
2019-11-14 cepheus HLSL: Fix #1976: Don't let ENABLE_HLSL change struct/class layout.
2019-11-12 cepheus HLSL: Fix #1960: fmod() was not converting int args to float.

Roll third_party/googletest/ d5707695c..50cfbb726 (4 commits)

https://github.com/google/googletest/compare/d5707695cb02...50cfbb726b26

$ git log d5707695c..50cfbb726 --date=short --no-merges --format='%ad %ae %s'
2019-11-18 absl-team Googletest export
2019-10-19 martinerikwerner pkg-config: Remove pthread link flag from Cflags
2019-11-05 krystian.kuzniarek update gen_gtest_pred_impl.py
2019-10-18 dieter.gnaier Fix Issue 2418

Roll third_party/spirv-cross/ 0b95cbdea..fd5aa3ad5 (2 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/0b95cbdea394...fd5aa3ad51ec

$ git log 0b95cbdea..fd5aa3ad5 --date=short --no-merges --format='%ad %ae %s'
2019-11-12 post CMake: Clarify some warning messages.
2019-11-12 post HLSL: Add CLI support for --hlsl-auto-binding.

Roll third_party/spirv-tools/ 57b4cb40b..0391d0823 (2 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/57b4cb40b21d...0391d0823ebf

$ git log 57b4cb40b..0391d0823 --date=short --no-merges --format='%ad %ae %s'
2019-11-19 stevenperron Handle OpPhi with no in operands in value numbering (#3056)
2019-11-19 stevenperron Kill the id-to-func map after wrap-opkill (#3055)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools