### PR TITLE
Rolling 4 dependencies & updating expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '38b4db48f98c4e3a9cc405de3a76547b857e1c37',
-  'googletest_revision': '679bfec6db73c021b0226e386c65ec1baee7a09f',
+  'glslang_revision': '0de87ee9a5bf5d094a3faa1a71fd9080e80b6be0',
+  'googletest_revision': 'ae8d1fc81b1469905b3d0fa6f8a077f58fc4b250',
   're2_revision': 'bb8e777557ddbdeabdedea4f23613c5021ffd7b1',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
-  'spirv_tools_revision': '85f3e93d13f32d45bd7f9999aa51baddf2452aae',
-  'spirv_cross_revision': 'fd5aa3ad51ece55a1b51fe6bfb271db6844ae291',
+  'spirv_tools_revision': 'e82a428605f6ce0a07337b36f8ba3935c9f165ac',
+  'spirv_cross_revision': '15b860eb1c9510e20831743e9996bf9d7883c7fc',
 }
 
 deps = {

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -57,9 +57,14 @@ shaders-msl/vert/float-math.invariant-float-math.vert,True
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,True
 shaders-no-opt/asm/comp/extended-debug-extinst.invalid.asm.comp,False
+shaders-no-opt/asm/comp/phi-temporary-copy-loop-variable.asm.invalid.comp,False
+shaders-no-opt/asm/frag/do-while-continue-phi.asm.invalid.frag,False
 shaders-no-opt/asm/frag/for-loop-dedicated-merge-block-inverted.asm.invalid.frag,False
 shaders-no-opt/asm/frag/for-loop-dedicated-merge-block-non-inverted.asm.invalid.frag,False
+shaders-no-opt/asm/frag/loop-merge-to-continue.asm.invalid.frag,False
+shaders-no-opt/asm/frag/selection-merge-to-continue.asm.invalid.frag,False
 shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
+shaders-no-opt/asm/frag/switch-merge-to-continue.asm.invalid.frag,False
 shaders-no-opt/frag/16bit-constants.invalid.frag,False
 shaders-no-opt/frag/fp16.invalid.desktop.frag,False
 shaders-no-opt/frag/multi-dimensional.desktop.invalid.flatten_dim.frag,False

--- a/spvc/test/unconfirmed_invalids
+++ b/spvc/test/unconfirmed_invalids
@@ -21,7 +21,12 @@ shaders-msl-no-opt/packing/struct-packing-array-of-scalar.comp,False
 shaders-msl-no-opt/packing/struct-packing-recursive.comp,False
 shaders-msl-no-opt/packing/struct-packing.comp,False
 shaders-no-opt/asm/comp/extended-debug-extinst.invalid.asm.comp,False
+shaders-no-opt/asm/comp/phi-temporary-copy-loop-variable.asm.invalid.comp,False
+shaders-no-opt/asm/frag/do-while-continue-phi.asm.invalid.frag,False
+shaders-no-opt/asm/frag/loop-merge-to-continue.asm.invalid.frag,False
+shaders-no-opt/asm/frag/selection-merge-to-continue.asm.invalid.frag,False
 shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
+shaders-no-opt/asm/frag/switch-merge-to-continue.asm.invalid.frag,False
 shaders-no-opt/frag/16bit-constants.invalid.frag,False
 shaders-no-opt/frag/fp16.invalid.desktop.frag,False
 shaders-no-opt/frag/multi-dimensional.desktop.invalid.flatten_dim.frag,False


### PR DESCRIPTION
Roll third_party/glslang/ 38b4db48f..0de87ee9a (6 commits)

https://github.com/KhronosGroup/glslang/compare/38b4db48f98c...0de87ee9a5bf

$ git log 38b4db48f..0de87ee9a --date=short --no-merges --format='%ad %ae %s'
2019-12-04 rnk Remove glslang::pool_allocator::setAllocator
2019-01-21 ian.d.romanick INTEL_shader_integer_functions2: Add SPIR-V generation
2018-09-20 ian.d.romanick INTEL_shader_integer_functions2: Add compiler front-end support
2018-09-20 ian.d.romanick INTEL_shader_integer_functions2: Add basic extension tracking
2019-12-02 ian.d.romanick Update README.md to include other test requirements
2019-11-27 malcolm.bechard Fix #1981

Roll third_party/googletest/ 679bfec6d..ae8d1fc81 (14 commits)

https://github.com/google/googletest/compare/679bfec6db73...ae8d1fc81b14

$ git log 679bfec6d..ae8d1fc81 --date=short --no-merges --format='%ad %ae %s'
2019-12-02 absl-team Googletest export
2019-11-27 Oleksandr.Yefremov Rename test case to test suite
2019-11-26 absl-team Googletest export
2019-11-25 absl-team Googletest export
2019-11-25 mate.pek README.md: added Catch2 and Google Test Explorer
2019-11-25 maximilianschwab Fixed typo
2019-11-17 krystian.kuzniarek unify googletest and googlemock main functions
2019-11-17 krystian.kuzniarek remove MSVC workaround: wmain link error in the static library
2019-11-22 krystian.kuzniarek remove Nokia's Symbian compiler workaround: SafeMatcherCastImpl
2019-11-22 krystian.kuzniarek consistency fix for SafeMatcherCastImpl member functions
2019-11-14 krystian.kuzniarek remove MSVC workaround: accessing namespace scope from within nested classes
2019-11-22 krystian.kuzniarek remove g++ 3.3 workaround: using on operator<<
2019-11-21 Christoph.Strehle Fix compile break for Microsoft Visual Studio 2017 v141
2019-11-05 krystian.kuzniarek change incorrect comments

Roll third_party/spirv-cross/ fd5aa3ad5..15b860eb1 (15 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/fd5aa3ad51ec...15b860eb1c95

$ git log fd5aa3ad5..15b860eb1 --date=short --no-merges --format='%ad %ae %s'
2019-12-04 post Remove obsolete use of AtomicCounterMemoryMask.
2019-12-04 post Don't emit memoryBarrierShared() in workgroup control barriers.
2019-12-03 dsinclair Update graphics robust access results
2019-12-03 post Fix MSVC warnings when building without exceptions.
2019-12-03 dsinclair Share test shader script
2019-12-03 post Update update_test_shaders.sh as well.
2019-12-02 dsinclair Roll SPIRV-Tools, SPIRV-Headers and GLSLang
2019-12-02 post Fix uninitialized memory issue.
2019-12-02 post MSL: Support ClipDistance as an input stage variable.
2019-11-28 post Fix sign handling for S/UToF.
2019-11-28 post MSL: Fix automatic binding allocation for image atomic buffers.
2019-11-27 agaule Added --msl-decoration-binding command line argument to enable binding decoration for Metal.
2019-11-26 sarahmashay Add licensing header to test_shaders.py
2019-11-26 post Mark loop headers as complex as early as possible.
2019-11-25 bill.hollings Expose as public Compiler::update_active_builtins() and has_active_builtin().

Roll third_party/spirv-tools/ 85f3e93d1..e82a42860 (13 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/85f3e93d13f3...e82a428605f6

$ git log 85f3e93d1..e82a42860 --date=short --no-merges --format='%ad %ae %s'
2019-12-03 dneto WebGPU: Array size at most max signed int + 1 (#3077)
2019-12-03 9856269+sarahM0 Permit the debug instructions in WebGPU SPIR-V - remove from the optimizer (#3083)
2019-12-03 dneto graphics robust access: use signed clamp (#3073)
2019-12-02 stevenperron Folding: perform add and sub on mismatched integer types (#3084)
2019-11-29 afdx spirv-fuzz: Fix invalid tests (#3079)
2019-11-27 alanbaker Validate nested constructs (#3068)
2019-11-27 afdx spirv-fuzz: Improve debugging facilities (#3074)
2019-11-27 stevenperron Handle unreachable block when computing register pressure (#3070)
2019-11-27 greg Improve RegisterSizePasses (#3059)
2019-11-26 headlessclayton utils/vscode: Add install.bat (#3071)
2019-11-26 52076061+digit-google build: cmake: Add support for Fuchsia. (#3062)
2019-11-26 dneto Add test with explicit example of stripping reflection info (#3064)
2019-11-26 9856269+sarahM0 Permit the debug instructions in WebGPU SPIR-V (#3063)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools