### PR TITLE
Rolling 5 dependencies and updated exceptions

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '965bd4d96613e57b75b125bff622b5fe6f671b96',
-  'googletest_revision': '8b4817e3df3746a20502a84580f661ac448821be',
+  'glslang_revision': '19ec0d2ff9059e8bc8ca0fc539597a771cefdc89',
+  'googletest_revision': '10b1902d893ea8cc43c69541d70868f91af3646b',
   're2_revision': '85c014206aee9bc1730dc416b33609974ae3ff5f',
-  'spirv_headers_revision': '204cd131c42b90d129073719f2766293ce35c081',
-  'spirv_tools_revision': '323a81fc5e30e43a04e5e22af4cba98ca2a161e6',
-  'spirv_cross_revision': 'f9818f0804e6e73ec8afcc523b7e7f8bfc362632',
+  'spirv_headers_revision': 'dc77030acc9c6fe7ca21fff54c5a9d7b532d7da6',
+  'spirv_tools_revision': '1b3441036a8f178cb3b41c1aa222b652db522a88',
+  'spirv_cross_revision': '68bf0f824cc9d4fa9e0844b8ecdc5fc271fa6b7a',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -17,12 +17,15 @@ shaders-msl/comp/basic.dispatchbase.comp,False
 shaders-msl/comp/basic.dispatchbase.comp,True
 shaders-msl/comp/basic.dispatchbase.msl11.comp,False
 shaders-msl/comp/basic.dispatchbase.msl11.comp,True
+shaders-msl/comp/basic.inline-block.msl2.comp,False
+shaders-msl/comp/basic.inline-block.msl2.comp,True
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,True
 shaders-msl/frag/barycentric-nv.msl22.frag,False
 shaders-msl/frag/barycentric-nv.msl22.frag,True
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,False
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,True
+shaders-msl/frag/for-loop-init.frag,True
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,False
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,True
 shaders-msl/frag/image-query-lod.msl22.frag,False
@@ -67,3 +70,6 @@ shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
+shaders/asm/frag/loop-body-dominator-continue-access.asm.frag,True
+shaders/frag/for-loop-init.frag,True
+shaders/frag/selection-block-dominator.frag,True

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -41,12 +41,15 @@ shaders-msl/comp/basic.dispatchbase.comp,False
 shaders-msl/comp/basic.dispatchbase.comp,True
 shaders-msl/comp/basic.dispatchbase.msl11.comp,False
 shaders-msl/comp/basic.dispatchbase.msl11.comp,True
+shaders-msl/comp/basic.inline-block.msl2.comp,False
+shaders-msl/comp/basic.inline-block.msl2.comp,True
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,True
 shaders-msl/frag/barycentric-nv.msl22.frag,False
 shaders-msl/frag/barycentric-nv.msl22.frag,True
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,False
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,True
+shaders-msl/frag/for-loop-init.frag,True
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,False
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,True
 shaders-msl/frag/image-query-lod.msl22.frag,False
@@ -103,3 +106,6 @@ shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
+shaders/asm/frag/loop-body-dominator-continue-access.asm.frag,True
+shaders/frag/for-loop-init.frag,True
+shaders/frag/selection-block-dominator.frag,True


### PR DESCRIPTION
Roll third_party/glslang/ 965bd4d96..19ec0d2ff (4 commits)

https://github.com/KhronosGroup/glslang/compare/965bd4d96613...19ec0d2ff905

$ git log 965bd4d96..19ec0d2ff --date=short --no-merges --format='%ad %ae %s'
2020-01-27 cepheus Build: Fix more build warnings caused by PR #2038.
2020-01-26 cepheus Build warning: Fix #2062, missing enum value in a switch.
2019-12-24 laddoc Add Tess machine dependent built-in variables initialization for GLES 3.2
2019-10-18 timo.suoranta Fixes for gcc 9 / -Werror=deprecated-copy

Roll third_party/googletest/ 8b4817e3d..10b1902d8 (6 commits)

https://github.com/google/googletest/compare/8b4817e3df37...10b1902d893e

$ git log 8b4817e3d..10b1902d8 --date=short --no-merges --format='%ad %ae %s'
2020-01-21 absl-team Googletest export
2020-01-17 absl-team Googletest export
2020-01-16 absl-team Googletest export
2020-01-15 36923279+ivan1993br Remove exclusion of *-main and*-all targets
2020-01-12 hilmanbeyri Use IsReadableTypeName IsReadableTypeName in OfType function in gmock-matchers_test.cc
2020-01-12 hilmanbeyri fix unit test failure on NoShortCircuitOnFailure and DetectsFlakyShortCircuit when GTEST_HAS_RTTI is 1

Roll third_party/spirv-cross/ f9818f080..68bf0f824 (6 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/f9818f0804e6...68bf0f824cc9

$ git log f9818f080..68bf0f824 --date=short --no-merges --format='%ad %ae %s'
2020-01-27 post Compile fix on older compilers.
2020-01-27 post GLSL: Support GL_ARB_enchanced_layouts for XFB.
2020-01-25 cdavis MSL: Move inline uniform blocks to the end of the argument buffer.
2019-12-16 cdavis MSL: Support inline uniform blocks in argument buffers.
2020-01-23 post Make SmallVector noexcept.
2020-01-22 42098783+barath121 Typo at line 324

Roll third_party/spirv-headers/ 204cd131c..dc77030ac (2 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/204cd131c42b...dc77030acc9c

$ git log 204cd131c..dc77030ac --date=short --no-merges --format='%ad %ae %s'
2020-01-20 dneto Fix the license to match LICENSE
2020-01-20 syoussefi Add BUILD.gn

Roll third_party/spirv-tools/ 323a81fc5..1b3441036 (9 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/323a81fc5e30...1b3441036a8f

$ git log 323a81fc5..1b3441036 --date=short --no-merges --format='%ad %ae %s'
2020-01-24 syoussefi Fix chromium build (#3152)
2020-01-24 dneto Clarify mapping of target env to SPIR-V version (#3150)
2020-01-24 greg Use dummy switch instead of dummy loop in MergeReturn pass. (#3151)
2020-01-23 alanbaker Fix structured exit validation (#3141)
2020-01-23 dneto Add spvParseVulkanEnv (#3142)
2020-01-23 jaebaek Handle conflict between debug info and existing validation rule (#3104)
2020-01-23 syoussefi Use spirv-headers' BUILD.gn (#3148)
2020-01-23 syoussefi Roll external/spirv-headers/ af64a9e82..dc77030ac (4 commits) (#3147)
2020-01-21 afdx spirv-fuzz: Refactoring and type-related fixes (#3144)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools