### PR TITLE
Big cleanup to normalize API behaviour

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -55,18 +55,50 @@ class CompilationResult {
     return *this;
   }
 
+  // DEPRECATED
   const std::string GetStringOutput() const {
-    return shaderc_spvc_result_get_string_output(result_.get());
+    std::string str;
+    GetStringOutput(&str);
+    return str;
   }
 
-  const std::vector<uint32_t> GetBinaryOutput() const {
-    const uint32_t* binary_output =
-        shaderc_spvc_result_get_binary_output(result_.get());
-    uint32_t binary_length =
-        shaderc_spvc_result_get_binary_length(result_.get());
-    if (!binary_output || !binary_length) return {};
+  shaderc_spvc_status GetStringOutput(std::string* str) const {
+    if (!str) return shaderc_spvc_status_invalid_out_param;
+    const char* inner_str;
+    shaderc_spvc_status status =
+        shaderc_spvc_result_get_string_output(result_.get(), &inner_str);
+    if (status != shaderc_spvc_status_success) {
+      return status;
+    }
+    *str = std::string(inner_str);
+    return shaderc_spvc_status_success;
+  }
 
-    return std::vector<uint32_t>(binary_output, binary_output + binary_length);
+  // DEPRECATED
+  const std::vector<uint32_t> GetBinaryOutput() const {
+    std::vector<uint32_t> result;
+    GetBinaryOutput(&result);
+    return result;
+  }
+
+  shaderc_spvc_status GetBinaryOutput(std::vector<uint32_t>* data) const {
+    if (!data) return shaderc_spvc_status_invalid_out_param;
+    const uint32_t* binary_output;
+    shaderc_spvc_status status =
+        shaderc_spvc_result_get_binary_output(result_.get(), &binary_output);
+    if (status != shaderc_spvc_status_success) {
+      return status;
+    }
+    uint32_t binary_length;
+    status =
+        shaderc_spvc_result_get_binary_length(result_.get(), &binary_length);
+    if (!binary_output || !binary_length) {
+      *data = std::vector<uint32_t>();
+    } else {
+      *data =
+          std::vector<uint32_t>(binary_output, binary_output + binary_length);
+    }
+    return shaderc_spvc_status_success;
   }
 
  private:
@@ -97,29 +129,32 @@ class CompileOptions {
   }
 
   // Set the environment for the input SPIR-V.  Default is Vulkan 1.0.
-  void SetSourceEnvironment(shaderc_target_env env,
-                            shaderc_env_version version) {
-    shaderc_spvc_compile_options_set_source_env(options_.get(), env, version);
+  shaderc_spvc_status SetSourceEnvironment(shaderc_target_env env,
+                                           shaderc_env_version version) {
+    return shaderc_spvc_compile_options_set_source_env(options_.get(), env,
+                                                       version);
   }
 
   // Set the target environment for the SPIR-V to be cross-compiled. If this is
   // different then the source a transformation will need to be applied.
   // Currently only Vulkan 1.1 <-> WebGPU transforms are defined. Default is
   // Vulkan 1.0.
-  void SetTargetEnvironment(shaderc_target_env env,
-                            shaderc_env_version version) {
-    shaderc_spvc_compile_options_set_target_env(options_.get(), env, version);
+  shaderc_spvc_status SetTargetEnvironment(shaderc_target_env env,
+                                           shaderc_env_version version) {
+    return shaderc_spvc_compile_options_set_target_env(options_.get(), env,
+                                                       version);
   }
 
   // Set the entry point.
-  void SetEntryPoint(const std::string& entry_point) {
-    shaderc_spvc_compile_options_set_entry_point(options_.get(),
-                                                 entry_point.c_str());
+  shaderc_spvc_status SetEntryPoint(const std::string& entry_point) {
+    return shaderc_spvc_compile_options_set_entry_point(options_.get(),
+                                                        entry_point.c_str());
   }
 
   // If true, unused variables will not appear in the output.
-  void SetRemoveUnusedVariables(bool b) {
-    shaderc_spvc_compile_options_set_remove_unused_variables(options_.get(), b);
+  shaderc_spvc_status SetRemoveUnusedVariables(bool b) {
+    return shaderc_spvc_compile_options_set_remove_unused_variables(
+        options_.get(), b);
   }
 
   // If true, enable robust buffer access pass in the spirv-opt, meaning:
@@ -127,148 +162,161 @@ class CompileOptions {
   // arrays, providing guarantees satisfying Vulkan's robustBufferAccess rules.
   // This is useful when an implementation does not support robust-buffer access
   // as a driver option.
-  void SetRobustBufferAccessPass(bool b){
-    shaderc_spvc_compile_options_set_robust_buffer_access_pass(options_.get(),
-                                                               b);
+
+  shaderc_spvc_status SetRobustBufferAccessPass(bool b) {
+    return shaderc_spvc_compile_options_set_robust_buffer_access_pass(
+        options_.get(), b);
   }
 
-  void SetEmitLineDirectives(bool b){
-    shaderc_spvc_compile_options_set_emit_line_directives(options_.get(), b);
+  shaderc_spvc_status SetEmitLineDirectives(bool b) {
+    return shaderc_spvc_compile_options_set_emit_line_directives(options_.get(),
+                                                                 b);
   }
   // If true, Vulkan GLSL features are used instead of GL-compatible features.
-  void SetVulkanSemantics(bool b) {
-    shaderc_spvc_compile_options_set_vulkan_semantics(options_.get(), b);
+  shaderc_spvc_status SetVulkanSemantics(bool b) {
+    return shaderc_spvc_compile_options_set_vulkan_semantics(options_.get(), b);
   }
 
   // If true, gl_PerVertex is explicitly redeclared in vertex, geometry and
   // tessellation shaders. The members of gl_PerVertex is determined by which
   // built-ins are declared by the shader.
-  void SetSeparateShaderObjects(bool b) {
-    shaderc_spvc_compile_options_set_separate_shader_objects(options_.get(), b);
+  shaderc_spvc_status SetSeparateShaderObjects(bool b) {
+    return shaderc_spvc_compile_options_set_separate_shader_objects(
+        options_.get(), b);
   }
 
   // Flatten uniform or push constant variable into (i|u)vec4 array.
-  void SetFlattenUbo(bool b) {
-    shaderc_spvc_compile_options_set_flatten_ubo(options_.get(), b);
+  shaderc_spvc_status SetFlattenUbo(bool b) {
+    return shaderc_spvc_compile_options_set_flatten_ubo(options_.get(), b);
   }
 
   // Which GLSL version should be produced.  Default is 450 (i.e. 4.5).
-  void SetGLSLLanguageVersion(uint32_t version) {
-    shaderc_spvc_compile_options_set_glsl_language_version(options_.get(),
-                                                           version);
+  shaderc_spvc_status SetGLSLLanguageVersion(uint32_t version) {
+    return shaderc_spvc_compile_options_set_glsl_language_version(
+        options_.get(), version);
   }
 
   // If true, flatten multidimensional arrays, e.g. foo[a][b][c] -> foo[a*b*c].
   // Default is false.
-  void SetFlattenMultidimensionalArrays(bool b) {
-    shaderc_spvc_compile_options_set_flatten_multidimensional_arrays(
+  shaderc_spvc_status SetFlattenMultidimensionalArrays(bool b) {
+    return shaderc_spvc_compile_options_set_flatten_multidimensional_arrays(
         options_.get(), b);
   }
 
   // Force interpretion as ES, or not.  Default is to detect from source.
-  void SetES(bool b) { shaderc_spvc_compile_options_set_es(options_.get(), b); }
+  shaderc_spvc_status SetES(bool b) {
+    return shaderc_spvc_compile_options_set_es(options_.get(), b);
+  }
 
   // If true, emit push constants as uniform buffer objects.  Default is false.
-  void SetGLSLEmitPushConstantAsUBO(bool b) {
-    shaderc_spvc_compile_options_set_glsl_emit_push_constant_as_ubo(
+  shaderc_spvc_status SetGLSLEmitPushConstantAsUBO(bool b) {
+    return shaderc_spvc_compile_options_set_glsl_emit_push_constant_as_ubo(
         options_.get(), b);
   }
 
   // Which MSL version should be produced.  Default is 10200 (i.e. 1.2).
-  void SetMSLLanguageVersion(uint32_t version) {
-    shaderc_spvc_compile_options_set_msl_language_version(options_.get(),
-                                                          version);
+  shaderc_spvc_status SetMSLLanguageVersion(uint32_t version) {
+    return shaderc_spvc_compile_options_set_msl_language_version(options_.get(),
+                                                                 version);
   }
 
   // If true, swizzle MSL texture samples.  Default is false.
-  void SetMSLSwizzleTextureSamples(bool b) {
-    shaderc_spvc_compile_options_set_msl_swizzle_texture_samples(options_.get(),
-                                                                 b);
+  shaderc_spvc_status SetMSLSwizzleTextureSamples(bool b) {
+    return shaderc_spvc_compile_options_set_msl_swizzle_texture_samples(
+        options_.get(), b);
   }
 
   // Choose MSL platform.  Default is MacOS.
-  void SetMSLPlatform(shaderc_spvc_msl_platform platform) {
-    shaderc_spvc_compile_options_set_msl_platform(options_.get(), platform);
+  shaderc_spvc_status SetMSLPlatform(shaderc_spvc_msl_platform platform) {
+    return shaderc_spvc_compile_options_set_msl_platform(options_.get(),
+                                                         platform);
   }
 
   // If true, pad MSL fragment output.  Default is false.
-  void SetMSLPadFragmentOutput(bool b) {
-    shaderc_spvc_compile_options_set_msl_pad_fragment_output(options_.get(), b);
+  shaderc_spvc_status SetMSLPadFragmentOutput(bool b) {
+    return shaderc_spvc_compile_options_set_msl_pad_fragment_output(
+        options_.get(), b);
   }
 
   // If true, capture MSL output to buffer.  Default is false.
-  void SetMSLCapture(bool b) {
-    shaderc_spvc_compile_options_set_msl_capture(options_.get(), b);
+  shaderc_spvc_status SetMSLCapture(bool b) {
+    return shaderc_spvc_compile_options_set_msl_capture(options_.get(), b);
   }
 
   // If true, flip the Y-coord of the built-in "TessCoord."  Default is top
   // left.
-  void SetMSLDomainLowerLeft(bool b) {
-    shaderc_spvc_compile_options_set_msl_domain_lower_left(options_.get(), b);
+  shaderc_spvc_status SetMSLDomainLowerLeft(bool b) {
+    return shaderc_spvc_compile_options_set_msl_domain_lower_left(
+        options_.get(), b);
   }
 
   // Enable use of MSL 2.0 indirect argument buffers.  Default is not to use
   // them.
-  void SetMSLArgumentBuffers(bool b) {
-    shaderc_spvc_compile_options_set_msl_argument_buffers(options_.get(), b);
+  shaderc_spvc_status SetMSLArgumentBuffers(bool b) {
+    return shaderc_spvc_compile_options_set_msl_argument_buffers(options_.get(),
+                                                                 b);
   }
 
   // When using MSL argument buffers, force "classic" MSL 1.0 binding for the
   // given descriptor sets. This corresponds to VK_KHR_push_descriptor in
   // Vulkan.
-  void SetMSLDiscreteDescriptorSets(const std::vector<uint32_t> descriptors) {
-    shaderc_spvc_compile_options_set_msl_discrete_descriptor_sets(
+  shaderc_spvc_status SetMSLDiscreteDescriptorSets(
+      const std::vector<uint32_t> descriptors) {
+    return shaderc_spvc_compile_options_set_msl_discrete_descriptor_sets(
         options_.get(), descriptors.data(), descriptors.size());
   }
 
   // Set whether or not PointSize builtin is used for MSL shaders
-  void SetMSLEnablePointSizeBuiltIn(bool b) {
-    shaderc_spvc_compile_options_set_msl_enable_point_size_builtin(
+  shaderc_spvc_status SetMSLEnablePointSizeBuiltIn(bool b) {
+    return shaderc_spvc_compile_options_set_msl_enable_point_size_builtin(
         options_.get(), b);
   }
 
   // Set the index in the buffer size in the buffer for MSL
-  void SetMSLBufferSizeBufferIndex(uint32_t index) {
-    shaderc_spvc_compile_options_set_msl_buffer_size_buffer_index(
+  shaderc_spvc_status SetMSLBufferSizeBufferIndex(uint32_t index) {
+    return shaderc_spvc_compile_options_set_msl_buffer_size_buffer_index(
         options_.get(), index);
   }
 
   // Which HLSL shader model should be used.  Default is 30.
-  void SetHLSLShaderModel(uint32_t model) {
-    shaderc_spvc_compile_options_set_hlsl_shader_model(options_.get(), model);
+  shaderc_spvc_status SetHLSLShaderModel(uint32_t model) {
+    return shaderc_spvc_compile_options_set_hlsl_shader_model(options_.get(),
+                                                              model);
   }
 
   // If true, ignore PointSize.  Default is false.
-  void SetHLSLPointSizeCompat(bool b) {
-    shaderc_spvc_compile_options_set_hlsl_point_size_compat(options_.get(), b);
+  shaderc_spvc_status SetHLSLPointSizeCompat(bool b) {
+    return shaderc_spvc_compile_options_set_hlsl_point_size_compat(
+        options_.get(), b);
   }
 
   // If true, ignore PointCoord.  Default is false.
-  void SetHLSLPointCoordCompat(bool b) {
-    shaderc_spvc_compile_options_set_hlsl_point_coord_compat(options_.get(), b);
+  shaderc_spvc_status SetHLSLPointCoordCompat(bool b) {
+    return shaderc_spvc_compile_options_set_hlsl_point_coord_compat(
+        options_.get(), b);
   }
 
   // If true (default is false):
   //   GLSL: map depth from Vulkan/D3D style to GL style, i.e. [ 0,w] -> [-w,w]
   //   MSL : map depth from GL style to Vulkan/D3D style, i.e. [-w,w] -> [ 0,w]
   //   HLSL: map depth from GL style to Vulkan/D3D style, i.e. [-w,w] -> [ 0,w]
-  void SetFixupClipspace(bool b) {
-    shaderc_spvc_compile_options_set_fixup_clipspace(options_.get(), b);
+  shaderc_spvc_status SetFixupClipspace(bool b) {
+    return shaderc_spvc_compile_options_set_fixup_clipspace(options_.get(), b);
   }
 
   // If true invert gl_Position.y or equivalent.  Default is false.
-  void SetFlipVertY(bool b) {
-    shaderc_spvc_compile_options_set_flip_vert_y(options_.get(), b);
+  shaderc_spvc_status SetFlipVertY(bool b) {
+    return shaderc_spvc_compile_options_set_flip_vert_y(options_.get(), b);
   }
 
   // If true validate input and intermediate source. Default is true.
-  void SetValidate(bool b) {
-    shaderc_spvc_compile_options_set_validate(options_.get(), b);
+  shaderc_spvc_status SetValidate(bool b) {
+    return shaderc_spvc_compile_options_set_validate(options_.get(), b);
   }
 
   // If true optimize input and intermediate source. Default is true.
-  void SetOptimize(bool b) {
-    shaderc_spvc_compile_options_set_optimize(options_.get(), b);
+  shaderc_spvc_status SetOptimize(bool b) {
+    return shaderc_spvc_compile_options_set_optimize(options_.get(), b);
   }
 
   // Fill options with given data.  Return amount of data used, or zero
@@ -304,17 +352,24 @@ class Context {
     return shaderc_spvc_context_get_messages(context_.get());
   }
 
+  // DEPRECATED
+  void* GetCompiler() const {
+    void* compiler;
+    shaderc_spvc_context_get_compiler(context_.get(), &compiler);
+    return compiler;
+  }
+
   // EXPERIMENTAL
   // Returns the internal spirv_cross compiler reference, does NOT transfer
   // ownership.
   // This is being exposed temporarily to ease integration of spvc into Dawn,
   // but this is will be removed in the future without warning.
-  void* GetCompiler() const {
-    return shaderc_spvc_context_get_compiler(context_.get());
+  shaderc_spvc_status GetCompiler(void** compiler) {
+    return shaderc_spvc_context_get_compiler(context_.get(), compiler);
   }
 
-  void SetUseSpvcParser(bool b) {
-     shaderc_spvc_context_set_use_spvc_parser(context_.get(), b);
+  shaderc_spvc_status SetUseSpvcParser(bool b) {
+    return shaderc_spvc_context_set_use_spvc_parser(context_.get(), b);
   }
 
   // Initializes state for compiling SPIR-V to GLSL.
@@ -383,26 +438,27 @@ class Context {
   // Analyzes all separate image and samplers used from the currently selected
   // entry point, and re-routes them all to a combined image sampler instead.
   // (added for GLSL API support in Dawn)
-  void BuildCombinedImageSamplers(void) {
-    shaderc_spvc_build_combined_image_samplers(context_.get());
+  shaderc_spvc_status BuildCombinedImageSamplers(void) {
+    return shaderc_spvc_build_combined_image_samplers(context_.get());
   }
 
   // After call to BuildCombinedImageSamplers, fetch the ids associated with the
   // combined image samplers.
-  void GetCombinedImageSamplers(
+  shaderc_spvc_status GetCombinedImageSamplers(
       std::vector<shaderc_spvc_combined_image_sampler>* samplers) {
     size_t count;
-    shaderc_spvc_get_combined_image_samplers(context_.get(), nullptr, &count);
+    shaderc_spvc_status status = shaderc_spvc_get_combined_image_samplers(
+        context_.get(), nullptr, &count);
+    if (status != shaderc_spvc_status_success) return status;
     samplers->resize(count);
-    shaderc_spvc_get_combined_image_samplers(context_.get(), samplers->data(),
-                                             &count);
+    return shaderc_spvc_get_combined_image_samplers(context_.get(),
+                                                    samplers->data(), &count);
   }
 
   // set |name| on a given |id| (added for GLSL support in Dawn).
   // Assuming id is valid.
-  void SetName(uint32_t id, const std::string& name) {
-    shaderc_spvc_set_name(context_.get(), id, name.c_str());
-    return;
+  shaderc_spvc_status SetName(uint32_t id, const std::string& name) {
+    return shaderc_spvc_set_name(context_.get(), id, name.c_str());
   }
 
   // Adds a binding to indicate the MSL buffer, texture or sampler index to use

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -155,13 +155,26 @@ const char* shaderc_spvc_context_get_messages(
   return context->messages_string.c_str();
 }
 
-void* shaderc_spvc_context_get_compiler(const shaderc_spvc_context_t context) {
-  return context->cross_compiler.get();
+shaderc_spvc_status shaderc_spvc_context_get_compiler(
+    const shaderc_spvc_context_t context, void** compiler) {
+  if (!context) return shaderc_spvc_status_missing_context_error;
+
+  if (!context->cross_compiler) {
+    context->messages.push_back(
+        "Invoked get_compiler without an initialized compiler");
+    return shaderc_spvc_status_uninitialized_compiler_error;
+  }
+
+  *compiler = context->cross_compiler.get();
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_context_set_use_spvc_parser(shaderc_spvc_context_t context,
-                                              bool b) {
+shaderc_spvc_status shaderc_spvc_context_set_use_spvc_parser(
+    shaderc_spvc_context_t context, bool b) {
+  if (!context) return shaderc_spvc_status_missing_context_error;
+
   context->use_spvc_parser = b;
+  return shaderc_spvc_status_success;
 }
 
 shaderc_spvc_compile_options_t shaderc_spvc_compile_options_create() {
@@ -184,87 +197,138 @@ void shaderc_spvc_compile_options_destroy(
   if (options) delete options;
 }
 
-void shaderc_spvc_compile_options_set_source_env(
+shaderc_spvc_status shaderc_spvc_compile_options_set_source_env(
     shaderc_spvc_compile_options_t options, shaderc_target_env env,
     shaderc_env_version version) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->source_env = spvc_private::get_spv_target_env(env, version);
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_target_env(
+shaderc_spvc_status shaderc_spvc_compile_options_set_target_env(
     shaderc_spvc_compile_options_t options, shaderc_target_env env,
     shaderc_env_version version) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->target_env = spvc_private::get_spv_target_env(env, version);
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_entry_point(
+shaderc_spvc_status shaderc_spvc_compile_options_set_entry_point(
     shaderc_spvc_compile_options_t options, const char* entry_point) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+  if (!entry_point) return shaderc_spvc_status_invalid_in_param;
+
   options->entry_point = entry_point;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_remove_unused_variables(
+shaderc_spvc_status shaderc_spvc_compile_options_set_remove_unused_variables(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->remove_unused_variables = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_robust_buffer_access_pass(
+shaderc_spvc_status shaderc_spvc_compile_options_set_robust_buffer_access_pass(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->robust_buffer_access_pass = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_emit_line_directives(
+shaderc_spvc_status shaderc_spvc_compile_options_set_emit_line_directives(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->glsl.emit_line_directives = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_vulkan_semantics(
+shaderc_spvc_status shaderc_spvc_compile_options_set_vulkan_semantics(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->glsl.vulkan_semantics = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_separate_shader_objects(
+shaderc_spvc_status shaderc_spvc_compile_options_set_separate_shader_objects(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->glsl.separate_shader_objects = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_flatten_ubo(
+shaderc_spvc_status shaderc_spvc_compile_options_set_flatten_ubo(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->flatten_ubo = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_glsl_language_version(
+shaderc_spvc_status shaderc_spvc_compile_options_set_glsl_language_version(
     shaderc_spvc_compile_options_t options, uint32_t version) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->glsl.version = version;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_flatten_multidimensional_arrays(
+shaderc_spvc_status
+shaderc_spvc_compile_options_set_flatten_multidimensional_arrays(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->glsl.flatten_multidimensional_arrays = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_es(shaderc_spvc_compile_options_t options,
-                                         bool b) {
+shaderc_spvc_status shaderc_spvc_compile_options_set_es(
+    shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->forced_es_setting = b;
   options->force_es = true;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_glsl_emit_push_constant_as_ubo(
+shaderc_spvc_status
+shaderc_spvc_compile_options_set_glsl_emit_push_constant_as_ubo(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->glsl.emit_push_constant_as_uniform_buffer = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_msl_language_version(
+shaderc_spvc_status shaderc_spvc_compile_options_set_msl_language_version(
     shaderc_spvc_compile_options_t options, uint32_t version) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->msl.msl_version = version;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_msl_swizzle_texture_samples(
+shaderc_spvc_status
+shaderc_spvc_compile_options_set_msl_swizzle_texture_samples(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->msl.swizzle_texture_samples = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_msl_platform(
+shaderc_spvc_status shaderc_spvc_compile_options_set_msl_platform(
     shaderc_spvc_compile_options_t options,
     shaderc_spvc_msl_platform platform) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   switch (platform) {
     case shaderc_spvc_msl_platform_ios:
       options->msl.platform = spirv_cross::CompilerMSL::Options::iOS;
@@ -273,84 +337,130 @@ void shaderc_spvc_compile_options_set_msl_platform(
       options->msl.platform = spirv_cross::CompilerMSL::Options::macOS;
       break;
   }
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_msl_pad_fragment_output(
+shaderc_spvc_status shaderc_spvc_compile_options_set_msl_pad_fragment_output(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->msl.pad_fragment_output_components = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_msl_capture(
+shaderc_spvc_status shaderc_spvc_compile_options_set_msl_capture(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->msl.capture_output_to_buffer = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_msl_domain_lower_left(
+shaderc_spvc_status shaderc_spvc_compile_options_set_msl_domain_lower_left(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->msl.tess_domain_origin_lower_left = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_msl_argument_buffers(
+shaderc_spvc_status shaderc_spvc_compile_options_set_msl_argument_buffers(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->msl.argument_buffers = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_msl_discrete_descriptor_sets(
+shaderc_spvc_status
+shaderc_spvc_compile_options_set_msl_discrete_descriptor_sets(
     shaderc_spvc_compile_options_t options, const uint32_t* descriptors,
     size_t num_descriptors) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->msl_discrete_descriptor_sets.resize(num_descriptors);
   std::copy_n(descriptors, num_descriptors,
               options->msl_discrete_descriptor_sets.begin());
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_msl_enable_point_size_builtin(
+shaderc_spvc_status
+shaderc_spvc_compile_options_set_msl_enable_point_size_builtin(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->msl.enable_point_size_builtin = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_msl_buffer_size_buffer_index(
+shaderc_spvc_status
+shaderc_spvc_compile_options_set_msl_buffer_size_buffer_index(
     shaderc_spvc_compile_options_t options, uint32_t index) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->msl.buffer_size_buffer_index = index;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_hlsl_shader_model(
+shaderc_spvc_status shaderc_spvc_compile_options_set_hlsl_shader_model(
     shaderc_spvc_compile_options_t options, uint32_t model) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->hlsl.shader_model = model;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_hlsl_point_size_compat(
+shaderc_spvc_status shaderc_spvc_compile_options_set_hlsl_point_size_compat(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->hlsl.point_size_compat = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_hlsl_point_coord_compat(
+shaderc_spvc_status shaderc_spvc_compile_options_set_hlsl_point_coord_compat(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->hlsl.point_coord_compat = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_fixup_clipspace(
+shaderc_spvc_status shaderc_spvc_compile_options_set_fixup_clipspace(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->glsl.vertex.fixup_clipspace = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_flip_vert_y(
+shaderc_spvc_status shaderc_spvc_compile_options_set_flip_vert_y(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->glsl.vertex.flip_vert_y = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_validate(
+shaderc_spvc_status shaderc_spvc_compile_options_set_validate(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->validate = b;
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_compile_options_set_optimize(
+shaderc_spvc_status shaderc_spvc_compile_options_set_optimize(
     shaderc_spvc_compile_options_t options, bool b) {
+  if (!options) return shaderc_spvc_status_missing_options_error;
+
   options->optimize = b;
+  return shaderc_spvc_status_success;
 }
 
 size_t shaderc_spvc_compile_options_set_for_fuzzing(
     shaderc_spvc_compile_options_t options, const uint8_t* data, size_t size) {
-  if (!data || size < sizeof(*options)) return 0;
+  if (!options || !data || size < sizeof(*options)) return 0;
 
   memcpy(static_cast<void*>(options), data, sizeof(*options));
   return sizeof(*options);
@@ -362,7 +472,7 @@ shaderc_spvc_status shaderc_spvc_initialize_impl(
     shaderc_spvc_status (*generator)(const shaderc_spvc_context_t,
                                      const uint32_t*, size_t,
                                      shaderc_spvc_compile_options_t)) {
-  if (!context) return shaderc_spvc_status_configuration_error;
+  if (!context) return shaderc_spvc_status_missing_context_error;
   shaderc_spvc_status status = spvc_private::validate_and_translate_spirv(
       context, source, source_len, options, &context->intermediate_shader);
   if (status != shaderc_spvc_status_success) return status;
@@ -409,8 +519,14 @@ shaderc_spvc_status shaderc_spvc_initialize_for_vulkan(
 shaderc_spvc_status shaderc_spvc_compile_shader(
     const shaderc_spvc_context_t context,
     shaderc_spvc_compilation_result_t result) {
-  if (!context->cross_compiler ||
-      context->target_lang == SPVC_TARGET_LANG_UNKNOWN) {
+  if (!context) return shaderc_spvc_status_missing_context_error;
+  if (!context->cross_compiler) {
+    context->messages.push_back(
+        "Invoked compile_shader without an initialized compiler");
+    return shaderc_spvc_status_uninitialized_compiler_error;
+  }
+  if (context->target_lang == SPVC_TARGET_LANG_UNKNOWN) {
+    context->messages.push_back("Invoked compile_shader with unknown language");
     return shaderc_spvc_status_configuration_error;
   }
 
@@ -451,6 +567,13 @@ shaderc_spvc_status shaderc_spvc_compile_shader(
 shaderc_spvc_status shaderc_spvc_set_decoration(
     const shaderc_spvc_context_t context, uint32_t id,
     shaderc_spvc_decoration decoration, uint32_t argument) {
+  if (!context) return shaderc_spvc_status_missing_context_error;
+  if (!context->cross_compiler) {
+    context->messages.push_back(
+        "Invoked set_decoration without an initialized compiler");
+    return shaderc_spvc_status_uninitialized_compiler_error;
+  }
+
   spv::Decoration spirv_cross_decoration;
   shaderc_spvc_status status =
       spvc_private::shaderc_spvc_decoration_to_spirv_cross_decoration(
@@ -470,7 +593,6 @@ shaderc_spvc_status shaderc_spvc_get_decoration(
     const shaderc_spvc_context_t context, uint32_t id,
     shaderc_spvc_decoration decoration, uint32_t* value) {
   if (!context) return shaderc_spvc_status_missing_context_error;
-
   if (!context->cross_compiler) {
     context->messages.push_back(
         "Invoked get_decoration without an initialized compiler");
@@ -508,6 +630,13 @@ shaderc_spvc_status shaderc_spvc_get_decoration(
 shaderc_spvc_status shaderc_spvc_unset_decoration(
     const shaderc_spvc_context_t context, uint32_t id,
     shaderc_spvc_decoration decoration) {
+  if (!context) return shaderc_spvc_status_missing_context_error;
+  if (!context->cross_compiler) {
+    context->messages.push_back(
+        "Invoked unset_decoration without an initialized compiler");
+    return shaderc_spvc_status_uninitialized_compiler_error;
+  }
+
   spv::Decoration spirv_cross_decoration;
   shaderc_spvc_status status =
       spvc_private::shaderc_spvc_decoration_to_spirv_cross_decoration(
@@ -523,14 +652,23 @@ shaderc_spvc_status shaderc_spvc_unset_decoration(
   return status;
 }
 
-void shaderc_spvc_get_combined_image_samplers(
+shaderc_spvc_status shaderc_spvc_get_combined_image_samplers(
     const shaderc_spvc_context_t context,
     shaderc_spvc_combined_image_sampler* samplers, size_t* num_samplers) {
-  assert(num_samplers);
-  if (!num_samplers) return;
+  if (!context) return shaderc_spvc_status_missing_context_error;
+  if (!context->cross_compiler) {
+    context->messages.push_back(
+        "Invoked get_combined_image_samplers without an initialized compiler");
+    return shaderc_spvc_status_uninitialized_compiler_error;
+  }
+  if (!num_samplers) {
+    context->messages.push_back(
+        "Invoked get_combined_image_samplers with an invalid out param");
+    return shaderc_spvc_status_invalid_out_param;
+  }
 
   *num_samplers = context->cross_compiler->get_combined_image_samplers().size();
-  if (!samplers) return;
+  if (!samplers) return shaderc_spvc_status_success;
 
   for (const auto& combined :
        context->cross_compiler->get_combined_image_samplers()) {
@@ -539,12 +677,24 @@ void shaderc_spvc_get_combined_image_samplers(
     samplers->sampler_id = combined.sampler_id;
     samplers++;
   }
+  return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_set_name(const shaderc_spvc_context_t context, uint32_t id,
-                           const char* name) {
+shaderc_spvc_status shaderc_spvc_set_name(const shaderc_spvc_context_t context,
+                                          uint32_t id, const char* name) {
+  if (!context) return shaderc_spvc_status_missing_context_error;
+  if (!context->cross_compiler) {
+    context->messages.push_back(
+        "Invoked set_name without an initialized compiler");
+    return shaderc_spvc_status_uninitialized_compiler_error;
+  }
+  if (!name) {
+    context->messages.push_back("Invoked set_name with an invalid in param");
+    return shaderc_spvc_status_invalid_in_param;
+  }
+
   context->cross_compiler->set_name(id, name);
-  return;
+  return shaderc_spvc_status_success;
 }
 
 shaderc_spvc_status shaderc_spvc_add_msl_resource_binding(
@@ -582,13 +732,16 @@ shaderc_spvc_status shaderc_spvc_get_workgroup_size(
     shaderc_spvc_execution_model execution_model,
     shaderc_spvc_workgroup_size* workgroup_size) {
   if (!context) return shaderc_spvc_status_missing_context_error;
-
   if (!context->cross_compiler) {
     context->messages.push_back(
         "Invoked get_workgroup_size without an initialized compiler");
     return shaderc_spvc_status_uninitialized_compiler_error;
   }
-
+  if (!function_name) {
+    context->messages.push_back(
+        "Invoked get_workgroup_size with an invalid in param");
+    return shaderc_spvc_status_invalid_in_param;
+  }
   if (!workgroup_size) {
     context->messages.push_back(
         "Invoked get_workgroup_size without a valid out param");
@@ -633,13 +786,15 @@ shaderc_spvc_status shaderc_spvc_needs_buffer_size_buffer(
   *b =
       reinterpret_cast<spirv_cross::CompilerMSL*>(context->cross_compiler.get())
           ->needs_buffer_size_buffer();
-
   return shaderc_spvc_status_success;
 }
 
-void shaderc_spvc_build_combined_image_samplers(
+shaderc_spvc_status shaderc_spvc_build_combined_image_samplers(
     const shaderc_spvc_context_t context) {
+  if (!context) return shaderc_spvc_status_missing_context_error;
+
   context->cross_compiler->build_combined_image_samplers();
+  return shaderc_spvc_status_success;
 }
 
 shaderc_spvc_status shaderc_spvc_get_execution_model(
@@ -889,17 +1044,30 @@ void shaderc_spvc_result_destroy(shaderc_spvc_compilation_result_t result) {
   if (result) delete result;
 }
 
-const char* shaderc_spvc_result_get_string_output(
-    const shaderc_spvc_compilation_result_t result) {
-  return result->string_output.c_str();
+shaderc_spvc_status shaderc_spvc_result_get_string_output(
+    const shaderc_spvc_compilation_result_t result, const char** str) {
+  if (!result) return shaderc_spvc_status_missing_result_error;
+  if (!str) return shaderc_spvc_status_invalid_out_param;
+
+  *str = result->string_output.c_str();
+  return shaderc_spvc_status_success;
 }
 
-const uint32_t* shaderc_spvc_result_get_binary_output(
-    const shaderc_spvc_compilation_result_t result) {
-  return result->binary_output.data();
+shaderc_spvc_status shaderc_spvc_result_get_binary_output(
+    const shaderc_spvc_compilation_result_t result,
+    const uint32_t** binary_output) {
+  if (!result) return shaderc_spvc_status_missing_result_error;
+  if (!binary_output) return shaderc_spvc_status_invalid_out_param;
+
+  *binary_output = result->binary_output.data();
+  return shaderc_spvc_status_success;
 }
 
-uint32_t shaderc_spvc_result_get_binary_length(
-    const shaderc_spvc_compilation_result_t result) {
-  return result->binary_output.size();
+shaderc_spvc_status shaderc_spvc_result_get_binary_length(
+    const shaderc_spvc_compilation_result_t result, uint32_t* len) {
+  if (!result) return shaderc_spvc_status_missing_result_error;
+  if (!len) return shaderc_spvc_status_invalid_out_param;
+
+  *len = result->binary_output.size();
+  return shaderc_spvc_status_success;
 }

--- a/libshaderc_spvc/src/spvc_smoke_test_util.c
+++ b/libshaderc_spvc/src/spvc_smoke_test_util.c
@@ -48,9 +48,10 @@ int test_exec(shaderc_spvc_context_t context,
     shaderc_spvc_status compile_status =
         shaderc_spvc_compile_shader(context, result);
     if (compile_status == shaderc_spvc_status_success) {
+      const char* result_str;
+      shaderc_spvc_result_get_string_output(result, &result_str);
       printf("success! %lu characters of %s\n",
-             (unsigned long)(strlen(
-                 shaderc_spvc_result_get_string_output(result))),
+             (unsigned long)(strlen(result_str)),
              target_lang);
       ret_val = 1;
     } else {


### PR DESCRIPTION
All functions now return a status value, and use out params to return data.
All functions now check state objects and in/out pointers for validity.