### PR TITLE
Make a source_set for libshaderc_spvc

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -176,6 +176,10 @@ config("shaderc_spvc_public") {
 }
 
 component("libshaderc_spvc") {
+  public_deps = [ ":libshaderc_spvc_sources" ]
+}
+
+source_set("libshaderc_spvc_sources") {
   public_configs = [
     ":shaderc_spvc_public",
   ]


### PR DESCRIPTION
This allows Dawn to include it as a source_set instead of a component,
so Dawn's complete_static_lib setting applies properly:
https://dawn-review.googlesource.com/c/dawn/+/15481

@zoddicus PTAL