### PR TITLE
Rolling 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '4b2483ee88ab2ce904f6bac27c7796823c45564c',
-  'googletest_revision': 'e588eb1ff9ff6598666279b737b27f983156ad85',
+  'glslang_revision': '1f0fcbe5a30fdc9632a8bff36277103fabf0797c',
+  'googletest_revision': '749148f1accc346d94825358a9a745b852961a11',
   're2_revision': 'ca93436e5b1be02f9f4bfca79b8202c400161994',
-  'spirv_headers_revision': 'a17e17e36da44d2cd1740132ecd7a8cb078f1d15',
-  'spirv_tools_revision': '25ede1ced6797f9a3689ae7dac5085ce8236c573',
-  'spirv_cross_revision': '65aa0c35d6c2044e4be25e13e6f070caf9b75f31',
+  'spirv_headers_revision': 'f8bf11a0253a32375c32cad92c841237b96696c0',
+  'spirv_tools_revision': '1c8bda3721e6b9302f694b58c26d32eff341b126',
+  'spirv_cross_revision': '871c85d7f0edc6b613e3959bc51d13bfbc2fe2df',
 }
 
 deps = {

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -71,6 +71,7 @@ shaders-msl/vert/return-array.force-native-array.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,True
 shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
+shaders-no-opt/asm/comp/extended-debug-extinst.invalid.asm.comp,False
 shaders-no-opt/asm/comp/phi-temporary-copy-loop-variable.asm.invalid.comp,False
 shaders-no-opt/asm/frag/do-while-continue-phi.asm.invalid.frag,False
 shaders-no-opt/asm/frag/for-loop-dedicated-merge-block-inverted.asm.invalid.frag,False


### PR DESCRIPTION
Roll third_party/glslang/ 4b2483ee8..1f0fcbe5a (9 commits)

https://github.com/KhronosGroup/glslang/compare/4b2483ee88ab...1f0fcbe5a30f

$ git log 4b2483ee8..1f0fcbe5a --date=short --no-merges --format='%ad %ae %s'
2020-03-21 arnfranke Make file formatting comply with POSIX and Unix standards
2020-03-19 courtneygo Fix MSVC build issue - remove invalid character
2020-03-18 alele Re-add NV enums for raytracing to prevent build breaks.
2020-03-18 cepheus Fix #2132: constant matrix constructor from single non-scalar argument
2020-03-18 cepheus Bump version (also fix line endings the grammar).
2020-03-17 dkoch update known_good
2020-03-17 dkoch Add support for GLSL_EXT_ray_tracing
2020-03-17 cepheus SPV headers: Bump up to the latest header.
2020-03-16 jbolz Forbid memoryBarrierAtomicCounter for Vulkan compiles

Roll third_party/googletest/ e588eb1ff..749148f1a (10 commits)

https://github.com/google/googletest/compare/e588eb1ff9ff...749148f1accc

$ git log e588eb1ff..749148f1a --date=short --no-merges --format='%ad %ae %s'
2020-03-20 absl-team Googletest export
2020-03-17 absl-team Googletest export
2020-03-16 dmauro Googletest export
2020-03-13 absl-team Googletest export
2020-03-06 absl-team Googletest export
2020-03-03 absl-team Googletest export
2020-03-03 absl-team Googletest export
2020-03-11 romain.geissler Make sure IsATTY does not clobber errno.
2020-02-21 johan.mabille Fixed warnings
2020-01-29 krystian.kuzniarek remove a dead reference to the Autotools script

Roll third_party/spirv-cross/ 65aa0c35d..871c85d7f (4 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/65aa0c35d6c2...871c85d7f0ed

$ git log 65aa0c35d..871c85d7f --date=short --no-merges --format='%ad %ae %s'
2020-03-19 post GLSL: Implement GL_EXT_shader_framebuffer_fetch.
2020-03-19 post Run format_all.sh.
2020-03-19 post GLSL/HLSL: Fix nonuniform qualifier for SSBO atomics.
2020-03-19 post GLSL/HLSL: Implement nonuniform qualifier for image atomics.

Roll third_party/spirv-headers/ a17e17e36..f8bf11a02 (5 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/a17e17e36da4...f8bf11a0253a

$ git log a17e17e36..f8bf11a02 --date=short --no-merges --format='%ad %ae %s'
2020-03-17 dkoch Add shadercalls scope
2020-03-03 ntorosda Added ray flags, primitive culling flags, queries
2020-03-17 cepheus Non-functional: Update header build to match Khronos spec. builder.
2020-02-14 alele Update headers for SPV_KHR_ray_tracing.
2020-01-01 xanto Also propagate SPIRV-Headers version to CMakeLists.txt

Roll third_party/spirv-tools/ 25ede1ced..1c8bda372 (7 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/25ede1ced679...1c8bda3721e6

$ git log 25ede1ced..1c8bda372 --date=short --no-merges --format='%ad %ae %s'
2020-03-23 jaebaek Add data structure for DebugScope, DebugDeclare in spirv-opt (#3183)
2020-03-23 ehsannas Whitelist SPV_KHR_ray_tracing (#3241)
2020-03-23 arnfranke Make file formatting comply with POSIX standards (#3242)
2020-03-19 dneto Add opt::Operand::AsCString and AsString (#3240)
2020-03-20 lujiao Add RayQueryProvisionalKHR to opt types (#3239)
2020-03-17 ehsannas Whitelist SPV_EXT_demote_to_helper_invocation for opt passes (#3236)
2020-03-17 dgkoch Add support for KHR_ray_{query,tracing} extensions (#3235)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools