### PR TITLE
Rolling 2 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -7,9 +7,9 @@ vars = {
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
   'glslang_revision': '9b620aa0c12d12dd7ec7ced43ce9e58f275d47c1',
   'googletest_revision': 'e588eb1ff9ff6598666279b737b27f983156ad85',
-  're2_revision': 'bc40cdeb40ad56327da31ae3d8f3983994d9c616',
+  're2_revision': '2695ecfed0bf7f530a3646abf8803df5ef62cfc9',
   'spirv_headers_revision': '30ef660ce2e666f7ae925598b8a267f4da6d33aa',
-  'spirv_tools_revision': 'dd3d91691f1e1dc4c0f42818756cf5e165c8918c',
+  'spirv_tools_revision': '1fe9bcc10824c1fa35bd9b697188340132d39213',
   'spirv_cross_revision': '65aa0c35d6c2044e4be25e13e6f070caf9b75f31',
 }
 


### PR DESCRIPTION
Roll third_party/re2/ bc40cdeb4..2695ecfed (1 commit)

https://github.com/google/re2/compare/bc40cdeb40ad...2695ecfed0bf

$ git log bc40cdeb4..2695ecfed --date=short --no-merges --format='%ad %ae %s'
2020-03-12 junyer SRWLOCK requires Windows Vista or Windows Server 2008 at minimum.

Roll third_party/spirv-tools/ dd3d91691..1fe9bcc10 (3 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/dd3d91691f1e...1fe9bcc10824

$ git log dd3d91691..1fe9bcc10 --date=short --no-merges --format='%ad %ae %s'
2020-03-12 greg Instrument: Debug Printf support (#3215)
2020-03-12 vasniktel spirv-fuzz: Support OpPhi when adding dead break and continue (#3225)
2020-03-12 afdx spirv-fuzz: Fix vector width issue in 'add equation instructions' pass (#3223)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools