### PR TITLE
Rolling 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': 'f4d4668529f1dad0e475295456b601353fe7cf33',
-  'googletest_revision': '50cfbb726b26700d143ce5bb55c0b5e86de7a1e6',
-  're2_revision': 'af3455996c0213fa030546eeba0cc44b947b1de8',
-  'spirv_headers_revision': 'af64a9e826bf5bb5fcd2434dd71be1e41e922563',
-  'spirv_tools_revision': '0391d0823ebfd7c37c07a54b8726cc417183a95f',
+  'glslang_revision': '38b4db48f98c4e3a9cc405de3a76547b857e1c37',
+  'googletest_revision': '679bfec6db73c021b0226e386c65ec1baee7a09f',
+  're2_revision': 'bb8e777557ddbdeabdedea4f23613c5021ffd7b1',
+  'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
+  'spirv_tools_revision': '85f3e93d13f32d45bd7f9999aa51baddf2452aae',
   'spirv_cross_revision': 'fd5aa3ad51ece55a1b51fe6bfb271db6844ae291',
 }
 


### PR DESCRIPTION
Roll third_party/glslang/ f4d466852..38b4db48f (6 commits)

https://github.com/KhronosGroup/glslang/compare/f4d4668529f1...38b4db48f98c

$ git log f4d466852..38b4db48f --date=short --no-merges --format='%ad %ae %s'
2019-11-23 cepheus Fix #1983: __ is okay starting with ES 300, rather than 310.
2019-11-22 cepheus Fix #1987: Use large enough built-in buffer to hold vec4 of maxint-64.
2019-11-21 dsinclair Check for ENABLE_SPVREMAPPER flag in CMakeList files.
2019-11-18 Arfrever Respect CMAKE_INSTALL_LIBDIR in installed CMake files
2019-11-14 andreas.floejt Add a test for 8- and 16-bit construction.
2019-11-11 andreas.floejt Fix construction issue for 8 and 16 bit types.

Roll third_party/googletest/ 50cfbb726..679bfec6d (5 commits)

https://github.com/google/googletest/compare/50cfbb726b26...679bfec6db73

$ git log 50cfbb726..679bfec6d --date=short --no-merges --format='%ad %ae %s'
2019-11-22 absl-team Googletest export
2019-11-20 absl-team Googletest export
2019-11-19 absl-team Googletest export
2019-11-16 xyb Fix internal memory leak in Windows _Crt report.
2019-11-15 b.gianfo Fix FlatTuple compilation on older msvc.

Roll third_party/re2/ af3455996..bb8e77755 (2 commits)

https://github.com/google/re2/compare/af3455996c02...bb8e777557dd

$ git log af3455996..bb8e77755 --date=short --no-merges --format='%ad %ae %s'
2019-11-25 junyer Fix nullptr-with-nonzero-offset bugs found by UBSan.
2019-11-25 junyer Check if empty() instead of comparing size() with 0.

Roll third_party/spirv-headers/ af64a9e82..204cd131c (2 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/af64a9e826bf...204cd131c42b

$ git log af64a9e82..204cd131c --date=short --no-merges --format='%ad %ae %s'
2019-11-20 Tobias.Hector Off-by-one errors
2019-11-20 Tobias.Hector Reserve a new block of 64 opcodes

Roll third_party/spirv-tools/ 0391d0823..85f3e93d1 (3 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/0391d0823ebf...85f3e93d13f3

$ git log 0391d0823..85f3e93d1 --date=short --no-merges --format='%ad %ae %s'
2019-11-22 mattst88 Respect CMAKE_INSTALL_LIBDIR in installed CMake files (#3054)
2019-11-20 rharrison Add missing dealloc (#3061)
2019-11-19 rharrison Initialize binary for use as guard later (#3058)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools