### PR TITLE
Rolling 4 dependencies and updated expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '19ec0d2ff9059e8bc8ca0fc539597a771cefdc89',
+  'glslang_revision': '5e86b28ffb8124a5ee2a58c640245ee5b285110d',
   'googletest_revision': '10b1902d893ea8cc43c69541d70868f91af3646b',
-  're2_revision': '85c014206aee9bc1730dc416b33609974ae3ff5f',
+  're2_revision': '05faa8db3a964918db24003c4614b701b7bbd08a',
   'spirv_headers_revision': 'dc77030acc9c6fe7ca21fff54c5a9d7b532d7da6',
-  'spirv_tools_revision': '1b3441036a8f178cb3b41c1aa222b652db522a88',
-  'spirv_cross_revision': '68bf0f824cc9d4fa9e0844b8ecdc5fc271fa6b7a',
+  'spirv_tools_revision': 'ddcc11763a38485bb0fd16e1bdbfe6276e6eac01',
+  'spirv_cross_revision': '6b2add8e2cdd2fcc3a94214775c35422881f9d13',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -64,9 +64,13 @@ shaders-reflection/vert/array-size-reflection.vert,False
 shaders-reflection/vert/read-from-row-major-array.vert,False
 shaders-reflection/vert/stride-reflection.vert,False
 shaders-reflection/vert/texture_buffer.vert,False
+shaders-ue4/asm/frag/global-constant-arrays.asm.frag,True
+shaders-ue4/asm/frag/padded-float-array-member-defef.asm.frag,True
+shaders-ue4/asm/frag/sample-mask-not-array.asm.frag,True
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,False
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,True
 shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
+shaders-ue4/asm/vert/array-missing-copies.asm.vert,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -100,9 +100,13 @@ shaders-reflection/vert/array-size-reflection.vert,False
 shaders-reflection/vert/read-from-row-major-array.vert,False
 shaders-reflection/vert/stride-reflection.vert,False
 shaders-reflection/vert/texture_buffer.vert,False
+shaders-ue4/asm/frag/global-constant-arrays.asm.frag,True
+shaders-ue4/asm/frag/padded-float-array-member-defef.asm.frag,True
+shaders-ue4/asm/frag/sample-mask-not-array.asm.frag,True
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,False
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,True
 shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
+shaders-ue4/asm/vert/array-missing-copies.asm.vert,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False


### PR DESCRIPTION
Roll third_party/glslang/ 19ec0d2ff..5e86b28ff (3 commits)

https://github.com/KhronosGroup/glslang/compare/19ec0d2ff905...5e86b28ffb81

$ git log 19ec0d2ff..5e86b28ff --date=short --no-merges --format='%ad %ae %s'
2020-01-29 jbolz Use NOT ... VERSION_LESS instead of VERSION_GREATER_EQUAL
2020-01-28 jordan.l.justen standalone: Fix --help
2020-01-27 rharrison Use correct enum type in case statement

Roll third_party/re2/ 85c014206..05faa8db3 (2 commits)

https://github.com/google/re2/compare/85c014206aee...05faa8db3a96

$ git log 85c014206..05faa8db3 --date=short --no-merges --format='%ad %ae %s'
2020-01-31 junyer Avoid using the forward DFA in "ANCHOR_END" cases.
2020-01-29 junyer Make the fuzzer use FuzzedDataProvider.

Roll third_party/spirv-cross/ 68bf0f824..6b2add8e2 (4 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/68bf0f824cc9...6b2add8e2cdd

$ git log 68bf0f824..6b2add8e2 --date=short --no-merges --format='%ad %ae %s'
2020-02-03 post Use GNUInstallDirs for include path as well.
2020-02-01 orbea cmake: Don't hardcode the pkg-config file.
2020-02-01 orbea cmake: Use GNUInstallDirs.
2020-02-01 post CMake: Avoid warning when parent project uses VERSION in project().

Roll third_party/spirv-tools/ 1b3441036..ddcc11763 (7 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/1b3441036a8f...ddcc11763a38

$ git log 1b3441036..ddcc11763 --date=short --no-merges --format='%ad %ae %s'
2020-02-03 stevenperron Update CHANGES
2020-02-03 arseny.kapoulkine Implement constant folding for many transcendentals (#3166)
2020-01-30 afdx Fix typo in comment. (#3163)
2020-01-30 afdx spirv-fuzz: Arbitrary variable facts (#3165)
2020-01-29 afdx spirv-fuzz: Add outlining test (#3164)
2020-01-29 afdx spirv-fuzz: Make functions "livesafe" during donation (#3146)
2020-01-28 stevenperron Dead branch elim fix (#3160)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools