### PR TITLE
Create spvc specific return codes and use them

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -32,6 +32,32 @@ typedef enum {
   shaderc_spvc_msl_platform_macos,
 } shaderc_spvc_msl_platform;
 
+// TODO(rharrison): Convert these to real enums instead of weird proxies around
+// the existing enum, once Dawn is using the new names.
+typedef shaderc_compilation_status shaderc_spvc_compilation_status;
+typedef shaderc_compilation_status shaderc_spvc_initialization_status;
+
+// These are temporary defines that will be removed once the above typedefs are
+// converted to enums.
+#define shaderc_spvc_initialization_status_success \
+  shaderc_compilation_status_success
+#define shaderc_spvc_initialization_status_configuration_error \
+  shaderc_compilation_status_configuration_error
+#define shaderc_spvc_initialization_status_internal_error \
+  shaderc_compilation_status_internal_error
+#define shaderc_spvc_initialization_status_validation_error \
+  shaderc_compilation_status_validation_error
+#define shaderc_spvc_initialization_status_transformation_error \
+  shaderc_compilation_status_transformation_error
+#define shaderc_spvc_initialization_status_compilation_error \
+  shaderc_compilation_status_compilation_error
+#define shaderc_spvc_compilation_status_success \
+  shaderc_compilation_status_success
+#define shaderc_spvc_compilation_status_configuration_error \
+  shaderc_compilation_status_configuration_error
+#define shaderc_spvc_compilation_status_compilation_error \
+  shaderc_compilation_status_compilation_error
+
 // An opaque handle to an object that manages all compiler state.
 typedef struct shaderc_spvc_context* shaderc_spvc_context_t;
 
@@ -246,31 +272,35 @@ typedef struct shaderc_spvc_compilation_result*
 
 // Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
 // internal compiler for translating to GLSL and performing reflection.
-SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_initialize_for_glsl(
-    const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options);
+SHADERC_EXPORT shaderc_spvc_initialization_status
+shaderc_spvc_initialize_for_glsl(const shaderc_spvc_context_t context,
+                                 const uint32_t* source, size_t source_len,
+                                 shaderc_spvc_compile_options_t options);
 
 // Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
 // internal compiler for translating to HLSL and performing reflection.
-SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_initialize_for_hlsl(
-    const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options);
+SHADERC_EXPORT shaderc_spvc_initialization_status
+shaderc_spvc_initialize_for_hlsl(const shaderc_spvc_context_t context,
+                                 const uint32_t* source, size_t source_len,
+                                 shaderc_spvc_compile_options_t options);
 
 // Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
 // internal compiler for translating to MSL and performing reflection.
-SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_initialize_for_msl(
-    const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options);
+SHADERC_EXPORT shaderc_spvc_initialization_status
+shaderc_spvc_initialize_for_msl(const shaderc_spvc_context_t context,
+                                const uint32_t* source, size_t source_len,
+                                shaderc_spvc_compile_options_t options);
 
 // Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
 // internal compiler for translating to Vulkan and performing reflection.
-SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_initialize_for_vulkan(
-    const shaderc_spvc_context_t context, const uint32_t* source,
-    size_t source_len, shaderc_spvc_compile_options_t options);
+SHADERC_EXPORT shaderc_spvc_initialization_status
+shaderc_spvc_initialize_for_vulkan(const shaderc_spvc_context_t context,
+                                   const uint32_t* source, size_t source_len,
+                                   shaderc_spvc_compile_options_t options);
 
 // Given an initialized compiler, generates a shader of the appropriate
 // language.
-SHADERC_EXPORT shaderc_compilation_status
+SHADERC_EXPORT shaderc_spvc_compilation_status
 shaderc_spvc_compile_shader(const shaderc_spvc_context_t context,
                             shaderc_spvc_compilation_result_t result);
 

--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -32,31 +32,23 @@ typedef enum {
   shaderc_spvc_msl_platform_macos,
 } shaderc_spvc_msl_platform;
 
-// TODO(rharrison): Convert these to real enums instead of weird proxies around
+// TODO(rharrison): Convert this to a real enum instead of a weird proxy around
 // the existing enum, once Dawn is using the new names.
-typedef shaderc_compilation_status shaderc_spvc_compilation_status;
-typedef shaderc_compilation_status shaderc_spvc_initialization_status;
+typedef shaderc_compilation_status shaderc_spvc_status;
 
-// These are temporary defines that will be removed once the above typedefs are
-// converted to enums.
-#define shaderc_spvc_initialization_status_success \
-  shaderc_compilation_status_success
-#define shaderc_spvc_initialization_status_configuration_error \
-  shaderc_compilation_status_configuration_error
-#define shaderc_spvc_initialization_status_internal_error \
+// These are temporary defines that will be removed once the above typedef is
+// converted to an enum.
+#define shaderc_spvc_status_success shaderc_compilation_status_success
+#define shaderc_spvc_status_compilation_error \
+  shaderc_compilation_status_compilation_error
+#define shaderc_spvc_status_internal_error \
   shaderc_compilation_status_internal_error
-#define shaderc_spvc_initialization_status_validation_error \
+#define shaderc_spvc_status_validation_error \
   shaderc_compilation_status_validation_error
-#define shaderc_spvc_initialization_status_transformation_error \
+#define shaderc_spvc_status_transformation_error \
   shaderc_compilation_status_transformation_error
-#define shaderc_spvc_initialization_status_compilation_error \
-  shaderc_compilation_status_compilation_error
-#define shaderc_spvc_compilation_status_success \
-  shaderc_compilation_status_success
-#define shaderc_spvc_compilation_status_configuration_error \
+#define shaderc_spvc_status_configuration_error \
   shaderc_compilation_status_configuration_error
-#define shaderc_spvc_compilation_status_compilation_error \
-  shaderc_compilation_status_compilation_error
 
 // An opaque handle to an object that manages all compiler state.
 typedef struct shaderc_spvc_context* shaderc_spvc_context_t;
@@ -272,35 +264,31 @@ typedef struct shaderc_spvc_compilation_result*
 
 // Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
 // internal compiler for translating to GLSL and performing reflection.
