### PR TITLE
Replace callback interface with data one for combined image samplers

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -71,6 +71,12 @@ typedef enum {
 // An opaque handle to an object that manages all compiler state.
 typedef struct shaderc_spvc_context* shaderc_spvc_context_t;
 
+typedef struct {
+  uint32_t combined_id;
+  uint32_t image_id;
+  uint32_t sampler_id;
+} shaderc_spvc_combined_image_sampler;
+
 // Create a spvc state handle.  A return of NULL indicates that there was an
 // error. Any function operating on a *_context_t must offer the basic
 // thread-safety guarantee.
@@ -335,12 +341,13 @@ SHADERC_EXPORT void shaderc_spvc_set_name(const shaderc_spvc_context_t context,
 SHADERC_EXPORT void shaderc_spvc_build_combined_image_samplers(
     const shaderc_spvc_context_t context);
 
-// For each combined_image_sampler, calls the provided callback function |f|,
-// passing in three arguments read from the combined_image_sampler.
-// (added for GLSL API support in Dawn)
-SHADERC_EXPORT void shaderc_spvc_for_each_combined_image_sampler(
+// Returns the combined image samplers.
+// If |samples| is NULL, then num_samplers is set, and no data is copied.
+// The caller responsible for |samplers| being larger enough to contain all of
+// the data.
+SHADERC_EXPORT void shaderc_spvc_get_combined_image_samplers(
     const shaderc_spvc_context_t context,
-    void (*f)(uint32_t, uint32_t, uint32_t));
+    shaderc_spvc_combined_image_sampler* samplers, size_t* num_samplers);
 
 // Set spirv_cross decoration (added for HLSL support in Dawn)
 // Given an id, decoration and argument, the decoration flag on the id is set

--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -348,9 +348,10 @@ SHADERC_EXPORT void shaderc_spvc_build_combined_image_samplers(
     const shaderc_spvc_context_t context);
 
 // Returns the combined image samplers.
+
 // If |samples| is NULL, then num_samplers is set, and no data is copied.
-// The caller responsible for |samplers| being larger enough to contain all of
-// the data.
+// The caller is responsible for |samplers| being large enough to
+// contain all of the data.
 SHADERC_EXPORT void shaderc_spvc_get_combined_image_samplers(
     const shaderc_spvc_context_t context,
     shaderc_spvc_combined_image_sampler* samplers, size_t* num_samplers);

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -379,25 +379,23 @@ class Context {
     return shaderc_spvc_unset_decoration(context_.get(), id, decoration);
   }
 
-  // For each combined_image_sampler, calls the provided callback function |f|,
-  // passing in three arguments read from the combined_image_sampler.
-  // (added for GLSL API support in Dawn)
-  void ForEachCombinedImageSamplers(void (*f)(uint32_t, uint32_t, uint32_t)) {
-    shaderc_spvc_for_each_combined_image_sampler(context_.get(), f);
-  }
-
-  // Same behaviour as above, but supports std::function instead a function
-  // pointer. Implemented in spvc.cc, since it needed to access internal bits of
-  // the library.
-  void ForEachCombinedImageSamplers(
-      std::function<void(uint32_t, uint32_t, uint32_t)> f);
-
   // spirv-cross comment:
   // Analyzes all separate image and samplers used from the currently selected
   // entry point, and re-routes them all to a combined image sampler instead.
   // (added for GLSL API support in Dawn)
   void BuildCombinedImageSamplers(void) {
     shaderc_spvc_build_combined_image_samplers(context_.get());
+  }
+
+  // After call to BuildCombinedImageSamplers, fetch the ids associated with the
+  // combined image samplers.
+  void GetCombinedImageSamplers(
+      std::vector<shaderc_spvc_combined_image_sampler>* samplers) {
+    size_t count;
+    shaderc_spvc_get_combined_image_samplers(context_.get(), nullptr, &count);
+    samplers->resize(count);
+    shaderc_spvc_get_combined_image_samplers(context_.get(), samplers->data(),
+                                             &count);
   }
 
   // set |name| on a given |id| (added for GLSL support in Dawn).

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -380,12 +380,21 @@ shaderc_spvc_status shaderc_spvc_unset_decoration(
   return status;
 }
 
-void shaderc_spvc_for_each_combined_image_sampler(
+void shaderc_spvc_get_combined_image_samplers(
     const shaderc_spvc_context_t context,
-    void (*f)(uint32_t, uint32_t, uint32_t)) {
+    shaderc_spvc_combined_image_sampler* samplers, size_t* num_samplers) {
+  assert(num_samplers);
+  if (!num_samplers) return;
+
+  *num_samplers = context->cross_compiler->get_combined_image_samplers().size();
+  if (!samplers) return;
+
   for (const auto& combined :
        context->cross_compiler->get_combined_image_samplers()) {
-    f(combined.sampler_id, combined.image_id, combined.combined_id);
+    samplers->combined_id = combined.combined_id;
+    samplers->image_id = combined.image_id;
+    samplers->sampler_id = combined.sampler_id;
+    samplers++;
   }
 }
 
@@ -423,15 +432,3 @@ uint32_t shaderc_spvc_result_get_binary_length(
     const shaderc_spvc_compilation_result_t result) {
   return result->binary_output.size();
 }
-
-namespace shaderc_spvc {
-
-void Context::ForEachCombinedImageSamplers(
-    std::function<void(uint32_t, uint32_t, uint32_t)> f) {
-  for (const auto& combined :
-       context_->cross_compiler->get_combined_image_samplers()) {
-    f(combined.sampler_id, combined.image_id, combined.combined_id);
-  }
-}
-
-}  // namespace shaderc_spvc


### PR DESCRIPTION
I originally championed the callback style interface that has been implemented, but it has become difficult to integrate into Dawn correctly. 
So I think @dj2's suggestion of a data return interface is the better way to go now. 