### PR TITLE
Rolling 3 dependencies and updating expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '4fc7a33910fb8e40b970d160e1b38ab3f67fe0f3',
-  'googletest_revision': 'd854bd6acc47f7f6e168007d58b5f509e4981b36',
+  'glslang_revision': 'b0ada80356ca7b560c600b93a596af1331442542',
+  'googletest_revision': '8b4817e3df3746a20502a84580f661ac448821be',
   're2_revision': '85c014206aee9bc1730dc416b33609974ae3ff5f',
   'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
   'spirv_tools_revision': '323a81fc5e30e43a04e5e22af4cba98ca2a161e6',
-  'spirv_cross_revision': '172e39f0398b920cfc221b7826c92105d44ad647',
+  'spirv_cross_revision': 'f9818f0804e6e73ec8afcc523b7e7f8bfc362632',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -4,8 +4,11 @@ shaders-hlsl/comp/num-workgroups-with-builtins.comp,False
 shaders-hlsl/comp/num-workgroups-with-builtins.comp,True
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
+shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
+shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
 shaders-msl-no-opt/comp/basic.dynamic-buffer.msl2.invalid.comp,False
 shaders-msl-no-opt/comp/int64.invalid.msl22.comp,False
+shaders-msl-no-opt/frag/force-active-resources.msl2.argument..force-active.discrete.frag,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,True
 shaders-msl/asm/frag/min-lod.msl22.asm.frag,False
@@ -32,6 +35,7 @@ shaders-msl/vert/float-math.invariant-float-math.vert,False
 shaders-msl/vert/float-math.invariant-float-math.vert,True
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,True
+shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
 shaders-reflection/asm/aliased-entry-point-names.asm.multi,False
 shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp,False
@@ -53,7 +57,9 @@ shaders-reflection/frag/push-constant.vk.frag,False
 shaders-reflection/frag/separate-sampler-texture-array.vk.frag,False
 shaders-reflection/frag/spec-constant.vk.frag,False
 shaders-reflection/rgen/acceleration_structure.vk.rgen,False
+shaders-reflection/vert/array-size-reflection.vert,False
 shaders-reflection/vert/read-from-row-major-array.vert,False
+shaders-reflection/vert/stride-reflection.vert,False
 shaders-reflection/vert/texture_buffer.vert,False
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,False
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,True
@@ -61,6 +67,3 @@ shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
-shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
-shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
-shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -9,6 +9,8 @@ shaders-hlsl/comp/num-workgroups-with-builtins.comp,False
 shaders-hlsl/comp/num-workgroups-with-builtins.comp,True
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
+shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
+shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
 shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-3.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-5.asm.comp,False
@@ -17,6 +19,7 @@ shaders-msl-no-opt/asm/packing/packed-vector-extract-insert.asm.comp,False
 shaders-msl-no-opt/comp/basic.dynamic-buffer.msl2.invalid.comp,False
 shaders-msl-no-opt/comp/int64.invalid.msl22.comp,False
 shaders-msl-no-opt/frag/16bit-constants.invalid.frag,False
+shaders-msl-no-opt/frag/force-active-resources.msl2.argument..force-active.discrete.frag,False
 shaders-msl-no-opt/frag/fp16.desktop.invalid.frag,False
 shaders-msl-no-opt/frag/min-max-clamp.invalid.asm.frag,False
 shaders-msl-no-opt/frag/shadow-compare-global-alias.invalid.frag,False
@@ -56,6 +59,7 @@ shaders-msl/vert/float-math.invariant-float-math.vert,False
 shaders-msl/vert/float-math.invariant-float-math.vert,True
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,True
+shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
 shaders-no-opt/asm/comp/extended-debug-extinst.invalid.asm.comp,False
 shaders-no-opt/asm/comp/phi-temporary-copy-loop-variable.asm.invalid.comp,False
 shaders-no-opt/asm/frag/do-while-continue-phi.asm.invalid.frag,False
@@ -89,7 +93,9 @@ shaders-reflection/frag/push-constant.vk.frag,False
 shaders-reflection/frag/separate-sampler-texture-array.vk.frag,False
 shaders-reflection/frag/spec-constant.vk.frag,False
 shaders-reflection/rgen/acceleration_structure.vk.rgen,False
+shaders-reflection/vert/array-size-reflection.vert,False
 shaders-reflection/vert/read-from-row-major-array.vert,False
+shaders-reflection/vert/stride-reflection.vert,False
 shaders-reflection/vert/texture_buffer.vert,False
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,False
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,True
@@ -97,6 +103,3 @@ shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
-shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
-shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
-shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False


### PR DESCRIPTION
Roll third_party/glslang/ 4fc7a3391..b0ada8035 (3 commits)

https://github.com/KhronosGroup/glslang/compare/4fc7a33910fb...b0ada80356ca

$ git log 4fc7a3391..b0ada8035 --date=short --no-merges --format='%ad %ae %s'
2020-01-17 cepheus HLSL: Fix #1974: ignore input primitives on non-entry-point functions.
2020-01-16 cepheus Fix #2059, and also attempt to skip test bots [skip ci]
2019-12-24 laddoc Add Error check flag in io mapper

Roll third_party/googletest/ d854bd6ac..8b4817e3d (6 commits)

https://github.com/google/googletest/compare/d854bd6acc47...8b4817e3df37

$ git log d854bd6ac..8b4817e3d --date=short --no-merges --format='%ad %ae %s'
2020-01-15 absl-team Googletest export
2020-01-15 absl-team Googletest export
2020-01-14 absl-team Googletest export
2020-01-14 absl-team Googletest export
2020-01-14 absl-team Googletest export
2020-01-10 absl-team Googletest export

Roll third_party/spirv-cross/ 172e39f03..f9818f080 (7 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/172e39f0398b...f9818f0804e6

$ git log 172e39f03..f9818f080 --date=short --no-merges --format='%ad %ae %s'
2020-01-16 post Update license headers to 2020.
2020-01-16 post Run format_all.sh.
2020-01-16 post MSL: Add support for force-activating IAB resources.
2020-01-16 post Deal with illegal names in types as well.
2020-01-15 post Reflection: Add array stride/matrix stride reflection.
2020-01-15 post Reflection: Emit reflection information for array size literalness.
2020-01-15 post GLSL: Implement geometry shader passthrough extension.

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools