### PR TITLE
Rolling 5 dependencies and updating expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': 'ebf634bcaa3e46ca8a912ed05b87281c731b2391',
-  'googletest_revision': '5b162a79d49d044690f3eb7d87ecc3b98a3f2e25',
-  're2_revision': '7470f4d027530ad7decab55e8e2d92ad49754e64',
+  'glslang_revision': '40801e31ed0cd8501c5daa0fe56e4e825165cc9e',
+  'googletest_revision': '306f3754a71d6d1ac644681d3544d06744914228',
+  're2_revision': '00af5b44d36d4f26af30bf1d19707c651a1edf51',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
-  'spirv_tools_revision': '96354f5047bf35765af49657304357e00264e5f9',
-  'spirv_cross_revision': 'f912c32898dbf558635c9d5a2d50ff887c1402ae',
+  'spirv_tools_revision': 'c8bf14393cf6e8e05e854e095352088a62818b5c',
+  'spirv_cross_revision': '961b9014af8664d01b5f9a7e2375c1bac287ef64',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -61,3 +61,6 @@ shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
+shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
+shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
+shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -97,3 +97,6 @@ shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
+shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
+shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
+shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False


### PR DESCRIPTION
Roll third_party/glslang/ ebf634bca..40801e31e (8 commits)

https://github.com/KhronosGroup/glslang/compare/ebf634bcaa3e...40801e31ed0c

$ git log ebf634bca..40801e31e --date=short --no-merges --format='%ad %ae %s'
2020-01-06 cepheus Bump revision
2020-01-06 laddoc Add builtin constants
2019-12-26 cepheus HLSL: Fix #2037: Integer dot used incorrect input for adds.
2019-12-25 laddoc atomic counter offset should align to 4
2019-11-26 laddoc Add support for ARB_uniform_buffer_object
2019-11-26 laddoc Add support for ARB_texture_multisample
2019-11-26 laddoc Add support for ARB_sample_shading
2019-12-20 cepheus Command-line: Give better error messages. From #1829.

Roll third_party/googletest/ 5b162a79d..306f3754a (17 commits)

https://github.com/google/googletest/compare/5b162a79d49d...306f3754a71d

$ git log 5b162a79d..306f3754a --date=short --no-merges --format='%ad %ae %s'
2019-12-30 absl-team Googletest export
2019-12-30 absl-team Googletest export
2019-12-26 absl-team Googletest export
2019-12-19 absl-team Googletest export
2019-12-18 absl-team Googletest export
2019-12-18 absl-team Googletest export
2019-12-20 kontakt Make move operation noexcept.
2019-12-20 kontakt Define default destructor for test classes
2019-12-20 kontakt Deleted functions as part of public interface
2019-12-20 kontakt Review notes: Return T& from assignment operators
2019-12-17 kontakt Disable move constructor and assignment operator for test classes.
2019-12-16 krzysio Googletest export
2019-12-10 syoussefi Revert "Googletest export": disallow empty prefix
2019-12-10 syoussefi Revert "Googletest export": Remove test for empty prefix
2019-12-16 syoussefi Workaround VS bug w.r.t empty arguments to macros
2019-12-13 kravlala.1 Activate GNU extensions in case of MSYS generator
2019-11-22 krystian.kuzniarek remove stale comments about older GCC versions

Roll third_party/re2/ 7470f4d02..00af5b44d (2 commits)

https://github.com/google/re2/compare/7470f4d02753...00af5b44d36d

$ git log 7470f4d02..00af5b44d --date=short --no-merges --format='%ad %ae %s'
2020-01-05 junyer Fix a comment.
2019-12-29 junyer Make DFA use hints.

Roll third_party/spirv-cross/ f912c3289..961b9014a (6 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/f912c32898db...961b9014af86

$ git log f912c3289..961b9014a --date=short --no-merges --format='%ad %ae %s'
2020-01-06 post Fix Clang warnings.
2020-01-06 post Roll custom versions of isalpha/isalnum.
2020-01-06 post Add test shader for OpCopyLogical with packing/unpacking.
2020-01-06 post Go through access chain path for OpCopyLogical.
2020-01-06 post Basic implementation of OpCopyLogical.
2019-12-21 dm86.jang Add debug prefix on Windows

Roll third_party/spirv-tools/ 96354f504..c8bf14393 (12 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/96354f5047bf...c8bf14393cf6

$ git log 96354f504..c8bf14393 --date=short --no-merges --format='%ad %ae %s'
2020-01-06 dneto GetOperandConstants operand can be const (#3126)
2019-12-27 dneto Avoid pessimizing std::move (#3124)
2019-12-27 kburjack Fix typo in validation message (#3122)
2019-12-27 greg Change default version for CreatInstBindlessCheckPass to 2 (#3119)
2019-12-20 greg Fix convert-relax-to-half invalid code (#3099) (#3106)
2019-12-19 dneto Support OpenCL.DebugInfo.100 extended instruction set (#3080)
2019-12-19 afdx spirv-fuzz: Always add new globals to entry point interfaces (#3113)
2019-12-19 afdx spirv-fuzz: Transformation to add a new function to a module (#3114)
2019-12-19 afdx spirv-fuzz: Avoid passing access chains as parameters (#3112)
2019-12-18 dneto Add support for SPV_KHR_non_semantic_info (#3110)
2019-12-16 afdx spirv-fuzz: Transformations to add types, constants and variables (#3101)
2019-12-16 greg Make Instrumentation format version 2 the default (Step 1) (#3096)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools