### PR TITLE
Rolling 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '0de87ee9a5bf5d094a3faa1a71fd9080e80b6be0',
-  'googletest_revision': 'ae8d1fc81b1469905b3d0fa6f8a077f58fc4b250',
-  're2_revision': 'bb8e777557ddbdeabdedea4f23613c5021ffd7b1',
+  'glslang_revision': '6c479796f6e4a6fa86ca4d25212ae1284c92fef5',
+  'googletest_revision': '78fdd6c00b8fa5dd67066fbb796affc87ba0e075',
+  're2_revision': '6a86f6b3f4a6d797886cd4cf6bca73ed25b2d00a',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
-  'spirv_tools_revision': 'e82a428605f6ce0a07337b36f8ba3935c9f165ac',
-  'spirv_cross_revision': '15b860eb1c9510e20831743e9996bf9d7883c7fc',
+  'spirv_tools_revision': '0a2b38d082a41a938328c9f453bc1e821726fbe2',
+  'spirv_cross_revision': 'f912c32898dbf558635c9d5a2d50ff887c1402ae',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ 0de87ee9a..6c479796f (4 commits)

https://github.com/KhronosGroup/glslang/compare/0de87ee9a5bf...6c479796f6e4

$ git log 0de87ee9a..6c479796f --date=short --no-merges --format='%ad %ae %s'
2019-12-09 cepheus Fix #2020: PR #1977 broke HLSL member consistency, this finishes it...
2019-12-09 cepheus Fix: #2014: Don't do "extension-on && version >= ..." keyword checks.
2019-12-09 cepheus Fix #2007: Fix a couple relative header paths in header files.
2019-12-09 cepheus Fix #1993: Fully exclude ftransform() from SPIR-V semantics.

Roll third_party/googletest/ ae8d1fc81..78fdd6c00 (6 commits)

https://github.com/google/googletest/compare/ae8d1fc81b14...78fdd6c00b8f

$ git log ae8d1fc81..78fdd6c00 --date=short --no-merges --format='%ad %ae %s'
2019-12-05 absl-team Googletest export
2019-12-05 absl-team Googletest export
2019-12-05 absl-team Googletest export
2019-11-27 krystian.kuzniarek Revert "remove MSVC workaround: wmain link error in the static library"
2019-11-27 krystian.kuzniarek Revert "unify googletest and googlemock main functions"
2019-11-17 krystian.kuzniarek remove MSVC workaround: cease const dropping

Roll third_party/re2/ bb8e77755..6a86f6b3f (1 commit)

https://github.com/google/re2/compare/bb8e777557dd...6a86f6b3f4a6

$ git log bb8e77755..6a86f6b3f --date=short --no-merges --format='%ad %ae %s'
2019-12-09 junyer Simplify the bytecode for the 80-10FFFF rune range.

Roll third_party/spirv-cross/ 15b860eb1..f912c3289 (2 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/15b860eb1c95...f912c32898db

$ git log 15b860eb1..f912c3289 --date=short --no-merges --format='%ad %ae %s'
2019-12-10 post GLSL: Fix array of input patch variables.
2019-12-09 post GLSL: Fix EmitStreamVertex/Primitive.

Roll third_party/spirv-tools/ e82a42860..0a2b38d08 (2 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/e82a428605f6...0a2b38d082a4

$ git log e82a42860..0a2b38d08 --date=short --no-merges --format='%ad %ae %s'
2019-12-10 afdx spirv-fuzz: function outlining fuzzer pass (#3078)
2019-12-06 afdx spirv-fuzz: Use validator to check break/continue dominance conditions (#3089)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools