### PR TITLE
Rolling 6 dependencies and updating expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': 'c12493ff69e21800fb08b6d6e92eb0b9c5cb5efb',
-  'googletest_revision': '23b2a3b1cf803999fb38175f6e9e038a4495c8a5',
-  're2_revision': '793b4e85e9af51ffa85485551a1088ad97fbc3ff',
-  'spirv_headers_revision': '5dbc1c32182e17b8ab8e8158a802ecabaf35aad3',
-  'spirv_tools_revision': '4a80497a888511834d9a1f5930226e82decc60d5',
-  'spirv_cross_revision': 'f19fdb94d7b8b681024b2f3e87ccbc8d60be1d97',
+  'glslang_revision': '56364b6b602696c021349794a8d39744a1052afc',
+  'googletest_revision': 'e588eb1ff9ff6598666279b737b27f983156ad85',
+  're2_revision': 'f734980e70ee217cc45d3e5535b47cd2422c8f4b',
+  'spirv_headers_revision': '0a7fc45259910f07f00c5a3fa10be5678bee1f83',
+  'spirv_tools_revision': 'e1688b60caf77e7efd9e440e57cca429ca7c5a1e',
+  'spirv_cross_revision': '9deb6ffbba01298fff649d911e45a774903e8802',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -9,6 +9,7 @@ shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
 shaders-msl-no-opt/comp/basic.dynamic-buffer.msl2.invalid.comp,False
 shaders-msl-no-opt/comp/int64.invalid.msl22.comp,False
 shaders-msl-no-opt/frag/force-active-resources.msl2.argument..force-active.discrete.frag,False
+shaders-msl-no-opt/vert/pass-array-by-value.force-native-array.vert,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,True
 shaders-msl/asm/frag/min-lod.msl22.asm.frag,False
@@ -19,6 +20,9 @@ shaders-msl/comp/basic.dispatchbase.msl11.comp,False
 shaders-msl/comp/basic.dispatchbase.msl11.comp,True
 shaders-msl/comp/basic.inline-block.msl2.comp,False
 shaders-msl/comp/basic.inline-block.msl2.comp,True
+shaders-msl/comp/composite-array-initialization.force-native-array.comp,False
+shaders-msl/comp/composite-array-initialization.force-native-array.comp,True
+shaders-msl/comp/copy-array-of-arrays.force-native-array.comp,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,True
 shaders-msl/frag/barycentric-nv.msl22.frag,False
@@ -35,6 +39,7 @@ shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,False
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,True
 shaders-msl/vert/float-math.invariant-float-math.vert,False
 shaders-msl/vert/float-math.invariant-float-math.vert,True
+shaders-msl/vert/return-array.force-native-array.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,True
 shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -33,6 +33,7 @@ shaders-msl-no-opt/packing/matrix-multiply-unpacked-row-major-2.comp,False
 shaders-msl-no-opt/packing/struct-packing-array-of-scalar.comp,False
 shaders-msl-no-opt/packing/struct-packing-recursive.comp,False
 shaders-msl-no-opt/packing/struct-packing.comp,False
+shaders-msl-no-opt/vert/pass-array-by-value.force-native-array.vert,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,True
 shaders-msl/asm/frag/min-lod.msl22.asm.frag,False
@@ -43,6 +44,9 @@ shaders-msl/comp/basic.dispatchbase.msl11.comp,False
 shaders-msl/comp/basic.dispatchbase.msl11.comp,True
 shaders-msl/comp/basic.inline-block.msl2.comp,False
 shaders-msl/comp/basic.inline-block.msl2.comp,True
+shaders-msl/comp/composite-array-initialization.force-native-array.comp,False
+shaders-msl/comp/composite-array-initialization.force-native-array.comp,True
+shaders-msl/comp/copy-array-of-arrays.force-native-array.comp,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,True
 shaders-msl/frag/barycentric-nv.msl22.frag,False
@@ -59,10 +63,10 @@ shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,False
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,True
 shaders-msl/vert/float-math.invariant-float-math.vert,False
 shaders-msl/vert/float-math.invariant-float-math.vert,True
+shaders-msl/vert/return-array.force-native-array.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,True
 shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
-shaders-no-opt/asm/comp/extended-debug-extinst.invalid.asm.comp,False
 shaders-no-opt/asm/comp/phi-temporary-copy-loop-variable.asm.invalid.comp,False
 shaders-no-opt/asm/frag/do-while-continue-phi.asm.invalid.frag,False
 shaders-no-opt/asm/frag/for-loop-dedicated-merge-block-inverted.asm.invalid.frag,False

--- a/spvc/test/unconfirmed_invalids
+++ b/spvc/test/unconfirmed_invalids
@@ -20,7 +20,6 @@ shaders-msl-no-opt/packing/matrix-multiply-unpacked-row-major-2.comp,False
 shaders-msl-no-opt/packing/struct-packing-array-of-scalar.comp,False
 shaders-msl-no-opt/packing/struct-packing-recursive.comp,False
 shaders-msl-no-opt/packing/struct-packing.comp,False
-shaders-no-opt/asm/comp/extended-debug-extinst.invalid.asm.comp,False
 shaders-no-opt/asm/comp/phi-temporary-copy-loop-variable.asm.invalid.comp,False
 shaders-no-opt/asm/frag/do-while-continue-phi.asm.invalid.frag,False
 shaders-no-opt/asm/frag/loop-merge-to-continue.asm.invalid.frag,False


### PR DESCRIPTION
Roll third_party/glslang/ c12493ff6..56364b6b6 (7 commits)

https://github.com/KhronosGroup/glslang/compare/c12493ff69e2...56364b6b6026

$ git log c12493ff6..56364b6b6 --date=short --no-merges --format='%ad %ae %s'
2020-03-01 cepheus Copyright update, mostly to trigger bots again.
2020-03-01 cepheus Fix #2095: correct the indentation.
2020-02-28 cepheus Fix #1461: set the SPIRV-Tools' optimizer's target environment.
2020-02-28 cepheus Fix #2091, remove incorrect assert for division by 0.0.
2020-02-28 wangli28 Add vcpkg installation instructions
2020-02-28 sk Fix for #2075: removed DefaultTBuiltInResource from glslang_c_interface.cpp
2020-02-22 rex.xu Fix an issue of SPV generation for imageAtomicStore.

Roll third_party/googletest/ 23b2a3b1c..e588eb1ff (3 commits)

https://github.com/google/googletest/compare/23b2a3b1cf80...e588eb1ff9ff

$ git log 23b2a3b1c..e588eb1ff --date=short --no-merges --format='%ad %ae %s'
2020-02-27 absl-team Googletest export
2020-02-25 absl-team Googletest export
2020-02-19 absl-team Googletest export

Roll third_party/re2/ 793b4e85e..f734980e7 (7 commits)

https://github.com/google/re2/compare/793b4e85e9af...f734980e70ee

$ git log 793b4e85e..f734980e7 --date=short --no-merges --format='%ad %ae %s'
2020-03-01 junyer Bump SONAME to reflect the ABI break.
2020-02-28 junyer Add macOS and Xcode jobs to the Travis CI matrix.
2020-02-26 junyer Don't break the RE2 object when compiling the reverse Prog fails.
2020-02-26 junyer Revert "Refuse to rewrite when MaxSubmatch() is too large."
2020-02-25 junyer Fall back to NFA execution when compiling the reverse Prog failed.
2020-02-25 junyer Refuse to rewrite when MaxSubmatch() is too large.
2020-02-20 junyer Tweak the comment on RE2::QuoteMeta().

Roll third_party/spirv-cross/ f19fdb94d..9deb6ffbb (6 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/f19fdb94d7b8...9deb6ffbba01

$ git log f19fdb94d..9deb6ffbb --date=short --no-merges --format='%ad %ae %s'
2020-03-02 post Add -V alias for --vulkan-semantics.
2020-02-24 post MSL: Add C API for force native arrays.
2020-02-24 post MSL: Add native array test for composite array initialization.
2020-02-24 post MSL: Reintroduce workaround for constant arrays being passed by value.
2020-02-24 post MSL: Reinstate workaround for returning arrays.
2020-02-24 post MSL: Add a workaround path to force native arrays for everything.

Roll third_party/spirv-headers/ 5dbc1c321..0a7fc4525 (1 commit)

https://github.com/KhronosGroup/SPIRV-Headers/compare/5dbc1c32182e...0a7fc4525991

$ git log 5dbc1c321..0a7fc4525 --date=short --no-merges --format='%ad %ae %s'
2020-02-26 dneto Add grammars, C header, and header generator for vendor and KHR extended instruction sets (#143)

Roll third_party/spirv-tools/ 4a80497a8..e1688b60c (8 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/4a80497a8885...e1688b60caf7

$ git log 4a80497a8..e1688b60c --date=short --no-merges --format='%ad %ae %s'
2020-02-28 dneto Avoid use of Python distutils.dir_util (#3203)
2020-02-28 rharrison Adding WebGPU specific Workgroup scope rule (#3204)
2020-02-25 jaebaek Add validation rules for OpenCL.DebugInfo.100 extension (#3133)
2020-02-25 geofflang Combine extinst-name and extinst-output-base into one arg. (#3200)
2020-02-23 nicolasweber Fix Wrange-loop-analysis warnings in SPIRV-Tools. (#3201)
2020-02-21 geofflang Add missing dependencies when generating spvtools_core_tables (#3199)
2020-02-21 afdx Brief guide to writing a spirv-fuzz fuzzer pass (#3190)
2020-02-21 47594367+rg3igalia Fix ignored const qualifier warning in static_cast (#3197)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools