### PR TITLE
Better help for glslc -S

### DIFF
--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -145,7 +145,7 @@ Options:
   -std=<value>      Version and profile for GLSL input files. Possible values
                     are concatenations of version and profile, e.g. 310es,
                     450core, etc.  Ignored for HLSL files.
-  -S                Only run preprocess and compilation steps.
+  -S                Emit SPIR-V assembly instead of binary.
   --show-limits     Display available limit names and their default values.
   --target-env=<environment>
                     Set the target client environment, and the semantics

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -149,7 +149,7 @@ Options:
   -std=<value>      Version and profile for GLSL input files. Possible values
                     are concatenations of version and profile, e.g. 310es,
                     450core, etc.  Ignored for HLSL files.
-  -S                Only run preprocess and compilation steps.
+  -S                Emit SPIR-V assembly instead of binary.
   --show-limits     Display available limit names and their default values.
   --target-env=<environment>
                     Set the target client environment, and the semantics


### PR DESCRIPTION
Long ago, compilers emitted assembly text, then called an assembler
stage to create the binary.
So, for example, clang describes its -S option as:

   -S   Only run preprocess and compilation steps

But that's very confusing these days.
Change the description for glslc -S from that old one to:

   -S   Emit SPIR-V assembly instead of binary.

The README.asciidoc already describes -S well.