### PR TITLE
Remove spvc's dependency on shaderc's util library

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -178,7 +178,6 @@ config("shaderc_spvc_public") {
 component("libshaderc_spvc") {
   public_configs = [
     ":shaderc_spvc_public",
-    ":shaderc_util_public",
   ]
 
   include_dirs = [
@@ -205,7 +204,6 @@ component("libshaderc_spvc") {
   ]
 
   deps = [
-    ":shaderc_util_sources",
     ":spirv_cross",
     "${spirv_tools_dir}:spvtools",
     "${spirv_tools_dir}:spvtools_core_enums_unified1",

--- a/libshaderc_spvc/CMakeLists.txt
+++ b/libshaderc_spvc/CMakeLists.txt
@@ -28,7 +28,6 @@ shaderc_default_compile_options(shaderc_spvc)
 target_include_directories(shaderc_spvc
   PUBLIC include
   ${shaderc_SOURCE_DIR}/libshaderc/include
-  ${shaderc_SOURCE_DIR}/libshaderc_util/include
   ${spirv-tools_SOURCE_DIR}/include
   ${spirv-tools_SOURCE_DIR}/
   ${CMAKE_CURRENT_BINARY_DIR}/../third_party/spirv-tools/)
@@ -40,7 +39,6 @@ shaderc_default_compile_options(shaderc_spvc_shared)
 target_include_directories(shaderc_spvc_shared
   PUBLIC include
   ${shaderc_SOURCE_DIR}/libshaderc/include
-  ${shaderc_SOURCE_DIR}/libshaderc_util/include
   ${spirv-tools_SOURCE_DIR}/include
   ${spirv-tools_SOURCE_DIR}/
   ${CMAKE_CURRENT_BINARY_DIR}/../third_party/spirv-tools/)
@@ -105,7 +103,7 @@ endif(SHADERC_ENABLE_INSTALL)
 
 shaderc_add_tests(
   TEST_PREFIX shaderc_spvc_combined
-  LINK_LIBS shaderc_spvc_combined ${SPVC_LIBS} ${CMAKE_THREAD_LIBS_INIT} shaderc_util
+  LINK_LIBS shaderc_spvc_combined ${SPVC_LIBS} ${CMAKE_THREAD_LIBS_INIT}
   INCLUDE_DIRS include ${shaderc_SOURCE_DIR}/libshaderc/include ${spirv-tools_SOURCE_DIR}/include
   TEST_NAMES
     spvc

--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -14,9 +14,19 @@
 
 #include "spvc_private.h"
 
-#include "libshaderc_util/exceptions.h"
 #include "spirv-tools/optimizer.hpp"
 #include "spvcir_pass.h"
+
+// Originally from libshaderc_utils/exceptions.h, copied here to avoid
+// needing to depend on libshaderc_utils and pull in its dependency on
+// glslang.
+#if (defined(_MSC_VER) && !defined(_CPPUNWIND)) || !defined(__EXCEPTIONS)
+#define TRY_IF_EXCEPTIONS_ENABLED
+#define CATCH_IF_EXCEPTIONS_ENABLED(X) if (0)
+#else
+#define TRY_IF_EXCEPTIONS_ENABLED try
+#define CATCH_IF_EXCEPTIONS_ENABLED(X) catch (X)
+#endif
 
 namespace spvc_private {
 


### PR DESCRIPTION
This is to remove transitive dependency on glslang that this is
pulling in.

Fixes #913