-SHADERC_EXPORT shaderc_spvc_initialization_status
-shaderc_spvc_initialize_for_glsl(const shaderc_spvc_context_t context,
-                                 const uint32_t* source, size_t source_len,
-                                 shaderc_spvc_compile_options_t options);
+SHADERC_EXPORT shaderc_spvc_status shaderc_spvc_initialize_for_glsl(
+    const shaderc_spvc_context_t context, const uint32_t* source,
+    size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
 // internal compiler for translating to HLSL and performing reflection.
-SHADERC_EXPORT shaderc_spvc_initialization_status
-shaderc_spvc_initialize_for_hlsl(const shaderc_spvc_context_t context,
-                                 const uint32_t* source, size_t source_len,
-                                 shaderc_spvc_compile_options_t options);
+SHADERC_EXPORT shaderc_spvc_status shaderc_spvc_initialize_for_hlsl(
+    const shaderc_spvc_context_t context, const uint32_t* source,
+    size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
 // internal compiler for translating to MSL and performing reflection.
-SHADERC_EXPORT shaderc_spvc_initialization_status
-shaderc_spvc_initialize_for_msl(const shaderc_spvc_context_t context,
-                                const uint32_t* source, size_t source_len,
-                                shaderc_spvc_compile_options_t options);
+SHADERC_EXPORT shaderc_spvc_status shaderc_spvc_initialize_for_msl(
+    const shaderc_spvc_context_t context, const uint32_t* source,
+    size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Takes SPIR-V as a sequence of 32-bit words, validates it, then creates the
 // internal compiler for translating to Vulkan and performing reflection.
-SHADERC_EXPORT shaderc_spvc_initialization_status
-shaderc_spvc_initialize_for_vulkan(const shaderc_spvc_context_t context,
-                                   const uint32_t* source, size_t source_len,
-                                   shaderc_spvc_compile_options_t options);
+SHADERC_EXPORT shaderc_spvc_status shaderc_spvc_initialize_for_vulkan(
+    const shaderc_spvc_context_t context, const uint32_t* source,
+    size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Given an initialized compiler, generates a shader of the appropriate
 // language.
-SHADERC_EXPORT shaderc_spvc_compilation_status
+SHADERC_EXPORT shaderc_spvc_status
 shaderc_spvc_compile_shader(const shaderc_spvc_context_t context,
                             shaderc_spvc_compilation_result_t result);
 

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -316,7 +316,7 @@ class Context {
   }
 
   // Initializes state for compiling SPIR-V to GLSL.
-  shaderc_compilation_status InitializeForGlsl(
+  shaderc_spvc_initialization_status InitializeForGlsl(
       const uint32_t* source, size_t source_len,
       const CompileOptions& options) const {
     return shaderc_spvc_initialize_for_glsl(context_.get(), source, source_len,
@@ -324,7 +324,7 @@ class Context {
   }
 
   // Initializes state for compiling SPIR-V to HLSL.
-  shaderc_compilation_status InitializeForHlsl(
+  shaderc_spvc_initialization_status InitializeForHlsl(
       const uint32_t* source, size_t source_len,
       const CompileOptions& options) const {
     return shaderc_spvc_initialize_for_hlsl(context_.get(), source, source_len,
@@ -332,7 +332,7 @@ class Context {
   }
 
   // Initializes state for compiling SPIR-V to MSL.
-  shaderc_compilation_status InitializeForMsl(
+  shaderc_spvc_initialization_status InitializeForMsl(
       const uint32_t* source, size_t source_len,
       const CompileOptions& options) const {
     return shaderc_spvc_initialize_for_msl(context_.get(), source, source_len,
@@ -340,7 +340,7 @@ class Context {
   }
 
   // Initializes state for compiling SPIR-V to Vulkan.
-  shaderc_compilation_status InitializeForVulkan(
+  shaderc_spvc_initialization_status InitializeForVulkan(
       const uint32_t* source, size_t source_len,
       const CompileOptions& options) const {
     return shaderc_spvc_initialize_for_vulkan(
@@ -348,7 +348,7 @@ class Context {
   }
 
   // After initialization compile the shader to desired language.
-  shaderc_compilation_status CompileShader(CompilationResult* result) {
+  shaderc_spvc_compilation_status CompileShader(CompilationResult* result) {
     return shaderc_spvc_compile_shader(context_.get(), result->result_.get());
   }
 

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -316,39 +316,39 @@ class Context {
   }
 
   // Initializes state for compiling SPIR-V to GLSL.
-  shaderc_spvc_initialization_status InitializeForGlsl(
-      const uint32_t* source, size_t source_len,
-      const CompileOptions& options) const {
+  shaderc_spvc_status InitializeForGlsl(const uint32_t* source,
+                                        size_t source_len,
+                                        const CompileOptions& options) const {
     return shaderc_spvc_initialize_for_glsl(context_.get(), source, source_len,
                                             options.options_.get());
   }
 
   // Initializes state for compiling SPIR-V to HLSL.
-  shaderc_spvc_initialization_status InitializeForHlsl(
-      const uint32_t* source, size_t source_len,
-      const CompileOptions& options) const {
+  shaderc_spvc_status InitializeForHlsl(const uint32_t* source,
+                                        size_t source_len,
+                                        const CompileOptions& options) const {
     return shaderc_spvc_initialize_for_hlsl(context_.get(), source, source_len,
                                             options.options_.get());
   }
 
   // Initializes state for compiling SPIR-V to MSL.
-  shaderc_spvc_initialization_status InitializeForMsl(
-      const uint32_t* source, size_t source_len,
-      const CompileOptions& options) const {
+  shaderc_spvc_status InitializeForMsl(const uint32_t* source,
+                                       size_t source_len,
+                                       const CompileOptions& options) const {
     return shaderc_spvc_initialize_for_msl(context_.get(), source, source_len,
                                            options.options_.get());
   }
 
   // Initializes state for compiling SPIR-V to Vulkan.
-  shaderc_spvc_initialization_status InitializeForVulkan(
-      const uint32_t* source, size_t source_len,
-      const CompileOptions& options) const {
+  shaderc_spvc_status InitializeForVulkan(const uint32_t* source,
+                                          size_t source_len,
+                                          const CompileOptions& options) const {
     return shaderc_spvc_initialize_for_vulkan(
         context_.get(), source, source_len, options.options_.get());
   }
 
   // After initialization compile the shader to desired language.
-  shaderc_spvc_compilation_status CompileShader(CompilationResult* result) {
+  shaderc_spvc_status CompileShader(CompilationResult* result) {
     return shaderc_spvc_compile_shader(context_.get(), result->result_.get());
   }
 

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -228,26 +228,26 @@ size_t shaderc_spvc_compile_options_set_for_fuzzing(
   return sizeof(*options);
 }
 
-shaderc_compilation_status shaderc_spvc_initialize_impl(
+shaderc_spvc_initialization_status shaderc_spvc_initialize_impl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options,
-    shaderc_compilation_status (*generator)(const shaderc_spvc_context_t,
-                                            const uint32_t*, size_t,
-                                            shaderc_spvc_compile_options_t)) {
-  if (!context) return shaderc_compilation_status_configuration_error;
-  shaderc_compilation_status status =
+    shaderc_spvc_initialization_status (*generator)(
+        const shaderc_spvc_context_t, const uint32_t*, size_t,
+        shaderc_spvc_compile_options_t)) {
+  if (!context) return shaderc_spvc_initialization_status_configuration_error;
+  shaderc_spvc_initialization_status status =
       spvc_private::validate_and_translate_spirv(
           context, source, source_len, options, &context->intermediate_shader);
-  if (status != shaderc_compilation_status_success) return status;
+  if (status != shaderc_spvc_initialization_status_success) return status;
 
   status = generator(context, context->intermediate_shader.data(),
                      context->intermediate_shader.size(), options);
-  if (status != shaderc_compilation_status_success) return status;
+  if (status != shaderc_spvc_initialization_status_success) return status;
 
-  return shaderc_compilation_status_success;
+  return shaderc_spvc_initialization_status_success;
 }
 
-shaderc_compilation_status shaderc_spvc_initialize_for_glsl(
+shaderc_spvc_initialization_status shaderc_spvc_initialize_for_glsl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   context->target_lang = SPVC_TARGET_LANG_GLSL;
@@ -255,7 +255,7 @@ shaderc_compilation_status shaderc_spvc_initialize_for_glsl(
                                       spvc_private::generate_glsl_compiler);
 }
 
-shaderc_compilation_status shaderc_spvc_initialize_for_hlsl(
+shaderc_spvc_initialization_status shaderc_spvc_initialize_for_hlsl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   context->target_lang = SPVC_TARGET_LANG_HLSL;
@@ -263,7 +263,7 @@ shaderc_compilation_status shaderc_spvc_initialize_for_hlsl(
                                       spvc_private::generate_hlsl_compiler);
 }
 
-shaderc_compilation_status shaderc_spvc_initialize_for_msl(
+shaderc_spvc_initialization_status shaderc_spvc_initialize_for_msl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   context->target_lang = SPVC_TARGET_LANG_MSL;
@@ -271,7 +271,7 @@ shaderc_compilation_status shaderc_spvc_initialize_for_msl(
                                       spvc_private::generate_msl_compiler);
 }
 
-shaderc_compilation_status shaderc_spvc_initialize_for_vulkan(
+shaderc_spvc_initialization_status shaderc_spvc_initialize_for_vulkan(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   context->target_lang = SPVC_TARGET_LANG_VULKAN;
@@ -279,23 +279,23 @@ shaderc_compilation_status shaderc_spvc_initialize_for_vulkan(
                                       spvc_private::generate_vulkan_compiler);
 }
 
-shaderc_compilation_status shaderc_spvc_compile_shader(
+shaderc_spvc_compilation_status shaderc_spvc_compile_shader(
     const shaderc_spvc_context_t context,
     shaderc_spvc_compilation_result_t result) {
   if (!context->cross_compiler ||
       context->target_lang == SPVC_TARGET_LANG_UNKNOWN) {
-    return shaderc_compilation_status_configuration_error;
+    return shaderc_spvc_compilation_status_configuration_error;
   }
 
   if (context->target_lang == SPVC_TARGET_LANG_VULKAN) {
     // No actual cross compilation is needed, since the intermediate shader is
     // already in Vulkan SPIR->V.
     result->binary_output = context->intermediate_shader;
-    return shaderc_compilation_status_success;
+    return shaderc_spvc_compilation_status_success;
   } else {
-    shaderc_compilation_status status =
+    shaderc_spvc_compilation_status status =
         spvc_private::generate_shader(context->cross_compiler.get(), result);
-    if (status != shaderc_compilation_status_success) {
+    if (status != shaderc_spvc_compilation_status_success) {
       context->messages.append("Compilation failed.  Partial source:\n");
       if (context->target_lang == SPVC_TARGET_LANG_GLSL) {
         spirv_cross::CompilerGLSL* cast_compiler =

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -228,26 +228,25 @@ size_t shaderc_spvc_compile_options_set_for_fuzzing(
   return sizeof(*options);
 }
 
-shaderc_spvc_initialization_status shaderc_spvc_initialize_impl(
+shaderc_spvc_status shaderc_spvc_initialize_impl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options,
-    shaderc_spvc_initialization_status (*generator)(
-        const shaderc_spvc_context_t, const uint32_t*, size_t,
-        shaderc_spvc_compile_options_t)) {
-  if (!context) return shaderc_spvc_initialization_status_configuration_error;
-  shaderc_spvc_initialization_status status =
-      spvc_private::validate_and_translate_spirv(
-          context, source, source_len, options, &context->intermediate_shader);
-  if (status != shaderc_spvc_initialization_status_success) return status;
+    shaderc_spvc_status (*generator)(const shaderc_spvc_context_t,
+                                     const uint32_t*, size_t,
+                                     shaderc_spvc_compile_options_t)) {
+  if (!context) return shaderc_spvc_status_configuration_error;
+  shaderc_spvc_status status = spvc_private::validate_and_translate_spirv(
+      context, source, source_len, options, &context->intermediate_shader);
+  if (status != shaderc_spvc_status_success) return status;
 
   status = generator(context, context->intermediate_shader.data(),
                      context->intermediate_shader.size(), options);
-  if (status != shaderc_spvc_initialization_status_success) return status;
+  if (status != shaderc_spvc_status_success) return status;
 
-  return shaderc_spvc_initialization_status_success;
+  return shaderc_spvc_status_success;
 }
 
-shaderc_spvc_initialization_status shaderc_spvc_initialize_for_glsl(
+shaderc_spvc_status shaderc_spvc_initialize_for_glsl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   context->target_lang = SPVC_TARGET_LANG_GLSL;
@@ -255,7 +254,7 @@ shaderc_spvc_initialization_status shaderc_spvc_initialize_for_glsl(
                                       spvc_private::generate_glsl_compiler);
 }
 
-shaderc_spvc_initialization_status shaderc_spvc_initialize_for_hlsl(
+shaderc_spvc_status shaderc_spvc_initialize_for_hlsl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   context->target_lang = SPVC_TARGET_LANG_HLSL;
@@ -263,7 +262,7 @@ shaderc_spvc_initialization_status shaderc_spvc_initialize_for_hlsl(
                                       spvc_private::generate_hlsl_compiler);
 }
 
-shaderc_spvc_initialization_status shaderc_spvc_initialize_for_msl(
+shaderc_spvc_status shaderc_spvc_initialize_for_msl(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   context->target_lang = SPVC_TARGET_LANG_MSL;
@@ -271,7 +270,7 @@ shaderc_spvc_initialization_status shaderc_spvc_initialize_for_msl(
                                       spvc_private::generate_msl_compiler);
 }
 
-shaderc_spvc_initialization_status shaderc_spvc_initialize_for_vulkan(
+shaderc_spvc_status shaderc_spvc_initialize_for_vulkan(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   context->target_lang = SPVC_TARGET_LANG_VULKAN;
@@ -279,23 +278,23 @@ shaderc_spvc_initialization_status shaderc_spvc_initialize_for_vulkan(
                                       spvc_private::generate_vulkan_compiler);
 }
 
-shaderc_spvc_compilation_status shaderc_spvc_compile_shader(
+shaderc_spvc_status shaderc_spvc_compile_shader(
     const shaderc_spvc_context_t context,
     shaderc_spvc_compilation_result_t result) {
   if (!context->cross_compiler ||
       context->target_lang == SPVC_TARGET_LANG_UNKNOWN) {
-    return shaderc_spvc_compilation_status_configuration_error;
+    return shaderc_spvc_status_configuration_error;
   }
 
   if (context->target_lang == SPVC_TARGET_LANG_VULKAN) {
     // No actual cross compilation is needed, since the intermediate shader is
     // already in Vulkan SPIR->V.
     result->binary_output = context->intermediate_shader;
-    return shaderc_spvc_compilation_status_success;
+    return shaderc_spvc_status_success;
   } else {
-    shaderc_spvc_compilation_status status =
+    shaderc_spvc_status status =
         spvc_private::generate_shader(context->cross_compiler.get(), result);
-    if (status != shaderc_spvc_compilation_status_success) {
+    if (status != shaderc_spvc_status_success) {
       context->messages.append("Compilation failed.  Partial source:\n");
       if (context->target_lang == SPVC_TARGET_LANG_GLSL) {
         spirv_cross::CompilerGLSL* cast_compiler =

--- a/libshaderc_spvc/src/spvc_cpp_test.cc
+++ b/libshaderc_spvc/src/spvc_cpp_test.cc
@@ -31,51 +31,65 @@ class CompileTest : public testing::Test {
 };
 
 TEST_F(CompileTest, Glsl) {
-  shaderc_compilation_status status = context_.InitializeForGlsl(
-      kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
-      options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
+  {
+    shaderc_spvc_initialization_status status = context_.InitializeForGlsl(
+        kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
+        options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+  }
 
-  status = context_.CompileShader(&result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(0, result_.GetStringOutput().size());
-  EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  {
+    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_NE(0, result_.GetStringOutput().size());
+    EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  }
 }
 
 TEST_F(CompileTest, Hlsl) {
-  shaderc_compilation_status status = context_.InitializeForHlsl(
-      kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
-      options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-
-  status = context_.CompileShader(&result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(0, result_.GetStringOutput().size());
-  EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  {
+    shaderc_spvc_initialization_status status = context_.InitializeForHlsl(
+        kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
+        options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+  }
+  {
+    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_NE(0, result_.GetStringOutput().size());
+    EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  }
 }
 
 TEST_F(CompileTest, Msl) {
-  shaderc_compilation_status status = context_.InitializeForMsl(
-      kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
-      options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
+  {
+    shaderc_spvc_initialization_status status = context_.InitializeForMsl(
+        kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
+        options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+  }
 
-  status = context_.CompileShader(&result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(0, result_.GetStringOutput().size());
-  EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  {
+    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_NE(0, result_.GetStringOutput().size());
+    EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  }
 }
 
 TEST_F(CompileTest, Vulkan) {
-  shaderc_compilation_status status = context_.InitializeForVulkan(
-      kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
-      options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-
-  status = context_.CompileShader(&result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_EQ(0, result_.GetStringOutput().size());
-  EXPECT_NE(0, result_.GetBinaryOutput().size());
+  {
+    shaderc_spvc_initialization_status status = context_.InitializeForVulkan(
+        kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
+        options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+  }
+  {
+    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_EQ(0, result_.GetStringOutput().size());
+    EXPECT_NE(0, result_.GetBinaryOutput().size());
+  }
 }
 
 }  // anonymous namespace

--- a/libshaderc_spvc/src/spvc_cpp_test.cc
+++ b/libshaderc_spvc/src/spvc_cpp_test.cc
@@ -32,15 +32,15 @@ class CompileTest : public testing::Test {
 
 TEST_F(CompileTest, Glsl) {
   {
-    shaderc_spvc_initialization_status status = context_.InitializeForGlsl(
+    shaderc_spvc_status status = context_.InitializeForGlsl(
         kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
         options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
 
   {
-    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(0, result_.GetStringOutput().size());
     EXPECT_EQ(0, result_.GetBinaryOutput().size());
   }
@@ -48,14 +48,14 @@ TEST_F(CompileTest, Glsl) {
 
 TEST_F(CompileTest, Hlsl) {
   {
-    shaderc_spvc_initialization_status status = context_.InitializeForHlsl(
+    shaderc_spvc_status status = context_.InitializeForHlsl(
         kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
         options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
   {
-    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(0, result_.GetStringOutput().size());
     EXPECT_EQ(0, result_.GetBinaryOutput().size());
   }
@@ -63,15 +63,15 @@ TEST_F(CompileTest, Hlsl) {
 
 TEST_F(CompileTest, Msl) {
   {
-    shaderc_spvc_initialization_status status = context_.InitializeForMsl(
+    shaderc_spvc_status status = context_.InitializeForMsl(
         kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
         options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
 
   {
-    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(0, result_.GetStringOutput().size());
     EXPECT_EQ(0, result_.GetBinaryOutput().size());
   }
@@ -79,14 +79,14 @@ TEST_F(CompileTest, Msl) {
 
 TEST_F(CompileTest, Vulkan) {
   {
-    shaderc_spvc_initialization_status status = context_.InitializeForVulkan(
+    shaderc_spvc_status status = context_.InitializeForVulkan(
         kSmokeShaderBinary, sizeof(kSmokeShaderBinary) / sizeof(uint32_t),
         options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
   {
-    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_EQ(0, result_.GetStringOutput().size());
     EXPECT_NE(0, result_.GetBinaryOutput().size());
   }

--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -69,14 +69,14 @@ void consume_spirv_tools_message(shaderc_spvc_context* context,
   context->messages.append("\n");
 }
 
-shaderc_compilation_status validate_spirv(shaderc_spvc_context* context,
-                                          spv_target_env env,
-                                          const uint32_t* source,
-                                          size_t source_len) {
+shaderc_spvc_initialization_status validate_spirv(shaderc_spvc_context* context,
+                                                  spv_target_env env,
+                                                  const uint32_t* source,
+                                                  size_t source_len) {
   spvtools::SpirvTools tools(env);
   if (!tools.IsValid()) {
     context->messages.append("Could not initialize SPIRV-Tools.\n");
-    return shaderc_compilation_status_internal_error;
+    return shaderc_spvc_initialization_status_internal_error;
   }
 
   tools.SetMessageConsumer(std::bind(
@@ -85,25 +85,25 @@ shaderc_compilation_status validate_spirv(shaderc_spvc_context* context,
 
   if (!tools.Validate(source, source_len, spvtools::ValidatorOptions())) {
     context->messages.append("Validation of shader failed.\n");
-    return shaderc_compilation_status_validation_error;
+    return shaderc_spvc_initialization_status_validation_error;
   }
 
-  return shaderc_compilation_status_success;
+  return shaderc_spvc_initialization_status_success;
 }
 
-shaderc_compilation_status translate_spirv(
+shaderc_spvc_initialization_status translate_spirv(
     shaderc_spvc_context* context, spv_target_env source_env,
     spv_target_env target_env, const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options, std::vector<uint32_t>* target) {
   if (!target) {
     context->messages.append("null provided for translation destination.\n");
-    return shaderc_compilation_status_transformation_error;
+    return shaderc_spvc_initialization_status_transformation_error;
   }
 
   if (source_env == target_env) {
     target->resize(source_len);
     memcpy(target->data(), source, source_len * sizeof(uint32_t));
-    return shaderc_compilation_status_success;
+    return shaderc_spvc_initialization_status_success;
   }
 
   spvtools::Optimizer opt(source_env);
@@ -120,7 +120,7 @@ shaderc_compilation_status translate_spirv(
     context->messages.append(
         "No defined transformation between source and "
         "target execution environments.\n");
-    return shaderc_compilation_status_transformation_error;
+    return shaderc_spvc_initialization_status_transformation_error;
   }
 
   if (options->robust_buffer_access_pass) {
@@ -131,19 +131,19 @@ shaderc_compilation_status translate_spirv(
     context->messages.append(
         "Transformations between source and target "
         "execution environments failed.\n");
-    return shaderc_compilation_status_transformation_error;
+    return shaderc_spvc_initialization_status_transformation_error;
   }
 
-  return shaderc_compilation_status_success;
+  return shaderc_spvc_initialization_status_success;
 }
 
-shaderc_compilation_status validate_and_translate_spirv(
+shaderc_spvc_initialization_status validate_and_translate_spirv(
     shaderc_spvc_context* context, const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options, std::vector<uint32_t>* target) {
-  shaderc_compilation_status status;
+  shaderc_spvc_initialization_status status;
   if (options->validate) {
     status = validate_spirv(context, options->source_env, source, source_len);
-    if (status != shaderc_compilation_status_success) {
+    if (status != shaderc_spvc_initialization_status_success) {
       context->messages.append("Validation of input source failed.\n");
       return status;
     }
@@ -151,13 +151,13 @@ shaderc_compilation_status validate_and_translate_spirv(
 
   status = translate_spirv(context, options->source_env, options->target_env,
                            source, source_len, options, target);
-  if (status != shaderc_compilation_status_success) return status;
+  if (status != shaderc_spvc_initialization_status_success) return status;
 
   if (options->validate && (options->source_env != options->target_env)) {
     // Re-run validation on input if actually transformed.
     status = validate_spirv(context, options->target_env, target->data(),
                             target->size());
-    if (status != shaderc_compilation_status_success) {
+    if (status != shaderc_spvc_initialization_status_success) {
       context->messages.append("Validation of transformed source failed.\n");
       return status;
     }
@@ -166,21 +166,21 @@ shaderc_compilation_status validate_and_translate_spirv(
   return status;
 }
 
-shaderc_compilation_status generate_shader(
+shaderc_spvc_compilation_status generate_shader(
     spirv_cross::Compiler* compiler, shaderc_spvc_compilation_result_t result) {
   TRY_IF_EXCEPTIONS_ENABLED {
     result->string_output = compiler->compile();
     // An exception during compiling would crash (if exceptions off) or jump to
     // the catch block (if exceptions on) so if we're here we know the compile
     // worked.
-    return shaderc_compilation_status_success;
+    return shaderc_spvc_compilation_status_success;
   }
   CATCH_IF_EXCEPTIONS_ENABLED(...) {
-    return shaderc_compilation_status_compilation_error;
+    return shaderc_spvc_compilation_status_compilation_error;
   }
 }
 
-shaderc_compilation_status generate_glsl_compiler(
+shaderc_spvc_initialization_status generate_glsl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   spirv_cross::CompilerGLSL* cross_compiler;
@@ -188,10 +188,10 @@ shaderc_compilation_status generate_glsl_compiler(
   // compiler, unless explicitly requested.
   // TODO (sarahM0): change the default to spvc IR generation when it's done
   if (context->use_spvc_parser) {
-    shaderc_compilation_status status;
+    shaderc_spvc_initialization_status status;
     spirv_cross::ParsedIR ir;
     status = generate_spvcir(context, &ir, source, source_len, options);
-    if (status != shaderc_compilation_status_success) {
+    if (status != shaderc_spvc_initialization_status_success) {
       context->messages.append(
           "Transformations between source and target "
           "execution environments failed (spvc-ir-pass).\n");
@@ -207,7 +207,7 @@ shaderc_compilation_status generate_glsl_compiler(
   if (!cross_compiler) {
     context->messages.append(
         "Unable to initialize SPIRV-Cross GLSL compiler.\n");
-    return shaderc_compilation_status_compilation_error;
+    return shaderc_spvc_initialization_status_compilation_error;
   }
   context->cross_compiler.reset(cross_compiler);
 
@@ -249,7 +249,7 @@ shaderc_compilation_status generate_glsl_compiler(
             "There is more than one entry point with name: " +
             options->entry_point + ". Use --stage.");
       }
-      return shaderc_compilation_status_compilation_error;
+      return shaderc_spvc_initialization_status_compilation_error;
     }
   }
 
@@ -301,10 +301,10 @@ shaderc_compilation_status generate_glsl_compiler(
 
   cross_compiler->set_common_options(options->glsl);
 
-  return shaderc_compilation_status_success;
+  return shaderc_spvc_initialization_status_success;
 }
 
-shaderc_compilation_status generate_hlsl_compiler(
+shaderc_spvc_initialization_status generate_hlsl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   spirv_cross::CompilerHLSL* cross_compiler;
@@ -312,10 +312,10 @@ shaderc_compilation_status generate_hlsl_compiler(
   // compiler, unless explicitly requested.
   // TODO (sarahM0): change the default to spvc IR generation when it's done
   if (context->use_spvc_parser) {
-    shaderc_compilation_status status;
+    shaderc_spvc_initialization_status status;
     spirv_cross::ParsedIR ir;
     status = generate_spvcir(context, &ir, source, source_len, options);
-    if (status != shaderc_compilation_status_success) {
+    if (status != shaderc_spvc_initialization_status_success) {
       context->messages.append(
           "Transformations between source and target "
           "execution environments failed (spvc-ir-pass).\n");
@@ -330,17 +330,17 @@ shaderc_compilation_status generate_hlsl_compiler(
   if (!cross_compiler) {
     context->messages.append(
         "Unable to initialize SPIRV-Cross HLSL compiler.\n");
-    return shaderc_compilation_status_compilation_error;
+    return shaderc_spvc_initialization_status_compilation_error;
   }
   context->cross_compiler.reset(cross_compiler);
 
   cross_compiler->set_common_options(options->glsl);
   cross_compiler->set_hlsl_options(options->hlsl);
 
-  return shaderc_compilation_status_success;
+  return shaderc_spvc_initialization_status_success;
 }
 
-shaderc_compilation_status generate_msl_compiler(
+shaderc_spvc_initialization_status generate_msl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   spirv_cross::CompilerMSL* cross_compiler;
@@ -348,10 +348,10 @@ shaderc_compilation_status generate_msl_compiler(
   // compiler, unless explicitly requested.
   // TODO (sarahM0): change the default to spvc IR generation when it's done
   if (context->use_spvc_parser) {
-    shaderc_compilation_status status;
+    shaderc_spvc_initialization_status status;
     spirv_cross::ParsedIR ir;
     status = generate_spvcir(context, &ir, source, source_len, options);
-    if (status != shaderc_compilation_status_success) {
+    if (status != shaderc_spvc_initialization_status_success) {
       context->messages.append(
           "Transformations between source and target "
           "execution environments failed (spvc-ir-pass).\n");
@@ -367,7 +367,7 @@ shaderc_compilation_status generate_msl_compiler(
   if (!cross_compiler) {
     context->messages.append(
         "Unable to initialize SPIRV-Cross MSL compiler.\n");
-    return shaderc_compilation_status_compilation_error;
+    return shaderc_spvc_initialization_status_compilation_error;
   }
   context->cross_compiler.reset(cross_compiler);
 
@@ -376,10 +376,10 @@ shaderc_compilation_status generate_msl_compiler(
   for (auto i : options->msl_discrete_descriptor_sets)
     cross_compiler->add_discrete_descriptor_set(i);
 
-  return shaderc_compilation_status_success;
+  return shaderc_spvc_initialization_status_success;
 }
 
-shaderc_compilation_status generate_vulkan_compiler(
+shaderc_spvc_initialization_status generate_vulkan_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options) {
   spirv_cross::CompilerReflection* cross_compiler;
@@ -389,9 +389,9 @@ shaderc_compilation_status generate_vulkan_compiler(
   // TODO (sarahM0): change the default to spvc IR generation when it's done
   if (context->use_spvc_parser) {
     spirv_cross::ParsedIR ir;
-    shaderc_compilation_status status =
+    shaderc_spvc_initialization_status status =
         generate_spvcir(context, &ir, source, source_len, options);
-    if (status != shaderc_compilation_status_success) {
+    if (status != shaderc_spvc_initialization_status_success) {
       context->messages.append(
           "Transformations between source and target "
           "execution environments failed (spvc-ir-pass).\n");
@@ -408,14 +408,14 @@ shaderc_compilation_status generate_vulkan_compiler(
     context->messages.append(
         "Unable to initialize SPIRV-Cross reflection "
         "compiler.\n");
-    return shaderc_compilation_status_compilation_error;
+    return shaderc_spvc_initialization_status_compilation_error;
   }
   context->cross_compiler.reset(cross_compiler);
 
-  return shaderc_compilation_status_success;
+  return shaderc_spvc_initialization_status_success;
 }
 
-shaderc_compilation_status generate_spvcir(
+shaderc_spvc_initialization_status generate_spvcir(
     const shaderc_spvc_context_t context, spirv_cross::ParsedIR* ir,
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options) {
@@ -433,10 +433,10 @@ shaderc_compilation_status generate_spvcir(
                 new spvtools::opt::SpvcIrPass(ir)))));
 
     if (!opt.Run(source, source_len, &binary_output)) {
-      return shaderc_compilation_status_transformation_error;
+      return shaderc_spvc_initialization_status_transformation_error;
     }
   }
-  return shaderc_compilation_status_success;
+  return shaderc_spvc_initialization_status_success;
 }
 
 }  // namespace spvc_private

--- a/libshaderc_spvc/src/spvc_private.h
+++ b/libshaderc_spvc/src/spvc_private.h
@@ -80,16 +80,16 @@ void consume_spirv_tools_message(shaderc_spvc_context* context,
 
 // Test whether or not the given SPIR-V binary is valid for the specific
 // environment. Invoke spirv-val to perform this operation.
-shaderc_compilation_status validate_spirv(shaderc_spvc_context* context,
-                                          spv_target_env env,
-                                          const uint32_t* source,
-                                          size_t source_len);
+shaderc_spvc_initialization_status validate_spirv(shaderc_spvc_context* context,
+                                                  spv_target_env env,
+                                                  const uint32_t* source,
+                                                  size_t source_len);
 
 // Convert SPIR-V from one environment to another, if there is a known
 // conversion. If the origin and destination environments are the same, then
 // the binary is just copied to the output buffer. Invokes spirv-opt to perform
 // the actual translation.
-shaderc_compilation_status translate_spirv(
+shaderc_spvc_initialization_status translate_spirv(
     shaderc_spvc_context* context, spv_target_env source_env,
     spv_target_env target_env, const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options, std::vector<uint32_t>* target);
@@ -97,43 +97,43 @@ shaderc_compilation_status translate_spirv(
 // Execute the validation and translate steps. Specifically validates the input,
 // transforms it, then validates the transformed input. All of these steps are
 // only done if needed.
-shaderc_compilation_status validate_and_translate_spirv(
+shaderc_spvc_initialization_status validate_and_translate_spirv(
     shaderc_spvc_context* context, const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options, std::vector<uint32_t>* target);
 
 // Given a configured compiler run it to generate a shader. Does all of the
 // required trapping to handle if the compile fails.
-shaderc_compilation_status generate_shader(
+shaderc_spvc_compilation_status generate_shader(
     spirv_cross::Compiler* compiler, shaderc_spvc_compilation_result_t result);
 
 // Given a Vulkan SPIR-V shader and set of options, create a compiler for
 // generating a GLSL shader and performing reflection.
-shaderc_compilation_status generate_glsl_compiler(
+shaderc_spvc_compilation_status generate_glsl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Given a Vulkan SPIR-V shader and set of options, create a compiler for
 // generating a HLSL shader and performing reflection.
-shaderc_compilation_status generate_hlsl_compiler(
+shaderc_spvc_compilation_status generate_hlsl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Given a Vulkan SPIR-V shader and set of options, create a compiler for
 // generating a MSL shader and performing reflection.
-shaderc_compilation_status generate_msl_compiler(
+shaderc_spvc_compilation_status generate_msl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Given a Vulkan SPIR-V shader and set of options, create a compiler for
 // generating performing reflection.
-shaderc_compilation_status generate_vulkan_compiler(
+shaderc_spvc_compilation_status generate_vulkan_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Given a pointer to an SPIRV-Cross IR (with initialized spirv field), Invokes
 // spirv-opt to generate a SPIRV-Cross IR (ie. populate empty fields of the
 // given spirv_cross::ParsedIR* ir).
-shaderc_compilation_status generate_spvcir(
+shaderc_spvc_initialization_status generate_spvcir(
     const shaderc_spvc_context_t context, spirv_cross::ParsedIR* ir,
     const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options);

--- a/libshaderc_spvc/src/spvc_private.h
+++ b/libshaderc_spvc/src/spvc_private.h
@@ -80,62 +80,63 @@ void consume_spirv_tools_message(shaderc_spvc_context* context,
 
 // Test whether or not the given SPIR-V binary is valid for the specific
 // environment. Invoke spirv-val to perform this operation.
-shaderc_spvc_initialization_status validate_spirv(shaderc_spvc_context* context,
-                                                  spv_target_env env,
-                                                  const uint32_t* source,
-                                                  size_t source_len);
+shaderc_spvc_status validate_spirv(shaderc_spvc_context* context,
+                                   spv_target_env env, const uint32_t* source,
+                                   size_t source_len);
 
 // Convert SPIR-V from one environment to another, if there is a known
 // conversion. If the origin and destination environments are the same, then
 // the binary is just copied to the output buffer. Invokes spirv-opt to perform
 // the actual translation.
-shaderc_spvc_initialization_status translate_spirv(
-    shaderc_spvc_context* context, spv_target_env source_env,
-    spv_target_env target_env, const uint32_t* source, size_t source_len,
-    shaderc_spvc_compile_options_t options, std::vector<uint32_t>* target);
+shaderc_spvc_status translate_spirv(shaderc_spvc_context* context,
+                                    spv_target_env source_env,
+                                    spv_target_env target_env,
+                                    const uint32_t* source, size_t source_len,
+                                    shaderc_spvc_compile_options_t options,
+                                    std::vector<uint32_t>* target);
 
 // Execute the validation and translate steps. Specifically validates the input,
 // transforms it, then validates the transformed input. All of these steps are
 // only done if needed.
-shaderc_spvc_initialization_status validate_and_translate_spirv(
+shaderc_spvc_status validate_and_translate_spirv(
     shaderc_spvc_context* context, const uint32_t* source, size_t source_len,
     shaderc_spvc_compile_options_t options, std::vector<uint32_t>* target);
 
 // Given a configured compiler run it to generate a shader. Does all of the
 // required trapping to handle if the compile fails.
-shaderc_spvc_compilation_status generate_shader(
-    spirv_cross::Compiler* compiler, shaderc_spvc_compilation_result_t result);
+shaderc_spvc_status generate_shader(spirv_cross::Compiler* compiler,
+                                    shaderc_spvc_compilation_result_t result);
 
 // Given a Vulkan SPIR-V shader and set of options, create a compiler for
 // generating a GLSL shader and performing reflection.
-shaderc_spvc_compilation_status generate_glsl_compiler(
+shaderc_spvc_status generate_glsl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Given a Vulkan SPIR-V shader and set of options, create a compiler for
 // generating a HLSL shader and performing reflection.
-shaderc_spvc_compilation_status generate_hlsl_compiler(
+shaderc_spvc_status generate_hlsl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Given a Vulkan SPIR-V shader and set of options, create a compiler for
 // generating a MSL shader and performing reflection.
-shaderc_spvc_compilation_status generate_msl_compiler(
+shaderc_spvc_status generate_msl_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Given a Vulkan SPIR-V shader and set of options, create a compiler for
 // generating performing reflection.
-shaderc_spvc_compilation_status generate_vulkan_compiler(
+shaderc_spvc_status generate_vulkan_compiler(
     const shaderc_spvc_context_t context, const uint32_t* source,
     size_t source_len, shaderc_spvc_compile_options_t options);
 
 // Given a pointer to an SPIRV-Cross IR (with initialized spirv field), Invokes
 // spirv-opt to generate a SPIRV-Cross IR (ie. populate empty fields of the
 // given spirv_cross::ParsedIR* ir).
-shaderc_spvc_initialization_status generate_spvcir(
-    const shaderc_spvc_context_t context, spirv_cross::ParsedIR* ir,
-    const uint32_t* source, size_t source_len,
-    shaderc_spvc_compile_options_t options);
+shaderc_spvc_status generate_spvcir(const shaderc_spvc_context_t context,
+                                    spirv_cross::ParsedIR* ir,
+                                    const uint32_t* source, size_t source_len,
+                                    shaderc_spvc_compile_options_t options);
 
 }  // namespace spvc_private

--- a/libshaderc_spvc/src/spvc_smoke_test_util.c
+++ b/libshaderc_spvc/src/spvc_smoke_test_util.c
@@ -19,9 +19,9 @@
 #include "shaderc/shaderc.h"
 #include "spvc/spvc.h"
 
-typedef shaderc_compilation_status (*InitCmd)(const shaderc_spvc_context_t,
-                                              const uint32_t*, size_t,
-                                              shaderc_spvc_compile_options_t);
+typedef shaderc_spvc_initialization_status (*InitCmd)(
+    const shaderc_spvc_context_t, const uint32_t*, size_t,
+    shaderc_spvc_compile_options_t);
 
 shaderc_compilation_result_t assemble_shader(const char* shader) {
   shaderc_compiler_t shaderc;
@@ -40,13 +40,14 @@ int test_exec(shaderc_spvc_context_t context,
               const char* target_lang) {
   shaderc_spvc_compilation_result_t result = shaderc_spvc_result_create();
   assert(result);
-  shaderc_compilation_status status = init_cmd(
+  shaderc_spvc_initialization_status status = init_cmd(
       context, (const uint32_t*)shaderc_result_get_bytes(assembled_shader),
       shaderc_result_get_length(assembled_shader) / sizeof(uint32_t), options);
   int ret_val;
-  if (status == shaderc_compilation_status_success) {
-    status = shaderc_spvc_compile_shader(context, result);
-    if (status == shaderc_compilation_status_success) {
+  if (status == shaderc_spvc_initialization_status_success) {
+    shaderc_spvc_compilation_status compile_status =
+        shaderc_spvc_compile_shader(context, result);
+    if (compile_status == shaderc_spvc_compilation_status_success) {
       printf("success! %lu characters of %s\n",
              (unsigned long)(strlen(
                  shaderc_spvc_result_get_string_output(result))),

--- a/libshaderc_spvc/src/spvc_smoke_test_util.c
+++ b/libshaderc_spvc/src/spvc_smoke_test_util.c
@@ -19,9 +19,9 @@
 #include "shaderc/shaderc.h"
 #include "spvc/spvc.h"
 
-typedef shaderc_spvc_initialization_status (*InitCmd)(
-    const shaderc_spvc_context_t, const uint32_t*, size_t,
-    shaderc_spvc_compile_options_t);
+typedef shaderc_spvc_status (*InitCmd)(const shaderc_spvc_context_t,
+                                       const uint32_t*, size_t,
+                                       shaderc_spvc_compile_options_t);
 
 shaderc_compilation_result_t assemble_shader(const char* shader) {
   shaderc_compiler_t shaderc;
@@ -40,14 +40,14 @@ int test_exec(shaderc_spvc_context_t context,
               const char* target_lang) {
   shaderc_spvc_compilation_result_t result = shaderc_spvc_result_create();
   assert(result);
-  shaderc_spvc_initialization_status status = init_cmd(
+  shaderc_spvc_status status = init_cmd(
       context, (const uint32_t*)shaderc_result_get_bytes(assembled_shader),
       shaderc_result_get_length(assembled_shader) / sizeof(uint32_t), options);
   int ret_val;
-  if (status == shaderc_spvc_initialization_status_success) {
-    shaderc_spvc_compilation_status compile_status =
+  if (status == shaderc_spvc_status_success) {
+    shaderc_spvc_status compile_status =
         shaderc_spvc_compile_shader(context, result);
-    if (compile_status == shaderc_spvc_compilation_status_success) {
+    if (compile_status == shaderc_spvc_status_success) {
       printf("success! %lu characters of %s\n",
              (unsigned long)(strlen(
                  shaderc_spvc_result_get_string_output(result))),

--- a/libshaderc_spvc/src/spvc_test.cc
+++ b/libshaderc_spvc/src/spvc_test.cc
@@ -72,97 +72,89 @@ TEST(Init, MultipleThreadsCalling) {
 
 TEST_F(CompileTest, ValidShaderIntoGlslPasses) {
   {
-    shaderc_spvc_initialization_status status =
-        shaderc_spvc_initialize_for_glsl(
-            context_, kSmokeShaderBinary,
-            sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    shaderc_spvc_status status = shaderc_spvc_initialize_for_glsl(
+        context_, kSmokeShaderBinary,
+        sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
-    shaderc_spvc_compilation_status status =
-        shaderc_spvc_compile_shader(context_, result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
 }
 
 TEST_F(CompileTest, InvalidShaderIntoGlslPasses) {
-  shaderc_spvc_initialization_status status = shaderc_spvc_initialize_for_glsl(
+  shaderc_spvc_status status = shaderc_spvc_initialize_for_glsl(
       context_, kInvalidShaderBinary,
       sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_NE(shaderc_spvc_initialization_status_success, status);
+  EXPECT_NE(shaderc_spvc_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 
 TEST_F(CompileTest, ValidShaderIntoHlslPasses) {
   {
-    shaderc_spvc_initialization_status status =
-        shaderc_spvc_initialize_for_hlsl(
-            context_, kSmokeShaderBinary,
-            sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    shaderc_spvc_status status = shaderc_spvc_initialize_for_hlsl(
+        context_, kSmokeShaderBinary,
+        sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
-    shaderc_spvc_compilation_status status =
-        shaderc_spvc_compile_shader(context_, result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
 }
 
 TEST_F(CompileTest, InvalidShaderIntoHlslPasses) {
-  shaderc_spvc_initialization_status status = shaderc_spvc_initialize_for_hlsl(
+  shaderc_spvc_status status = shaderc_spvc_initialize_for_hlsl(
       context_, kInvalidShaderBinary,
       sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_NE(shaderc_spvc_initialization_status_success, status);
+  EXPECT_NE(shaderc_spvc_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 
 TEST_F(CompileTest, ValidShaderIntoMslPasses) {
   {
-    shaderc_spvc_initialization_status status = shaderc_spvc_initialize_for_msl(
+    shaderc_spvc_status status = shaderc_spvc_initialize_for_msl(
         context_, kSmokeShaderBinary,
         sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
-    shaderc_spvc_compilation_status status =
-        shaderc_spvc_compile_shader(context_, result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
 }
 
 TEST_F(CompileTest, InvalidShaderIntoMslPasses) {
-  shaderc_spvc_initialization_status status = shaderc_spvc_initialize_for_msl(
+  shaderc_spvc_status status = shaderc_spvc_initialize_for_msl(
       context_, kInvalidShaderBinary,
       sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_NE(shaderc_spvc_initialization_status_success, status);
+  EXPECT_NE(shaderc_spvc_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 
 TEST_F(CompileTest, ValidShaderIntoVulkanPasses) {
   {
-    shaderc_spvc_initialization_status status =
-        shaderc_spvc_initialize_for_vulkan(
-            context_, kSmokeShaderBinary,
-            sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    shaderc_spvc_status status = shaderc_spvc_initialize_for_vulkan(
+        context_, kSmokeShaderBinary,
+        sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
-    shaderc_spvc_compilation_status status =
-        shaderc_spvc_compile_shader(context_, result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
 }
 
 TEST_F(CompileTest, InvalidShaderIntoVulkanPasses) {
-  shaderc_spvc_initialization_status status =
-      shaderc_spvc_initialize_for_vulkan(
-          context_, kInvalidShaderBinary,
-          sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_NE(shaderc_spvc_initialization_status_success, status);
+  shaderc_spvc_status status = shaderc_spvc_initialize_for_vulkan(
+      context_, kInvalidShaderBinary,
+      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
+  EXPECT_NE(shaderc_spvc_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 

--- a/libshaderc_spvc/src/spvc_test.cc
+++ b/libshaderc_spvc/src/spvc_test.cc
@@ -71,78 +71,98 @@ TEST(Init, MultipleThreadsCalling) {
 #endif
 
 TEST_F(CompileTest, ValidShaderIntoGlslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_glsl(
-      context_, kSmokeShaderBinary,
-      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(context_->cross_compiler.get(), nullptr);
-
-  status = shaderc_spvc_compile_shader(context_, result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
+  {
+    shaderc_spvc_initialization_status status =
+        shaderc_spvc_initialize_for_glsl(
+            context_, kSmokeShaderBinary,
+            sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_NE(context_->cross_compiler.get(), nullptr);
+  }
+  {
+    shaderc_spvc_compilation_status status =
+        shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+  }
 }
 
 TEST_F(CompileTest, InvalidShaderIntoGlslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_glsl(
+  shaderc_spvc_initialization_status status = shaderc_spvc_initialize_for_glsl(
       context_, kInvalidShaderBinary,
       sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_NE(shaderc_compilation_status_success, status);
+  EXPECT_NE(shaderc_spvc_initialization_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 
 TEST_F(CompileTest, ValidShaderIntoHlslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_hlsl(
-      context_, kSmokeShaderBinary,
-      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(context_->cross_compiler.get(), nullptr);
-
-  status = shaderc_spvc_compile_shader(context_, result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
+  {
+    shaderc_spvc_initialization_status status =
+        shaderc_spvc_initialize_for_hlsl(
+            context_, kSmokeShaderBinary,
+            sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_NE(context_->cross_compiler.get(), nullptr);
+  }
+  {
+    shaderc_spvc_compilation_status status =
+        shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+  }
 }
 
 TEST_F(CompileTest, InvalidShaderIntoHlslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_hlsl(
+  shaderc_spvc_initialization_status status = shaderc_spvc_initialize_for_hlsl(
       context_, kInvalidShaderBinary,
       sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_NE(shaderc_compilation_status_success, status);
+  EXPECT_NE(shaderc_spvc_initialization_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 
 TEST_F(CompileTest, ValidShaderIntoMslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_msl(
-      context_, kSmokeShaderBinary,
-      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(context_->cross_compiler.get(), nullptr);
-
-  status = shaderc_spvc_compile_shader(context_, result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
+  {
+    shaderc_spvc_initialization_status status = shaderc_spvc_initialize_for_msl(
+        context_, kSmokeShaderBinary,
+        sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_NE(context_->cross_compiler.get(), nullptr);
+  }
+  {
+    shaderc_spvc_compilation_status status =
+        shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+  }
 }
 
 TEST_F(CompileTest, InvalidShaderIntoMslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_msl(
+  shaderc_spvc_initialization_status status = shaderc_spvc_initialize_for_msl(
       context_, kInvalidShaderBinary,
       sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_NE(shaderc_compilation_status_success, status);
+  EXPECT_NE(shaderc_spvc_initialization_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 
 TEST_F(CompileTest, ValidShaderIntoVulkanPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_vulkan(
-      context_, kSmokeShaderBinary,
-      sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(context_->cross_compiler.get(), nullptr);
-
-  status = shaderc_spvc_compile_shader(context_, result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
+  {
+    shaderc_spvc_initialization_status status =
+        shaderc_spvc_initialize_for_vulkan(
+            context_, kSmokeShaderBinary,
+            sizeof(kSmokeShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_NE(context_->cross_compiler.get(), nullptr);
+  }
+  {
+    shaderc_spvc_compilation_status status =
+        shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+  }
 }
 
 TEST_F(CompileTest, InvalidShaderIntoVulkanPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_vulkan(
-      context_, kInvalidShaderBinary,
-      sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_NE(shaderc_compilation_status_success, status);
+  shaderc_spvc_initialization_status status =
+      shaderc_spvc_initialize_for_vulkan(
+          context_, kInvalidShaderBinary,
+          sizeof(kInvalidShaderBinary) / sizeof(uint32_t), options_);
+  EXPECT_NE(shaderc_spvc_initialization_status_success, status);
   EXPECT_EQ(context_->cross_compiler.get(), nullptr);
 }
 

--- a/libshaderc_spvc/src/spvc_webgpu_cpp_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_cpp_test.cc
@@ -38,51 +38,63 @@ class CompileTest : public testing::Test {
 };
 
 TEST_F(CompileTest, Glsl) {
-  shaderc_compilation_status status = context_.InitializeForGlsl(
-      kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
-      options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-
-  status = context_.CompileShader(&result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(0, result_.GetStringOutput().size());
-  EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  {
+    shaderc_spvc_initialization_status status = context_.InitializeForGlsl(
+        kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
+        options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+  }
+  {
+    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_NE(0, result_.GetStringOutput().size());
+    EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  }
 }
 
 TEST_F(CompileTest, Hlsl) {
-  shaderc_compilation_status status = context_.InitializeForHlsl(
-      kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
-      options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-
-  status = context_.CompileShader(&result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(0, result_.GetStringOutput().size());
-  EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  {
+    shaderc_spvc_initialization_status status = context_.InitializeForHlsl(
+        kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
+        options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+  }
+  {
+    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_NE(0, result_.GetStringOutput().size());
+    EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  }
 }
 
 TEST_F(CompileTest, Msl) {
-  shaderc_compilation_status status = context_.InitializeForMsl(
-      kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
-      options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-
-  status = context_.CompileShader(&result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(0, result_.GetStringOutput().size());
-  EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  {
+    shaderc_spvc_initialization_status status = context_.InitializeForMsl(
+        kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
+        options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+  }
+  {
+    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_NE(0, result_.GetStringOutput().size());
+    EXPECT_EQ(0, result_.GetBinaryOutput().size());
+  }
 }
 
 TEST_F(CompileTest, Vulkan) {
-  shaderc_compilation_status status = context_.InitializeForVulkan(
-      kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
-      options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-
-  status = context_.CompileShader(&result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_EQ(0, result_.GetStringOutput().size());
-  EXPECT_NE(0, result_.GetBinaryOutput().size());
+  {
+    shaderc_spvc_initialization_status status = context_.InitializeForVulkan(
+        kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
+        options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+  }
+  {
+    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_EQ(0, result_.GetStringOutput().size());
+    EXPECT_NE(0, result_.GetBinaryOutput().size());
+  }
 }
 
 }  // anonymous namespace

--- a/libshaderc_spvc/src/spvc_webgpu_cpp_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_cpp_test.cc
@@ -39,14 +39,14 @@ class CompileTest : public testing::Test {
 
 TEST_F(CompileTest, Glsl) {
   {
-    shaderc_spvc_initialization_status status = context_.InitializeForGlsl(
+    shaderc_spvc_status status = context_.InitializeForGlsl(
         kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
         options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
   {
-    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(0, result_.GetStringOutput().size());
     EXPECT_EQ(0, result_.GetBinaryOutput().size());
   }
@@ -54,14 +54,14 @@ TEST_F(CompileTest, Glsl) {
 
 TEST_F(CompileTest, Hlsl) {
   {
-    shaderc_spvc_initialization_status status = context_.InitializeForHlsl(
+    shaderc_spvc_status status = context_.InitializeForHlsl(
         kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
         options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
   {
-    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(0, result_.GetStringOutput().size());
     EXPECT_EQ(0, result_.GetBinaryOutput().size());
   }
@@ -69,14 +69,14 @@ TEST_F(CompileTest, Hlsl) {
 
 TEST_F(CompileTest, Msl) {
   {
-    shaderc_spvc_initialization_status status = context_.InitializeForMsl(
+    shaderc_spvc_status status = context_.InitializeForMsl(
         kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
         options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
   {
-    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(0, result_.GetStringOutput().size());
     EXPECT_EQ(0, result_.GetBinaryOutput().size());
   }
@@ -84,14 +84,14 @@ TEST_F(CompileTest, Msl) {
 
 TEST_F(CompileTest, Vulkan) {
   {
-    shaderc_spvc_initialization_status status = context_.InitializeForVulkan(
+    shaderc_spvc_status status = context_.InitializeForVulkan(
         kWebGPUShaderBinary, sizeof(kWebGPUShaderBinary) / sizeof(uint32_t),
         options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
   {
-    shaderc_spvc_compilation_status status = context_.CompileShader(&result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    shaderc_spvc_status status = context_.CompileShader(&result_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_EQ(0, result_.GetStringOutput().size());
     EXPECT_NE(0, result_.GetBinaryOutput().size());
   }

--- a/libshaderc_spvc/src/spvc_webgpu_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_test.cc
@@ -47,47 +47,66 @@ class CompileTest : public testing::Test {
 };
 
 TEST_F(CompileTest, ValidShaderIntoGlslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_glsl(
-      context_, kWebGPUShaderBinary,
-      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(context_->cross_compiler.get(), nullptr);
-
-  status = shaderc_spvc_compile_shader(context_, result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
+  {
+    shaderc_spvc_initialization_status status =
+        shaderc_spvc_initialize_for_glsl(
+            context_, kWebGPUShaderBinary,
+            sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_NE(context_->cross_compiler.get(), nullptr);
+  }
+  {
+    shaderd_spvc_compilation_status status =
+        shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+  }
 }
 
 TEST_F(CompileTest, ValidShaderIntoHlslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_hlsl(
-      context_, kWebGPUShaderBinary,
-      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(context_->cross_compiler.get(), nullptr);
-
-  status = shaderc_spvc_compile_shader(context_, result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
+  {
+    shaderc_spvc_initialization_status status =
+        shaderc_spvc_initialize_for_hlsl(
+            context_, kWebGPUShaderBinary,
+            sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_NE(context_->cross_compiler.get(), nullptr);
+  }
+  {
+    shaderd_spvc_compilation_status status =
+        shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+  }
 }
 
 TEST_F(CompileTest, ValidShaderIntoMslPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_msl(
-      context_, kWebGPUShaderBinary,
-      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(context_->cross_compiler.get(), nullptr);
-
-  status = shaderc_spvc_compile_shader(context_, result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
+  {
+    shaderc_spvc_initialization_status status = shaderc_spvc_initialize_for_msl(
+        context_, kWebGPUShaderBinary,
+        sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_NE(context_->cross_compiler.get(), nullptr);
+  }
+  {
+    shaderd_spvc_compilation_status status =
+        shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+  }
 }
 
 TEST_F(CompileTest, ValidShaderIntoVulkanPasses) {
-  shaderc_compilation_status status = shaderc_spvc_initialize_for_vulkan(
-      context_, kWebGPUShaderBinary,
-      sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
-  EXPECT_NE(context_->cross_compiler.get(), nullptr);
-
-  status = shaderc_spvc_compile_shader(context_, result_);
-  EXPECT_EQ(shaderc_compilation_status_success, status);
+  {
+    shaderc_spvc_initialization_status status =
+        shaderc_spvc_initialize_for_vulkan(
+            context_, kWebGPUShaderBinary,
+            sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_NE(context_->cross_compiler.get(), nullptr);
+  }
+  {
+    shaderd_spvc_compilation_status status =
+        shaderc_spvc_compile_shader(context_, result_);
+    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+  }
 }
 
 }  // anonymous namespace

--- a/libshaderc_spvc/src/spvc_webgpu_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_test.cc
@@ -48,64 +48,61 @@ class CompileTest : public testing::Test {
 
 TEST_F(CompileTest, ValidShaderIntoGlslPasses) {
   {
-    shaderc_spvc_initialization_status status =
-        shaderc_spvc_initialize_for_glsl(
-            context_, kWebGPUShaderBinary,
-            sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    shaderc_spvc_status status = shaderc_spvc_initialize_for_glsl(
+        context_, kWebGPUShaderBinary,
+        sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
     shaderd_spvc_compilation_status status =
         shaderc_spvc_compile_shader(context_, result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
 }
 
 TEST_F(CompileTest, ValidShaderIntoHlslPasses) {
   {
-    shaderc_spvc_initialization_status status =
-        shaderc_spvc_initialize_for_hlsl(
-            context_, kWebGPUShaderBinary,
-            sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    shaderc_spvc_status status = shaderc_spvc_initialize_for_hlsl(
+        context_, kWebGPUShaderBinary,
+        sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
     shaderd_spvc_compilation_status status =
         shaderc_spvc_compile_shader(context_, result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
 }
 
 TEST_F(CompileTest, ValidShaderIntoMslPasses) {
   {
-    shaderc_spvc_initialization_status status = shaderc_spvc_initialize_for_msl(
+    shaderc_spvc_status status = shaderc_spvc_initialize_for_msl(
         context_, kWebGPUShaderBinary,
         sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
     shaderd_spvc_compilation_status status =
         shaderc_spvc_compile_shader(context_, result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
 }
 
 TEST_F(CompileTest, ValidShaderIntoVulkanPasses) {
   {
-    shaderc_spvc_initialization_status status =
-        shaderc_spvc_initialize_for_vulkan(
-            context_, kWebGPUShaderBinary,
-            sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
-    EXPECT_EQ(shaderc_spvc_initialization_status_success, status);
+    shaderc_spvc_status status = shaderc_spvc_initialize_for_vulkan(
+        context_, kWebGPUShaderBinary,
+        sizeof(kWebGPUShaderBinary) / sizeof(uint32_t), options_);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
     shaderd_spvc_compilation_status status =
         shaderc_spvc_compile_shader(context_, result_);
-    EXPECT_EQ(shaderc_spvc_compilation_status_success, status);
+    EXPECT_EQ(shaderc_spvc_status_success, status);
   }
 }
 

--- a/libshaderc_spvc/src/spvc_webgpu_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_test.cc
@@ -55,7 +55,7 @@ TEST_F(CompileTest, ValidShaderIntoGlslPasses) {
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
-    shaderd_spvc_compilation_status status =
+    shaderc_spvc_status status =
         shaderc_spvc_compile_shader(context_, result_);
     EXPECT_EQ(shaderc_spvc_status_success, status);
   }
@@ -70,7 +70,7 @@ TEST_F(CompileTest, ValidShaderIntoHlslPasses) {
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
-    shaderd_spvc_compilation_status status =
+    shaderc_spvc_status status =
         shaderc_spvc_compile_shader(context_, result_);
     EXPECT_EQ(shaderc_spvc_status_success, status);
   }
@@ -85,7 +85,7 @@ TEST_F(CompileTest, ValidShaderIntoMslPasses) {
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
-    shaderd_spvc_compilation_status status =
+    shaderc_spvc_status status =
         shaderc_spvc_compile_shader(context_, result_);
     EXPECT_EQ(shaderc_spvc_status_success, status);
   }
@@ -100,7 +100,7 @@ TEST_F(CompileTest, ValidShaderIntoVulkanPasses) {
     EXPECT_NE(context_->cross_compiler.get(), nullptr);
   }
   {
-    shaderd_spvc_compilation_status status =
+    shaderc_spvc_status status =
         shaderc_spvc_compile_shader(context_, result_);
     EXPECT_EQ(shaderc_spvc_status_success, status);
   }


### PR DESCRIPTION
These currently proxy to the previous shaderc ones, so that downstream
integrators are not broken by this change. Once integrators have
migrated, proper distinct enums will be used.

Part of #916