### PR TITLE
Rolling 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '9b620aa0c12d12dd7ec7ced43ce9e58f275d47c1',
+  'glslang_revision': '4b2483ee88ab2ce904f6bac27c7796823c45564c',
   'googletest_revision': 'e588eb1ff9ff6598666279b737b27f983156ad85',
-  're2_revision': '2695ecfed0bf7f530a3646abf8803df5ef62cfc9',
-  'spirv_headers_revision': '30ef660ce2e666f7ae925598b8a267f4da6d33aa',
-  'spirv_tools_revision': '1fe9bcc10824c1fa35bd9b697188340132d39213',
+  're2_revision': 'ca93436e5b1be02f9f4bfca79b8202c400161994',
+  'spirv_headers_revision': 'a17e17e36da44d2cd1740132ecd7a8cb078f1d15',
+  'spirv_tools_revision': '25ede1ced6797f9a3689ae7dac5085ce8236c573',
   'spirv_cross_revision': '65aa0c35d6c2044e4be25e13e6f070caf9b75f31',
 }
 


### PR DESCRIPTION
Roll third_party/glslang/ 9b620aa0c..4b2483ee8 (1 commit)

https://github.com/KhronosGroup/glslang/compare/9b620aa0c12d...4b2483ee88ab

$ git log 9b620aa0c..4b2483ee8 --date=short --no-merges --format='%ad %ae %s'
2020-03-16 mbechard Fix #2005. Allow multiple compilation units to declare identical push_constant blocks (#2123)

Roll third_party/re2/ 2695ecfed..ca93436e5 (1 commit)

https://github.com/google/re2/compare/2695ecfed0bf...ca93436e5b1b

$ git log 2695ecfed..ca93436e5 --date=short --no-merges --format='%ad %ae %s'
2020-03-15 junyer Update Unicode data to 13.0.0.

Roll third_party/spirv-headers/ 30ef660ce..a17e17e36 (1 commit)

https://github.com/KhronosGroup/SPIRV-Headers/compare/30ef660ce2e6...a17e17e36da4

$ git log 30ef660ce..a17e17e36 --date=short --no-merges --format='%ad %ae %s'
2020-03-13 jmadill Add missing header to BUILD.gn.

Roll third_party/spirv-tools/ 1fe9bcc10..25ede1ced (2 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/1fe9bcc10824...25ede1ced679

$ git log 1fe9bcc10..25ede1ced --date=short --no-merges --format='%ad %ae %s'
2020-03-16 jmadill Roll external/spirv-headers/ 30ef660ce..a17e17e36 (1 commit) (#3230)
2020-03-13 vasniktel Update dependencies (#3228)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools