### PR TITLE
Convert spvc messages internal struct to be a vector

### DIFF
--- a/libshaderc_spvc/src/spvc_private.h
+++ b/libshaderc_spvc/src/spvc_private.h
@@ -36,7 +36,8 @@ typedef enum {
 
 struct shaderc_spvc_context {
   std::unique_ptr<spirv_cross::Compiler> cross_compiler;
-  std::string messages;
+  std::vector<std::string> messages;
+  std::string messages_string;
   spvc_target_lang target_lang = SPVC_TARGET_LANG_UNKNOWN;
   std::vector<uint32_t> intermediate_shader;
   bool use_spvc_parser = false;


### PR DESCRIPTION
This is mostly done so that code adding messages doesn't need to remember to put
a '\n' after, like they are a telegraph operator or something.

Part of resolving #951