### PR TITLE
Change from old status type in the API

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -313,7 +313,7 @@ shaderc_spvc_compile_shader(const shaderc_spvc_context_t context,
 // Set spirv_cross decoration (added for HLSL support in Dawn)
 // Given an id, decoration and argument, the decoration flag on the id is set
 // Assuming id is valid.
-SHADERC_EXPORT shaderc_compilation_status shaderc_spvc_set_decoration(
+SHADERC_EXPORT shaderc_spvc_status shaderc_spvc_set_decoration(
     const shaderc_spvc_context_t context, uint32_t id,
     shaderc_spvc_decoration decoration, uint32_t argument);
 

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -356,8 +356,8 @@ class Context {
   // Given an id, decoration and argument, the decoration flag on the id is set,
   // assuming id is valid.
   shaderc_spvc_status SetDecoration(uint32_t id,
-                                           shaderc_spvc_decoration decoration,
-                                           uint32_t argument) {
+                                    shaderc_spvc_decoration decoration,
+                                    uint32_t argument) {
     return shaderc_spvc_set_decoration(context_.get(), id, decoration, argument);
   }
 

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -355,7 +355,7 @@ class Context {
   // Set spirv_cross decoration (added for HLSL support in Dawn)
   // Given an id, decoration and argument, the decoration flag on the id is set,
   // assuming id is valid.
-  shaderc_compilation_status SetDecoration(uint32_t id,
+  shaderc_spvc_status SetDecoration(uint32_t id,
                                            shaderc_spvc_decoration decoration,
                                            uint32_t argument) {
     return shaderc_spvc_set_decoration(context_.get(), id, decoration, argument);

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -320,14 +320,14 @@ shaderc_spvc_status shaderc_spvc_compile_shader(
   }
 }
 
-shaderc_compilation_status shaderc_spvc_set_decoration(
+shaderc_spvc_status shaderc_spvc_set_decoration(
     const shaderc_spvc_context_t context, uint32_t id,
     shaderc_spvc_decoration decoration, uint32_t argument) {
   spv::Decoration spirv_cross_decoration;
-  shaderc_compilation_status status =
+  shaderc_spvc_status status =
       spvc_private::shaderc_spvc_decoration_to_spirv_cross_decoration(
           decoration, &spirv_cross_decoration);
-  if (status == shaderc_compilation_status_success) {
+  if (status == shaderc_spvc_status_success) {
     context->cross_compiler->set_decoration(static_cast<spirv_cross::ID>(id),
                                             spirv_cross_decoration, argument);
   } else {

--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -443,8 +443,7 @@ shaderc_spvc_status generate_spvcir(const shaderc_spvc_context_t context,
 shaderc_spvc_status shaderc_spvc_decoration_to_spirv_cross_decoration(
     const shaderc_spvc_decoration decoration,
     spv::Decoration* spirv_cross_decoration_ptr) {
-  if (!spirv_cross_decoration_ptr)
-    return shaderc_spvc_status_internal_error;
+  if (!spirv_cross_decoration_ptr) return shaderc_spvc_status_internal_error;
 
   shaderc_spvc_status status = shaderc_spvc_status_success;
 

--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -446,78 +446,77 @@ shaderc_spvc_status shaderc_spvc_decoration_to_spirv_cross_decoration(
   if (!spirv_cross_decoration_ptr)
     return shaderc_spvc_status_internal_error;
 
-  spv::Decoration& spirv_cross_decoration = *spirv_cross_decoration_ptr;
   shaderc_spvc_status status = shaderc_spvc_status_success;
 
   switch (decoration) {
     case SHADERC_SPVC_DECORATION_SPECID:
-      spirv_cross_decoration = spv::DecorationSpecId;
+      *spirv_cross_decoration_ptr = spv::DecorationSpecId;
       break;
     case SHADERC_SPVC_DECORATION_BLOCK:
-      spirv_cross_decoration = spv::DecorationBlock;
+      *spirv_cross_decoration_ptr = spv::DecorationBlock;
       break;
     case SHADERC_SPVC_DECORATION_ROWMAJOR:
-      spirv_cross_decoration = spv::DecorationRowMajor;
+      *spirv_cross_decoration_ptr = spv::DecorationRowMajor;
       break;
     case SHADERC_SPVC_DECORATION_COLMAJOR:
-      spirv_cross_decoration = spv::DecorationColMajor;
+      *spirv_cross_decoration_ptr = spv::DecorationColMajor;
       break;
     case SHADERC_SPVC_DECORATION_ARRAYSTRIDE:
-      spirv_cross_decoration = spv::DecorationArrayStride;
+      *spirv_cross_decoration_ptr = spv::DecorationArrayStride;
       break;
     case SHADERC_SPVC_DECORATION_MATRIXSTRIDE:
-      spirv_cross_decoration = spv::DecorationMatrixStride;
+      *spirv_cross_decoration_ptr = spv::DecorationMatrixStride;
       break;
     case SHADERC_SPVC_DECORATION_BUILTIN:
-      spirv_cross_decoration = spv::DecorationBuiltIn;
+      *spirv_cross_decoration_ptr = spv::DecorationBuiltIn;
       break;
     case SHADERC_SPVC_DECORATION_NOPERSPECTIVE:
-      spirv_cross_decoration = spv::DecorationNoPerspective;
+      *spirv_cross_decoration_ptr = spv::DecorationNoPerspective;
       break;
     case SHADERC_SPVC_DECORATION_FLAT:
-      spirv_cross_decoration = spv::DecorationFlat;
+      *spirv_cross_decoration_ptr = spv::DecorationFlat;
       break;
     case SHADERC_SPVC_DECORATION_CENTROID:
-      spirv_cross_decoration = spv::DecorationCentroid;
+      *spirv_cross_decoration_ptr = spv::DecorationCentroid;
       break;
     case SHADERC_SPVC_DECORATION_RESTRICT:
-      spirv_cross_decoration = spv::DecorationRestrict;
+      *spirv_cross_decoration_ptr = spv::DecorationRestrict;
       break;
     case SHADERC_SPVC_DECORATION_ALIASED:
-      spirv_cross_decoration = spv::DecorationAliased;
+      *spirv_cross_decoration_ptr = spv::DecorationAliased;
       break;
     case SHADERC_SPVC_DECORATION_NONWRITABLE:
-      spirv_cross_decoration = spv::DecorationNonWritable;
+      *spirv_cross_decoration_ptr = spv::DecorationNonWritable;
       break;
     case SHADERC_SPVC_DECORATION_NONREADABLE:
-      spirv_cross_decoration = spv::DecorationNonReadable;
+      *spirv_cross_decoration_ptr = spv::DecorationNonReadable;
       break;
     case SHADERC_SPVC_DECORATION_UNIFORM:
-      spirv_cross_decoration = spv::DecorationUniform;
+      *spirv_cross_decoration_ptr = spv::DecorationUniform;
       break;
     case SHADERC_SPVC_DECORATION_LOCATION:
-      spirv_cross_decoration = spv::DecorationLocation;
+      *spirv_cross_decoration_ptr = spv::DecorationLocation;
       break;
     case SHADERC_SPVC_DECORATION_COMPONENT:
-      spirv_cross_decoration = spv::DecorationComponent;
+      *spirv_cross_decoration_ptr = spv::DecorationComponent;
       break;
     case SHADERC_SPVC_DECORATION_INDEX:
-      spirv_cross_decoration = spv::DecorationIndex;
+      *spirv_cross_decoration_ptr = spv::DecorationIndex;
       break;
     case SHADERC_SPVC_DECORATION_BINDING:
-      spirv_cross_decoration = spv::DecorationBinding;
+      *spirv_cross_decoration_ptr = spv::DecorationBinding;
       break;
     case SHADERC_SPVC_DECORATION_DESCRIPTORSET:
-      spirv_cross_decoration = spv::DecorationDescriptorSet;
+      *spirv_cross_decoration_ptr = spv::DecorationDescriptorSet;
       break;
     case SHADERC_SPVC_DECORATION_OFFSET:
-      spirv_cross_decoration = spv::DecorationOffset;
+      *spirv_cross_decoration_ptr = spv::DecorationOffset;
       break;
     case SHADERC_SPVC_DECORATION_NOCONTRACTION:
-      spirv_cross_decoration = spv::DecorationNoContraction;
+      *spirv_cross_decoration_ptr = spv::DecorationNoContraction;
       break;
     default:
-      spirv_cross_decoration = spv::DecorationMax;
+      *spirv_cross_decoration_ptr = spv::DecorationMax;
       status = shaderc_spvc_status_internal_error;
       break;
   }

--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -440,107 +440,85 @@ shaderc_spvc_status generate_spvcir(const shaderc_spvc_context_t context,
   return shaderc_spvc_status_success;
 }
 
-shaderc_compilation_status shaderc_spvc_decoration_to_spirv_cross_decoration(
+shaderc_spvc_status shaderc_spvc_decoration_to_spirv_cross_decoration(
     const shaderc_spvc_decoration decoration,
     spv::Decoration* spirv_cross_decoration_ptr) {
   if (!spirv_cross_decoration_ptr)
-    return shaderc_compilation_status_internal_error;
+    return shaderc_spvc_status_internal_error;
 
   spv::Decoration& spirv_cross_decoration = *spirv_cross_decoration_ptr;
-  shaderc_compilation_status status;
+  shaderc_spvc_status status = shaderc_spvc_status_success;
 
   switch (decoration) {
     case SHADERC_SPVC_DECORATION_SPECID:
       spirv_cross_decoration = spv::DecorationSpecId;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_BLOCK:
       spirv_cross_decoration = spv::DecorationBlock;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_ROWMAJOR:
       spirv_cross_decoration = spv::DecorationRowMajor;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_COLMAJOR:
       spirv_cross_decoration = spv::DecorationColMajor;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_ARRAYSTRIDE:
       spirv_cross_decoration = spv::DecorationArrayStride;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_MATRIXSTRIDE:
       spirv_cross_decoration = spv::DecorationMatrixStride;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_BUILTIN:
       spirv_cross_decoration = spv::DecorationBuiltIn;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_NOPERSPECTIVE:
       spirv_cross_decoration = spv::DecorationNoPerspective;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_FLAT:
       spirv_cross_decoration = spv::DecorationFlat;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_CENTROID:
       spirv_cross_decoration = spv::DecorationCentroid;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_RESTRICT:
       spirv_cross_decoration = spv::DecorationRestrict;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_ALIASED:
       spirv_cross_decoration = spv::DecorationAliased;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_NONWRITABLE:
       spirv_cross_decoration = spv::DecorationNonWritable;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_NONREADABLE:
       spirv_cross_decoration = spv::DecorationNonReadable;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_UNIFORM:
       spirv_cross_decoration = spv::DecorationUniform;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_LOCATION:
       spirv_cross_decoration = spv::DecorationLocation;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_COMPONENT:
       spirv_cross_decoration = spv::DecorationComponent;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_INDEX:
       spirv_cross_decoration = spv::DecorationIndex;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_BINDING:
       spirv_cross_decoration = spv::DecorationBinding;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_DESCRIPTORSET:
       spirv_cross_decoration = spv::DecorationDescriptorSet;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_OFFSET:
       spirv_cross_decoration = spv::DecorationOffset;
-      status = shaderc_compilation_status_success;
       break;
     case SHADERC_SPVC_DECORATION_NOCONTRACTION:
       spirv_cross_decoration = spv::DecorationNoContraction;
-      status = shaderc_compilation_status_success;
       break;
     default:
       spirv_cross_decoration = spv::DecorationMax;
-      status = shaderc_compilation_status_internal_error;
+      status = shaderc_spvc_status_internal_error;
       break;
   }
   return status;

--- a/libshaderc_spvc/src/spvc_private.h
+++ b/libshaderc_spvc/src/spvc_private.h
@@ -145,7 +145,7 @@ shaderc_spvc_status generate_spvcir(const shaderc_spvc_context_t context,
 // Only WebGPU decorations are supported. More cases can be added if necessary.
 // PS. Added because spirv_cross forks Vulkan spirv headers instead of having
 // it as a dependency.
-shaderc_compilation_status shaderc_spvc_decoration_to_spirv_cross_decoration(
+shaderc_spvc_status shaderc_spvc_decoration_to_spirv_cross_decoration(
     const shaderc_spvc_decoration decoration,
     spv::Decoration* spirv_cross_decoration);
 


### PR DESCRIPTION
Missed this in the review of the initial patch, probably a rebasing/patch timing issue.