### PR TITLE
Support Vulkan 1.2

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': 'd203754bc1160cbb14e80de238042a2b9b439917',
+  'glslang_revision': '4fc7a33910fb8e40b970d160e1b38ab3f67fe0f3',
   'googletest_revision': 'd854bd6acc47f7f6e168007d58b5f509e4981b36',
   're2_revision': '85c014206aee9bc1730dc416b33609974ae3ff5f',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
-  'spirv_tools_revision': '18b3b94567a9251a6f8491a6d07c4422abadd22c',
+  'spirv_tools_revision': '323a81fc5e30e43a04e5e22af4cba98ca2a161e6',
   'spirv_cross_revision': '172e39f0398b920cfc221b7826c92105d44ad647',
 }
 

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -153,6 +153,7 @@ Options:
                     the client version.  Values are:
                         vulkan1.0       # The default
                         vulkan1.1
+                        vulkan1.2
                         vulkan          # Same as vulkan1.0
                         opengl4.5
                         opengl          # Same as opengl4.5
@@ -161,7 +162,8 @@ Options:
                     module.  The default is the highest version of SPIR-V
                     required to be supported for the target environment.
                     For example, default for vulkan1.0 is spv1.0, and
-                    the default for vulkan1.1 is spv1.3.
+                    the default for vulkan1.1 is spv1.3,
+                    the default for vulkan1.2 is spv1.5.
                     Values are:
                         spv1.0, spv1.1, spv1.2, spv1.3, spv1.4, spv1.5
   --version         Display compiler version information.
@@ -425,6 +427,9 @@ int main(int argc, char** argv) {
       } else if (target_env_str == "vulkan1.1") {
         target_env = shaderc_target_env_vulkan;
         version = shaderc_env_version_vulkan_1_1;
+      } else if (target_env_str == "vulkan1.2") {
+        target_env = shaderc_target_env_vulkan;
+        version = shaderc_env_version_vulkan_1_2;
       } else if (target_env_str == "opengl") {
         target_env = shaderc_target_env_opengl;
       } else if (target_env_str == "opengl4.5") {

--- a/glslc/test/option_target_env.py
+++ b/glslc/test/option_target_env.py
@@ -120,6 +120,15 @@ class TestTargetEnvEqVulkan1_1WithVulkan1_1ShaderSucceeds(expect.ValidObjectFile
     shader = FileShader(vulkan_compute_subgroup_shader(), '.comp')
     glslc_args = ['--target-env=vulkan1.1', '-c', shader]
 
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqVulkan1_2WithVulkan1_0ShaderSucceeds(expect.ValidObjectFile1_5):
+    shader = FileShader(vulkan_vertex_shader(), '.vert')
+    glslc_args = ['--target-env=vulkan1.2', '-c', shader]
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqVulkan1_2WithVulkan1_1ShaderSucceeds(expect.ValidObjectFile1_5):
+    shader = FileShader(vulkan_compute_subgroup_shader(), '.comp')
+    glslc_args = ['--target-env=vulkan1.2', '-c', shader]
 
 @inside_glslc_testsuite('OptionTargetEnv')
 class TestTargetEnvEqOpenGL4_5WithOpenGLShaderSucceeds(expect.ValidObjectFile):

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -157,6 +157,7 @@ Options:
                     the client version.  Values are:
                         vulkan1.0       # The default
                         vulkan1.1
+                        vulkan1.2
                         vulkan          # Same as vulkan1.0
                         opengl4.5
                         opengl          # Same as opengl4.5
@@ -165,7 +166,8 @@ Options:
                     module.  The default is the highest version of SPIR-V
                     required to be supported for the target environment.
                     For example, default for vulkan1.0 is spv1.0, and
-                    the default for vulkan1.1 is spv1.3.
+                    the default for vulkan1.1 is spv1.3,
+                    the default for vulkan1.2 is spv1.5.
                     Values are:
                         spv1.0, spv1.1, spv1.2, spv1.3, spv1.4, spv1.5
   --version         Display compiler version information.

--- a/libshaderc/include/shaderc/env.h
+++ b/libshaderc/include/shaderc/env.h
@@ -38,6 +38,7 @@ typedef enum {
   // See vulkan.h
   shaderc_env_version_vulkan_1_0 = ((1u << 22)),
   shaderc_env_version_vulkan_1_1 = ((1u << 22) | (1 << 12)),
+  shaderc_env_version_vulkan_1_2 = ((1u << 22) | (2 << 12)),
   // For OpenGL, use the number from #version in shaders.
   // TODO(dneto): Currently no difference between OpenGL 4.5 and 4.6.
   // See glslang/Standalone/Standalone.cpp

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -307,6 +307,10 @@ shaderc_util::Compiler::TargetEnvVersion GetCompilerTargetEnvVersion(
       version_number) {
     return Compiler::TargetEnvVersion::Vulkan_1_1;
   }
+  if (static_cast<uint32_t>(Compiler::TargetEnvVersion::Vulkan_1_2) ==
+      version_number) {
+    return Compiler::TargetEnvVersion::Vulkan_1_2;
+  }
   if (static_cast<uint32_t>(Compiler::TargetEnvVersion::OpenGL_4_5) ==
       version_number) {
     return Compiler::TargetEnvVersion::OpenGL_4_5;

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -117,6 +117,7 @@ class Compiler {
     // For Vulkan, use numbering scheme from vulkan.h
     Vulkan_1_0 = ((1 << 22)),              // Vulkan 1.0
     Vulkan_1_1 = ((1 << 22) | (1 << 12)),  // Vulkan 1.1
+    Vulkan_1_2 = ((1 << 22) | (2 << 12)),  // Vulkan 1.2
     // For OpenGL, use the numbering from #version in shaders.
     OpenGL_4_5 = 450,
   };

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -671,6 +671,9 @@ GlslangClientInfo GetGlslangClientInfo(
       } else if (env_version == Compiler::TargetEnvVersion::Vulkan_1_1) {
         result.client_version = glslang::EShTargetVulkan_1_1;
         result.target_language_version = glslang::EShTargetSpv_1_3;
+      } else if (env_version == Compiler::TargetEnvVersion::Vulkan_1_2) {
+        result.client_version = glslang::EShTargetVulkan_1_2;
+        result.target_language_version = glslang::EShTargetSpv_1_5;
       } else {
         errs << "error:" << error_tag << ": Invalid target client version "
              << static_cast<uint32_t>(env_version) << " for Vulkan environment "

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -165,7 +165,7 @@ void main() { o = clamp(i, vec4(0.5), vec4(1.0)); }
 std::string Disassemble(const std::vector<uint32_t> binary) {
   std::string result;
   shaderc_util::SpirvToolsDisassemble(Compiler::TargetEnv::Vulkan,
-                                      Compiler::TargetEnvVersion::Vulkan_1_1,
+                                      Compiler::TargetEnvVersion::Vulkan_1_2,
                                       binary, &result);
   return result;
 }

--- a/libshaderc_util/src/spirv_tools_wrapper.cc
+++ b/libshaderc_util/src/spirv_tools_wrapper.cc
@@ -35,6 +35,8 @@ spv_target_env GetSpirvToolsTargetEnv(Compiler::TargetEnv env,
           return SPV_ENV_VULKAN_1_0;
         case Compiler::TargetEnvVersion::Vulkan_1_1:
           return SPV_ENV_VULKAN_1_1;
+        case Compiler::TargetEnvVersion::Vulkan_1_2:
+          return SPV_ENV_VULKAN_1_2;
         default:
           break;
       }


### PR DESCRIPTION
Compiling for Vulkan 1.2 defaults to using SPIR-V 1.5.

Depends on Vulkan 1.2 support in Glslang, and SPIRV-Tools
Depends on SPIR-V 1.5 support in SPIRV-Headers