### PR TITLE
Convert compile options to require explicit environments

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -179,6 +179,33 @@ typedef enum {
   shaderc_spvc_storage_texture_format_bc7rgbaunormsrgb = 0x00000034,
 } shaderc_spvc_storage_texture_format;
 
+typedef enum {
+  shaderc_spvc_spv_env_universal_1_0,
+  shaderc_spvc_spv_env_vulkan_1_0,
+  shaderc_spvc_spv_env_universal_1_1,
+  shaderc_spvc_spv_env_opencl_2_1,
+  shaderc_spvc_spv_env_opencl_2_2,
+  shaderc_spvc_spv_env_opengl_4_0,
+  shaderc_spvc_spv_env_opengl_4_1,
+  shaderc_spvc_spv_env_opengl_4_2,
+  shaderc_spvc_spv_env_opengl_4_3,
+  shaderc_spvc_spv_env_opengl_4_5,
+  shaderc_spvc_spv_env_universal_1_2,
+  shaderc_spvc_spv_env_opencl_1_2,
+  shaderc_spvc_spv_env_opencl_embedded_1_2,
+  shaderc_spvc_spv_env_opencl_2_0,
+  shaderc_spvc_spv_env_opencl_embedded_2_0,
+  shaderc_spvc_spv_env_opencl_embedded_2_1,
+  shaderc_spvc_spv_env_opencl_embedded_2_2,
+  shaderc_spvc_spv_env_universal_1_3,
+  shaderc_spvc_spv_env_vulkan_1_1,
+  shaderc_spvc_spv_env_webgpu_0,
+  shaderc_spvc_spv_env_universal_1_4,
+  shaderc_spvc_spv_env_vulkan_1_1_spirv_1_4,
+  shaderc_spvc_spv_env_universal_1_5,
+  shaderc_spvc_spv_env_vulkan_1_2,
+} shaderc_spvc_spv_env;
+
 // An opaque handle to an object that manages all compiler state.
 typedef struct shaderc_spvc_context* shaderc_spvc_context_t;
 
@@ -268,11 +295,10 @@ typedef struct shaderc_spvc_compile_options* shaderc_spvc_compile_options_t;
 // Any function operating on shaderc_spvc_compile_options_t must offer the
 // basic thread-safety guarantee.
 SHADERC_EXPORT shaderc_spvc_compile_options_t
-shaderc_spvc_compile_options_create(void);
+shaderc_spvc_compile_options_create(shaderc_spvc_spv_env source_env,
+                                    shaderc_spvc_spv_env target_env);
 
 // Returns a copy of the given options.
-// If NULL is passed as the parameter the call is the same as
-// shaderc_spvc_compile_options_init.
 SHADERC_EXPORT shaderc_spvc_compile_options_t
 shaderc_spvc_compile_options_clone(
     const shaderc_spvc_compile_options_t options);
@@ -283,6 +309,7 @@ shaderc_spvc_compile_options_clone(
 SHADERC_EXPORT void shaderc_spvc_compile_options_destroy(
     shaderc_spvc_compile_options_t options);
 
+// DEPRECATED
 // Sets the source shader environment, affecting which warnings or errors will
 // be issued during validation.
 // Default value for environment is Vulkan 1.0.
@@ -290,6 +317,7 @@ SHADERC_EXPORT shaderc_spvc_status shaderc_spvc_compile_options_set_source_env(
     shaderc_spvc_compile_options_t options, shaderc_target_env env,
     shaderc_env_version version);
 
+// DEPRECATED
 // Sets the target shader environment, if this is different from the source
 // environment, then a transform between the environments will be performed if
 // possible. Currently only WebGPU <-> Vulkan 1.1 are defined.

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -101,9 +101,14 @@ class CompilationResult {
 // Contains any options that can have default values for a compilation.
 class CompileOptions {
  public:
-  CompileOptions()
-      : options_(shaderc_spvc_compile_options_create(),
+  CompileOptions(shaderc_spvc_spv_env source_env,
+                 shaderc_spvc_spv_env target_env)
+      : options_(shaderc_spvc_compile_options_create(source_env, target_env),
                  shaderc_spvc_compile_options_destroy) {}
+  // DEPRECATED
+  CompileOptions()
+      : CompileOptions(shaderc_spvc_spv_env_universal_1_0,
+                       shaderc_spvc_spv_env_universal_1_0) {}
   CompileOptions(const CompileOptions& other)
       : options_(nullptr, shaderc_spvc_compile_options_destroy) {
     options_.reset(shaderc_spvc_compile_options_clone(other.options_.get()));
@@ -114,6 +119,7 @@ class CompileOptions {
     options_.reset(other.options_.release());
   }
 
+  // DEPRECATED
   // Set the environment for the input SPIR-V.  Default is Vulkan 1.0.
   shaderc_spvc_status SetSourceEnvironment(shaderc_target_env env,
                                            shaderc_env_version version) {
@@ -121,6 +127,7 @@ class CompileOptions {
                                                        version);
   }
 
+  // DEPRECATED
   // Set the target environment for the SPIR-V to be cross-compiled. If this is
   // different then the source a transformation will need to be applied.
   // Currently only Vulkan 1.1 <-> WebGPU transforms are defined. Default is
@@ -148,7 +155,6 @@ class CompileOptions {
   // arrays, providing guarantees satisfying Vulkan's robustBufferAccess rules.
   // This is useful when an implementation does not support robust-buffer access
   // as a driver option.
-
   shaderc_spvc_status SetRobustBufferAccessPass(bool b) {
     return shaderc_spvc_compile_options_set_robust_buffer_access_pass(
         options_.get(), b);

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -246,6 +246,64 @@ shaderc_spvc_storage_texture_format spv_image_format_to_storage_texture_format(
   }
 }
 
+spv_target_env shaderc_spvc_spv_env_to_spv_target_env(
+    shaderc_spvc_spv_env env) {
+  switch (env) {
+    case shaderc_spvc_spv_env_universal_1_0:
+      return SPV_ENV_UNIVERSAL_1_0;
+    case shaderc_spvc_spv_env_vulkan_1_0:
+      return SPV_ENV_VULKAN_1_0;
+    case shaderc_spvc_spv_env_universal_1_1:
+      return SPV_ENV_UNIVERSAL_1_1;
+    case shaderc_spvc_spv_env_opencl_2_1:
+      return SPV_ENV_OPENCL_2_1;
+    case shaderc_spvc_spv_env_opencl_2_2:
+      return SPV_ENV_OPENCL_2_2;
+    case shaderc_spvc_spv_env_opengl_4_0:
+      return SPV_ENV_OPENGL_4_0;
+    case shaderc_spvc_spv_env_opengl_4_1:
+      return SPV_ENV_OPENGL_4_1;
+    case shaderc_spvc_spv_env_opengl_4_2:
+      return SPV_ENV_OPENGL_4_2;
+    case shaderc_spvc_spv_env_opengl_4_3:
+      return SPV_ENV_OPENGL_4_3;
+    case shaderc_spvc_spv_env_opengl_4_5:
+      return SPV_ENV_OPENGL_4_5;
+    case shaderc_spvc_spv_env_universal_1_2:
+      return SPV_ENV_UNIVERSAL_1_2;
+    case shaderc_spvc_spv_env_opencl_1_2:
+      return SPV_ENV_OPENCL_1_2;
+    case shaderc_spvc_spv_env_opencl_embedded_1_2:
+      return SPV_ENV_OPENCL_EMBEDDED_1_2;
+    case shaderc_spvc_spv_env_opencl_2_0:
+      return SPV_ENV_OPENCL_2_0;
+    case shaderc_spvc_spv_env_opencl_embedded_2_0:
+      return SPV_ENV_OPENCL_EMBEDDED_2_0;
+    case shaderc_spvc_spv_env_opencl_embedded_2_1:
+      return SPV_ENV_OPENCL_EMBEDDED_2_1;
+    case shaderc_spvc_spv_env_opencl_embedded_2_2:
+      return SPV_ENV_OPENCL_EMBEDDED_2_2;
+    case shaderc_spvc_spv_env_universal_1_3:
+      return SPV_ENV_UNIVERSAL_1_3;
+    case shaderc_spvc_spv_env_vulkan_1_1:
+      return SPV_ENV_VULKAN_1_1;
+    case shaderc_spvc_spv_env_webgpu_0:
+      return SPV_ENV_WEBGPU_0;
+    case shaderc_spvc_spv_env_universal_1_4:
+      return SPV_ENV_UNIVERSAL_1_4;
+    case shaderc_spvc_spv_env_vulkan_1_1_spirv_1_4:
+      return SPV_ENV_VULKAN_1_1_SPIRV_1_4;
+    case shaderc_spvc_spv_env_universal_1_5:
+      return SPV_ENV_UNIVERSAL_1_5;
+    case shaderc_spvc_spv_env_vulkan_1_2:
+      return SPV_ENV_VULKAN_1_2;
+  }
+  shaderc_spvc::ErrorLog(nullptr)
+      << "Attempted to convert unknown shaderc_spvc_spv_env value, " << env;
+  assert(false);
+  return SPV_ENV_UNIVERSAL_1_0;
+}
+
 shaderc_spvc_status get_location_info_impl(
     spirv_cross::Compiler* compiler,
     const spirv_cross::SmallVector<spirv_cross::Resource>& resources,
@@ -309,11 +367,14 @@ shaderc_spvc_status shaderc_spvc_context_set_use_spvc_parser(
   return shaderc_spvc_status_success;
 }
 
-shaderc_spvc_compile_options_t shaderc_spvc_compile_options_create() {
+shaderc_spvc_compile_options_t shaderc_spvc_compile_options_create(
+    shaderc_spvc_spv_env source_env, shaderc_spvc_spv_env target_env) {
   shaderc_spvc_compile_options_t options =
       new (std::nothrow) shaderc_spvc_compile_options;
   if (options) {
     options->glsl.version = 0;
+    options->source_env = shaderc_spvc_spv_env_to_spv_target_env(source_env);
+    options->target_env = shaderc_spvc_spv_env_to_spv_target_env(target_env);
   }
   return options;
 }
@@ -321,7 +382,7 @@ shaderc_spvc_compile_options_t shaderc_spvc_compile_options_create() {
 shaderc_spvc_compile_options_t shaderc_spvc_compile_options_clone(
     shaderc_spvc_compile_options_t options) {
   if (options) return new (std::nothrow) shaderc_spvc_compile_options(*options);
-  return shaderc_spvc_compile_options_create();
+  return nullptr;
 }
 
 void shaderc_spvc_compile_options_destroy(
@@ -329,6 +390,7 @@ void shaderc_spvc_compile_options_destroy(
   if (options) delete options;
 }
 
+// DEPRECATED
 shaderc_spvc_status shaderc_spvc_compile_options_set_source_env(
     shaderc_spvc_compile_options_t options, shaderc_target_env env,
     shaderc_env_version version) {
@@ -338,6 +400,7 @@ shaderc_spvc_status shaderc_spvc_compile_options_set_source_env(
   return shaderc_spvc_status_success;
 }
 
+// DEPRECATED
 shaderc_spvc_status shaderc_spvc_compile_options_set_target_env(
     shaderc_spvc_compile_options_t options, shaderc_target_env env,
     shaderc_env_version version) {

--- a/libshaderc_spvc/src/spvc_smoke_test_util.c
+++ b/libshaderc_spvc/src/spvc_smoke_test_util.c
@@ -97,13 +97,13 @@ int run_smoke_test(const char* shader, int transform_from_webgpu) {
 
   int ret_code = 0;
   shaderc_spvc_context_t context = shaderc_spvc_context_create();
-  shaderc_spvc_compile_options_t options =
-      shaderc_spvc_compile_options_create();
+  shaderc_spvc_compile_options_t options;
   if (transform_from_webgpu) {
-    shaderc_spvc_compile_options_set_source_env(
-        options, shaderc_target_env_webgpu, shaderc_env_version_webgpu);
-    shaderc_spvc_compile_options_set_target_env(
-        options, shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_1);
+    options = shaderc_spvc_compile_options_create(
+        shaderc_spvc_spv_env_webgpu_0, shaderc_spvc_spv_env_vulkan_1_1);
+  } else {
+    options = shaderc_spvc_compile_options_create(
+        shaderc_spvc_spv_env_vulkan_1_0, shaderc_spvc_spv_env_vulkan_1_0);
   }
 
   if (!run_glsl(context, options, assembled_shader)) ret_code = -1;

--- a/libshaderc_spvc/src/spvc_test.cc
+++ b/libshaderc_spvc/src/spvc_test.cc
@@ -27,7 +27,8 @@ class CompileTest : public testing::Test {
  public:
   void SetUp() override {
     context_ = shaderc_spvc_context_create();
-    options_ = shaderc_spvc_compile_options_create();
+    options_ = shaderc_spvc_compile_options_create(
+        shaderc_spvc_spv_env_vulkan_1_0, shaderc_spvc_spv_env_vulkan_1_0);
     result_ = shaderc_spvc_result_create();
   }
 

--- a/libshaderc_spvc/src/spvc_webgpu_cpp_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_cpp_test.cc
@@ -25,12 +25,9 @@ namespace {
 
 class CompileTest : public testing::Test {
  public:
-  void SetUp() override {
-    options_.SetSourceEnvironment(shaderc_target_env_webgpu,
-                                  shaderc_env_version_webgpu);
-    options_.SetTargetEnvironment(shaderc_target_env_vulkan,
-                                  shaderc_env_version_vulkan_1_1);
-  }
+  CompileTest()
+      : options_(shaderc_spvc_spv_env_webgpu_0,
+                 shaderc_spvc_spv_env_vulkan_1_1) {}
 
   Context context_;
   CompileOptions options_;

--- a/libshaderc_spvc/src/spvc_webgpu_test.cc
+++ b/libshaderc_spvc/src/spvc_webgpu_test.cc
@@ -26,13 +26,9 @@ class CompileTest : public testing::Test {
  public:
   void SetUp() override {
     context_ = shaderc_spvc_context_create();
-    options_ = shaderc_spvc_compile_options_create();
+    options_ = shaderc_spvc_compile_options_create(
+        shaderc_spvc_spv_env_webgpu_0, shaderc_spvc_spv_env_vulkan_1_1);
     result_ = shaderc_spvc_result_create();
-
-    shaderc_spvc_compile_options_set_source_env(
-        options_, shaderc_target_env_webgpu, shaderc_env_version_webgpu);
-    shaderc_spvc_compile_options_set_target_env(
-        options_, shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_1);
   }
 
   void TearDown() override {


### PR DESCRIPTION
This is designed to replace the existing code which has default values, and
setters, with a pattern that requires specifying the environments at creation
time.

All of the internal code and tests has been updated to use the new API.

The old API has been marked as a deprecated and will be removed once Dawn no
longer uses it.

Part of #1017