### PR TITLE
Revert "Convert to using standard spirv_cross deps in BUILD.gn (#902)"

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -149,7 +149,7 @@ component("libshaderc_spvc") {
 
   deps = [
     ":shaderc_util_sources",
-    "${spirv_cross_dir}:spirv_cross",
+    "${spirv_cross_dir}:spirv_cross_full_for_fuzzers",
     "${spirv_tools_dir}:spvtools",
     "${spirv_tools_dir}:spvtools_core_enums_unified1",
     "${spirv_tools_dir}:spvtools_opt",


### PR DESCRIPTION
This reverts commit eca11511a0c09dd599837862c96658a91e927a3a.