### PR TITLE
Rolling 6 dependencies and update expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '5e86b28ffb8124a5ee2a58c640245ee5b285110d',
-  'googletest_revision': '10b1902d893ea8cc43c69541d70868f91af3646b',
-  're2_revision': '05faa8db3a964918db24003c4614b701b7bbd08a',
-  'spirv_headers_revision': 'dc77030acc9c6fe7ca21fff54c5a9d7b532d7da6',
-  'spirv_tools_revision': 'ddcc11763a38485bb0fd16e1bdbfe6276e6eac01',
-  'spirv_cross_revision': '6b2add8e2cdd2fcc3a94214775c35422881f9d13',
+  'glslang_revision': 'c12493ff69e21800fb08b6d6e92eb0b9c5cb5efb',
+  'googletest_revision': '23b2a3b1cf803999fb38175f6e9e038a4495c8a5',
+  're2_revision': '793b4e85e9af51ffa85485551a1088ad97fbc3ff',
+  'spirv_headers_revision': '5dbc1c32182e17b8ab8e8158a802ecabaf35aad3',
+  'spirv_tools_revision': '4a80497a888511834d9a1f5930226e82decc60d5',
+  'spirv_cross_revision': 'f19fdb94d7b8b681024b2f3e87ccbc8d60be1d97',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -25,7 +25,6 @@ shaders-msl/frag/barycentric-nv.msl22.frag,False
 shaders-msl/frag/barycentric-nv.msl22.frag,True
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,False
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,True
-shaders-msl/frag/for-loop-init.frag,True
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,False
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,True
 shaders-msl/frag/image-query-lod.msl22.frag,False
@@ -64,16 +63,9 @@ shaders-reflection/vert/array-size-reflection.vert,False
 shaders-reflection/vert/read-from-row-major-array.vert,False
 shaders-reflection/vert/stride-reflection.vert,False
 shaders-reflection/vert/texture_buffer.vert,False
-shaders-ue4/asm/frag/global-constant-arrays.asm.frag,True
-shaders-ue4/asm/frag/padded-float-array-member-defef.asm.frag,True
-shaders-ue4/asm/frag/sample-mask-not-array.asm.frag,True
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,False
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,True
 shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
-shaders-ue4/asm/vert/array-missing-copies.asm.vert,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
-shaders/asm/frag/loop-body-dominator-continue-access.asm.frag,True
-shaders/frag/for-loop-init.frag,True
-shaders/frag/selection-block-dominator.frag,True

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -49,7 +49,6 @@ shaders-msl/frag/barycentric-nv.msl22.frag,False
 shaders-msl/frag/barycentric-nv.msl22.frag,True
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,False
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,True
-shaders-msl/frag/for-loop-init.frag,True
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,False
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,True
 shaders-msl/frag/image-query-lod.msl22.frag,False
@@ -100,16 +99,9 @@ shaders-reflection/vert/array-size-reflection.vert,False
 shaders-reflection/vert/read-from-row-major-array.vert,False
 shaders-reflection/vert/stride-reflection.vert,False
 shaders-reflection/vert/texture_buffer.vert,False
-shaders-ue4/asm/frag/global-constant-arrays.asm.frag,True
-shaders-ue4/asm/frag/padded-float-array-member-defef.asm.frag,True
-shaders-ue4/asm/frag/sample-mask-not-array.asm.frag,True
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,False
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,True
 shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
-shaders-ue4/asm/vert/array-missing-copies.asm.vert,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
-shaders/asm/frag/loop-body-dominator-continue-access.asm.frag,True
-shaders/frag/for-loop-init.frag,True
-shaders/frag/selection-block-dominator.frag,True


### PR DESCRIPTION
Roll third_party/glslang/ 5e86b28ff..c12493ff6 (10 commits)

https://github.com/KhronosGroup/glslang/compare/5e86b28ffb81...c12493ff69e2

$ git log 5e86b28ff..c12493ff6 --date=short --no-merges --format='%ad %ae %s'
2020-02-17 siglesias SPV_AMD_shader_image_load_store_lod is now validated by spirv-tools
2020-02-19 lryer Fix iomapper issue
2020-02-11 cepheus Fix part of #2070: Correctly handle promotion for <unary-op>(int).
2020-02-18 swda.durl Add an option to make RTTI enabled
2020-02-06 kainino Split "is emscripten" config from "enable glslang.js"
2020-02-06 dneto Avoid enum-compare warning
2020-02-06 rex.xu Fix a parser error of GL_KHR_memory_scope_semantics
2020-01-23 kainino glslang.js: Make the SPIR-V target version configurable (1.0 ~ 1.5)
2020-02-02 timo.suoranta Fix memory corruption in TGlslIoMapper
2019-12-23 laddoc Add constant expression with mod

Roll third_party/googletest/ 10b1902d8..23b2a3b1c (21 commits)

https://github.com/google/googletest/compare/10b1902d893e...23b2a3b1cf80

$ git log 10b1902d8..23b2a3b1c --date=short --no-merges --format='%ad %ae %s'
2020-02-12 absl-team Googletest export
2020-02-11 absl-team Googletest export
2020-02-11 absl-team Googletest export
2020-02-10 absl-team Googletest export
2020-02-10 absl-team Googletest export
2020-02-07 absl-team Googletest export
2020-02-07 absl-team Googletest export
2020-02-06 durandal Googletest export
2020-02-05 absl-team Googletest export
2020-02-05 absl-team Googletest export
2020-02-03 absl-team Googletest export
2020-02-03 absl-team Googletest export
2020-01-31 absl-team Googletest export
2020-01-31 absl-team Googletest export
2020-01-29 absl-team Googletest export
2020-01-27 absl-team Googletest export
2020-01-27 absl-team Googletest export
2020-01-27 absl-team Googletest export
2020-01-24 absl-team Googletest export
2020-01-24 absl-team Googletest export
2020-01-23 absl-team Googletest export

Roll third_party/re2/ 05faa8db3..793b4e85e (10 commits)

https://github.com/google/re2/compare/05faa8db3a96...793b4e85e9af

$ git log 05faa8db3..793b4e85e --date=short --no-merges --format='%ad %ae %s'
2020-02-17 junyer Move DeBruijnString() alongside StringGenerator.
2020-02-14 junyer Fix the check for Apple platforms. Mea culpa.
2020-02-14 junyer Provide hooks::context iff thread_local is supported.
2020-02-14 junyer Update doc/syntax.html.
2020-02-13 junyer MSVC also doesn't like casting lambdas with `+'. Sigh.
2020-02-13 junyer Only the latest MSVC allows designated initalisers.
2020-02-13 junyer Provide instrumentation points called "hooks".
2020-02-11 junyer Tidy up some GCC-only guards.
2020-02-04 junyer Tidy up the SWIG guard around LazyRE2.
2020-02-03 junyer Tweak some of the comments about FilteredRE2.

Roll third_party/spirv-cross/ 6b2add8e2..f19fdb94d (4 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/6b2add8e2cdd...f19fdb94d7b8

$ git log 6b2add8e2..f19fdb94d --date=short --no-merges --format='%ad %ae %s'
2020-02-19 dsinclair Roll GLSLang, SPIRV-Tools and SPIRV-Headers
2020-02-14 post Reject SPIR-V modules with garbage ID bound.
2020-02-08 post HLSL: Declare undef variables as static.
2020-02-06 post Remove old memory_scope flag from iOS barriers.

Roll third_party/spirv-headers/ dc77030ac..5dbc1c321 (1 commit)

https://github.com/KhronosGroup/SPIRV-Headers/compare/dc77030acc9c...5dbc1c32182e

$ git log dc77030ac..5dbc1c321 --date=short --no-merges --format='%ad %ae %s'
2020-02-07 michael.kinsner Allocate three bits for upcoming Intel extension

Roll third_party/spirv-tools/ ddcc11763..4a80497a8 (19 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/ddcc11763a38...4a80497a8885

$ git log ddcc11763..4a80497a8 --date=short --no-merges --format='%ad %ae %s'
2020-02-20 stevenperron Make spvOpcodeString part of the public API (#3174)
2020-02-20 danyspin97 Fix static libraries linking order (#3189)
2020-02-18 bclayton vscode: Add missing fields to schema.Opcode (#3169)
2020-02-18 siglesias spirv-val: Add support for SPV_AMD_shader_image_load_store_lod (#3186)
2020-02-14 afdx spirvfuzz: Fix type-related bug, change undef to zero, and add assert (#3188)
2020-02-11 afdx spirv-fuzz: Fuzzer pass that adds access chains (#3182)
2020-02-10 afdx spirv-fuzz: Fuzzer pass to add function calls (#3178)
2020-02-10 afdx spirv-fuzz: Ensure that donated variables are always initialized (#3181)
2020-02-06 afdx spirv-fuzz: Add fuzzer passes to add loads/stores (#3176)
2020-02-05 afdx spirv-fuzz: Fuzzer passes to add local and global variables (#3175)
2020-02-04 bclayton utils/vscode: LSP - Support OpExtInst (#3140)
2020-02-04 kubak Fix typos in opt's help. Update environment version. (#3170)
2020-02-04 stevenperron Start SPIRV-Tools v2020.2
2020-02-04 stevenperron Finalize SPIRV-Tools v2020.1
2020-02-04 stevenperron Update CHANGES
2020-02-04 afdx spirv-fuzz: Fuzzer pass to add composite types (#3171)
2020-02-04 afdx Update script that checks copyright years. (#3173)
2020-02-04 afdx spirv-fuzz: Disallow copying of null and undefined pointers (#3172)
2020-02-03 dnovillo Handle TimeAMD in AmdExtensionToKhrPass. (#3168)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools