### PR TITLE
Rolling 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '6c479796f6e4a6fa86ca4d25212ae1284c92fef5',
-  'googletest_revision': '78fdd6c00b8fa5dd67066fbb796affc87ba0e075',
-  're2_revision': '6a86f6b3f4a6d797886cd4cf6bca73ed25b2d00a',
+  'glslang_revision': 'ebf634bcaa3e46ca8a912ed05b87281c731b2391',
+  'googletest_revision': '5b162a79d49d044690f3eb7d87ecc3b98a3f2e25',
+  're2_revision': '7470f4d027530ad7decab55e8e2d92ad49754e64',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
-  'spirv_tools_revision': '0a2b38d082a41a938328c9f453bc1e821726fbe2',
+  'spirv_tools_revision': '96354f5047bf35765af49657304357e00264e5f9',
   'spirv_cross_revision': 'f912c32898dbf558635c9d5a2d50ff887c1402ae',
 }
 


### PR DESCRIPTION
Roll third_party/glslang/ 6c479796f..ebf634bca (1 commit)

https://github.com/KhronosGroup/glslang/compare/6c479796f6e4...ebf634bcaa3e

$ git log 6c479796f..ebf634bca --date=short --no-merges --format='%ad %ae %s'
2019-12-12 greg Update spriv-tools known good

Roll third_party/googletest/ 78fdd6c00..5b162a79d (7 commits)

https://github.com/google/googletest/compare/78fdd6c00b8f...5b162a79d49d

$ git log 78fdd6c00..5b162a79d --date=short --no-merges --format='%ad %ae %s'
2019-12-12 absl-team Googletest export
2019-12-11 absl-team Googletest export
2019-12-10 absl-team Googletest export
2019-12-06 misterg Googletest export
2019-11-17 krystian.kuzniarek remove MSVC workaround: warning 4355
2019-11-14 krystian.kuzniarek remove MSVC workaround: error C2665
2019-11-22 krystian.kuzniarek remove g++ 2.95.0 workaround: no space after first comma in macros

Roll third_party/re2/ 6a86f6b3f..7470f4d02 (1 commit)

https://github.com/google/re2/compare/6a86f6b3f4a6...7470f4d02753

$ git log 6a86f6b3f..7470f4d02 --date=short --no-merges --format='%ad %ae %s'
2019-12-13 junyer std::is_pod<> was deprecated in C++20.

Roll third_party/spirv-tools/ 0a2b38d08..96354f504 (5 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/0a2b38d082a4...96354f5047bf

$ git log 0a2b38d08..96354f504 --date=short --no-merges --format='%ad %ae %s'
2019-12-12 afdx spirv-fuzz: Fuzzer pass to merge blocks (#3097)
2019-12-11 stevenperron Start SPIRV-Tools v2020.1
2019-12-11 stevenperron Finalize SPIRV-Tools v2019.5
2019-12-11 stevenperron Update CHANGES
2019-12-10 stevenperron Don't crash when folding construct of empty struct (#3092)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools