### PR TITLE
Rolling 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '40801e31ed0cd8501c5daa0fe56e4e825165cc9e',
-  'googletest_revision': '306f3754a71d6d1ac644681d3544d06744914228',
-  're2_revision': '00af5b44d36d4f26af30bf1d19707c651a1edf51',
+  'glslang_revision': 'd203754bc1160cbb14e80de238042a2b9b439917',
+  'googletest_revision': 'd854bd6acc47f7f6e168007d58b5f509e4981b36',
+  're2_revision': '85c014206aee9bc1730dc416b33609974ae3ff5f',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
-  'spirv_tools_revision': 'c8bf14393cf6e8e05e854e095352088a62818b5c',
-  'spirv_cross_revision': '961b9014af8664d01b5f9a7e2375c1bac287ef64',
+  'spirv_tools_revision': '18b3b94567a9251a6f8491a6d07c4422abadd22c',
+  'spirv_cross_revision': '172e39f0398b920cfc221b7826c92105d44ad647',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ 40801e31e..d203754bc (6 commits)

https://github.com/KhronosGroup/glslang/compare/40801e31ed0c...d203754bc116

$ git log 40801e31e..d203754bc --date=short --no-merges --format='%ad %ae %s'
2020-01-07 cepheus Fix #1829: Add "--" command-line options for macro def/undef.
2020-01-08 laddoc Move symbol builtin check to grammar stage
2020-01-06 lryer Add missing extension defination
2019-11-26 laddoc Add support for ARB_gpu_shader_fp64
2020-01-03 lryer Fix glslang can't link multiple AST in a single stage
2019-12-25 laddoc Modify atomic_uint binding check

Roll third_party/googletest/ 306f3754a..d854bd6ac (4 commits)

https://github.com/google/googletest/compare/306f3754a71d...d854bd6acc47

$ git log 306f3754a..d854bd6ac --date=short --no-merges --format='%ad %ae %s'
2020-01-09 absl-team Googletest export
2020-01-09 absl-team Googletest export
2020-01-07 absl-team Googletest export
2020-01-07 absl-team Googletest export

Roll third_party/re2/ 00af5b44d..85c014206 (2 commits)

https://github.com/google/re2/compare/00af5b44d36d...85c014206aee

$ git log 00af5b44d..85c014206 --date=short --no-merges --format='%ad %ae %s'
2020-01-12 junyer Tidy up a test.
2020-01-07 junyer Prevent ShortVisit() from crashing fuzzers.

Roll third_party/spirv-cross/ 961b9014a..172e39f03 (14 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/961b9014af86...172e39f0398b

$ git log 961b9014a..172e39f03 --date=short --no-merges --format='%ad %ae %s'
2020-01-09 post HLSL: Add a resource remapping API similar to MSL.
2020-01-09 post MSL: Deal with sign on wave min/max.
2020-01-09 post HLSL: Deal with casting for WaveActiveMin/Max.
2020-01-09 post GLSL: Deal with sign in subgroup Min/Max operations.
2020-01-08 post Run format_all.sh.
2020-01-08 post HLSL: Fix bug when reading and writing structs from SSBO.
2020-01-08 post HLSL: Implement stores for complex composites in ByteAddressBuffers.
2020-01-08 post HLSL: Support loading complex composites from ByteAddressBuffer.
2020-01-08 post Run format_all.sh.
2020-01-07 post MSL: Deal with padded fragment output + Component decoration.
2020-01-07 post MSL: Explicitly don't support component packing for tessellation.
2020-01-07 post MSL: Don't set OrigID when emitting component packed vectors.
2020-01-07 post MSL: Deal with packing vectors for vertex input/fragment output.
2020-01-07 post MSL: Add trivial tests for Component decoration.

Roll third_party/spirv-tools/ c8bf14393..18b3b9456 (6 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/c8bf14393cf6...18b3b94567a9

$ git log c8bf14393..18b3b9456 --date=short --no-merges --format='%ad %ae %s'
2020-01-10 33791085+aqnuep Remove names and decorations of imported symbols (#3081)
2020-01-08 dneto Fix GN build for OpenCL.DebugInfo.100 update (#3134)
2020-01-08 bclayton Fix bad parameter names in error message (#3129)
2020-01-07 alanbaker Revert PR #3093 (#3131)
2020-01-07 alanbaker Disallow forward references in arrays (#3093)
2020-01-07 afdx spirv-fuzz: Add fuzzer pass to perform module donation (#3117)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools