### PR TITLE
Roll glslang dependency

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '1f0fcbe5a30fdc9632a8bff36277103fabf0797c',
+  'glslang_revision': '8e26c5f50e8589e42d8c0ceb28abe93f3049fbd5',
   'googletest_revision': '749148f1accc346d94825358a9a745b852961a11',
   're2_revision': 'ca93436e5b1be02f9f4bfca79b8202c400161994',
   'spirv_headers_revision': 'f8bf11a0253a32375c32cad92c841237b96696c0',


### PR DESCRIPTION
Roll third_party/glslang/ 1f0fcbe5a..8e26c5f50 (26 commits)

$ git log 1f0fcbe5a..8e26c5f50 --date=short --no-merges --format='%ad %ae %s'
2020-03-25 neslisah.torosdagli@amd.com switch format update
2020-03-24 neslisah.torosdagli@amd.com copyright notice changes removed from unchanged files
2020-03-24 neslisah.torosdagli@amd.com copyright notice changes removed from unchanged files
2020-03-24 neslisah.torosdagli@amd.com copyright notice changes removed from unchanged files
2020-03-24 neslisah.torosdagli@amd.com spirv.hpp reverted to commit f368dcbb7d8af23f0cba3015d0f4dda9dc3aa66d
2020-03-24 neslisah.torosdagli@amd.com .travis updated to origin, rayQueryCheck removed
2020-03-23 neslisah.torosdagli@amd.com const rayFlag defs used in the test cases in stead of numerical values
2020-03-23 neslisah.torosdagli@amd.com compute and fragment shader test_cases added for rayQuery
2020-03-23 neslisah.torosdagli@amd.com rayQuery test cases added
2020-03-23 neslisah.torosdagli@amd.com rayQueryEXT function parameter
2020-03-23 neslisah.torosdagli@amd.com rayQueryEXT assignment is allowed.
2020-03-23 neslisah.torosdagli@amd.com test names updated
2020-03-23 kainino@chromium.org update README
2020-03-23 kainino@chromium.org Fix build on CMake 2.8, and fix Web build
2020-03-23 neslisah.torosdagli@amd.com wait time increased for the install
2020-03-23 neslisah.torosdagli@amd.com rayQuery test cases disabled
2020-03-20 neslisah.torosdagli@amd.com GL_EXT_ray_query glslang updates, and test cases added.
2020-03-19 neslisah.torosdagli@amd.com comment update, rayQueryEXT is writable, readonly check removed.
2020-03-19 ntorosda@amd.com GL_EXT_ray_query updates
2020-03-18 cepheus@frii.com Fix #2132: constant matrix constructor from single non-scalar argument
2020-03-19 neslisah.torosdagli@amd.com comment update, rayQueryEXT is writable, readonly check removed.
2020-03-19 ntorosda@amd.com GL_EXT_ray_query updates
2020-03-18 cepheus@frii.com Fix #2132: constant matrix constructor from single non-scalar argument
2020-03-19 neslisah.torosdagli@amd.com comment update, rayQueryEXT is writable, readonly check removed.
2020-03-19 neslisah.torosdagli@amd.com GL_EXT_ray_query updates
2020-03-19 ntorosda@amd.com GL_EXT_ray_query updates