### PR TITLE
Rolling 5 dependencies and updating expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '56364b6b602696c021349794a8d39744a1052afc',
+  'glslang_revision': '9b620aa0c12d12dd7ec7ced43ce9e58f275d47c1',
   'googletest_revision': 'e588eb1ff9ff6598666279b737b27f983156ad85',
-  're2_revision': 'f734980e70ee217cc45d3e5535b47cd2422c8f4b',
-  'spirv_headers_revision': '0a7fc45259910f07f00c5a3fa10be5678bee1f83',
-  'spirv_tools_revision': 'e1688b60caf77e7efd9e440e57cca429ca7c5a1e',
-  'spirv_cross_revision': '9deb6ffbba01298fff649d911e45a774903e8802',
+  're2_revision': 'bc40cdeb40ad56327da31ae3d8f3983994d9c616',
+  'spirv_headers_revision': '30ef660ce2e666f7ae925598b8a267f4da6d33aa',
+  'spirv_tools_revision': 'dd3d91691f1e1dc4c0f42818756cf5e165c8918c',
+  'spirv_cross_revision': '65aa0c35d6c2044e4be25e13e6f070caf9b75f31',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -1,7 +1,11 @@
+shaders-hlsl/comp/access-chains.force-uav.comp,False
+shaders-hlsl/comp/access-chains.force-uav.comp,True
 shaders-hlsl/comp/num-workgroups-alone.comp,False
 shaders-hlsl/comp/num-workgroups-alone.comp,True
 shaders-hlsl/comp/num-workgroups-with-builtins.comp,False
 shaders-hlsl/comp/num-workgroups-with-builtins.comp,True
+shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,False
+shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,True
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
 shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
@@ -74,3 +78,5 @@ shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
+shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,False
+shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,True

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -3,10 +3,14 @@ shaders-hlsl-no-opt/frag/constant-buffer-array.invalid.sm51.frag,False
 shaders-hlsl-no-opt/frag/fp16.invalid.desktop.frag,False
 shaders-hlsl/asm/comp/control-flow-hints.asm.comp,False
 shaders-hlsl/asm/comp/control-flow-hints.asm.comp,True
+shaders-hlsl/comp/access-chains.force-uav.comp,False
+shaders-hlsl/comp/access-chains.force-uav.comp,True
 shaders-hlsl/comp/num-workgroups-alone.comp,False
 shaders-hlsl/comp/num-workgroups-alone.comp,True
 shaders-hlsl/comp/num-workgroups-with-builtins.comp,False
 shaders-hlsl/comp/num-workgroups-with-builtins.comp,True
+shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,False
+shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,True
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
 shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
@@ -109,3 +113,5 @@ shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
+shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,False
+shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,True


### PR DESCRIPTION
Roll third_party/glslang/ 56364b6b6..9b620aa0c (17 commits)

https://github.com/KhronosGroup/glslang/compare/56364b6b6026...9b620aa0c12d

$ git log 56364b6b6..9b620aa0c --date=short --no-merges --format='%ad %ae %s'
2020-03-11 laddoc Add flag to check whether offset is implicit or explicit (#2031)
2020-03-11 rharrison Use strcmp for all of the extended instruction set checks in the disassembler (#2107)
2020-03-10 jbolz EXT_debug_printf - make escape sequences better match C/C++
2020-03-09 jbolz disable escape sequences for #line and #error
2020-03-09 jbolz Decorate accesschain operand for nonuniform UBO loads
2020-03-09 jbolz Allow nonuniformEXT() on sampler types.
2020-03-06 kainino Fix typo in Web CMakeLists
2020-03-06 foo.travis add missing string.h header for resource_limits_c.cpp
2020-03-06 foo.travis add c wrapper for standalone ResourceLimits and remove that dependency from glslang_c_interface
2020-03-05 foo.travis add stdbool.h to properly support bool type
2020-03-05 foo.travis add c interface support for TBuiltInResource and glslang::DefaultTBuiltInResource
2019-05-31 jbolz GL_EXT_debug_printf implementation
2020-03-04 s.fricke Add Android build instructions to README
2020-03-04 johnkslang Improve formatting.
2020-03-04 johnkslang Add "news" section and component status.
2020-03-03 cepheus Fix long lines in the SPIR-V generator, retrigger bots.
2020-03-03 cepheus Fix #1843: Handle built-in function output parameters to a swizzled arg

Roll third_party/re2/ f734980e7..bc40cdeb4 (2 commits)

https://github.com/google/re2/compare/f734980e70ee...bc40cdeb40ad

$ git log f734980e7..bc40cdeb4 --date=short --no-merges --format='%ad %ae %s'
2020-03-04 donatas.saulys Using slim RW lock on windows
2020-03-02 junyer Set SONAME to 6.

Roll third_party/spirv-cross/ 9deb6ffbb..65aa0c35d (6 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/9deb6ffbba01...65aa0c35d6c2

$ git log 9deb6ffbb..65aa0c35d --date=short --no-merges --format='%ad %ae %s'
2020-03-10 post include/spirv_cross: Fix typo.
2020-03-05 post HLSL: Do not emit globallycoherent for SRV ByteAddressBuffer.
2020-03-04 post Add test for disable-storage-image-qualifier-deduction.
2020-03-04 post HLSL: Add option to always treat SSBO as UAV, even with readonly.
2020-03-04 post Add option to disable storage image qualifier deduction.
2020-03-04 post Remove old hack which forces NonWritable/NonReadable.

Roll third_party/spirv-headers/ 0a7fc4525..30ef660ce (3 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/0a7fc4525991...30ef660ce2e6

$ git log 0a7fc4525..30ef660ce --date=short --no-merges --format='%ad %ae %s'
2020-03-09 stevenperron Export NonSemanticDebugPrintf.h in bazel build
2020-03-02 jbolz Add NonSemantic.DebugPrintf JSON/header
2020-03-02 jbolz Fix max enum value

Roll third_party/spirv-tools/ e1688b60c..dd3d91691 (9 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/e1688b60caf7...dd3d91691f1e

$ git log e1688b60c..dd3d91691 --date=short --no-merges --format='%ad %ae %s'
2020-03-09 jbolz Allow sampledimage types as operand of OpCopyObject (#3222)
2020-03-09 vasniktel spirv-fuzz: Remove duplicated functionality (#3220)
2020-03-09 andreperezmaselco.developer spirv-fuzz: Allow OpPhi operand to be replaced with a composite synonym (#3221)
2020-03-08 andreperezmaselco.developer spirv-fuzz: Add toggle access chain instruction transformation (#3211)
2020-03-08 vasniktel spirv-fuzz: Add fuzzer pass to permute function parameters (#3212)
2020-03-06 afdx spirv-fuzz: Use better function name (#3207)
2020-03-05 afdx spirv-fuzz: Add swap commutable operands transformation (#3205)
2020-03-04 afdx spirv-fuzz: Fuzzer pass to add equation instructions (#3202)
2020-03-04 andreperezmaselco.developer Refactor FuzzerPass::ApplyTransformation code duplication. (#3206)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools