### PR TITLE
Add support for WebGPU to shaderc

### DIFF
--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -277,6 +277,8 @@ shaderc_util::Compiler::TargetEnv GetCompilerTargetEnv(shaderc_target_env env) {
       return shaderc_util::Compiler::TargetEnv::OpenGL;
     case shaderc_target_env_opengl_compat:
       return shaderc_util::Compiler::TargetEnv::OpenGLCompat;
+    case shaderc_target_env_webgpu:
+      return shaderc_util::Compiler::TargetEnv::WebGPU;
     case shaderc_target_env_vulkan:
     default:
       break;

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -109,6 +109,7 @@ class Compiler {
     Vulkan,        // Default to Vulkan 1.0
     OpenGL,        // Default to OpenGL 4.5
     OpenGLCompat,  // Deprecated.
+    WebGPU,
   };
 
   // Target environment versions.  These numbers match those used by Glslang.

--- a/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
+++ b/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
@@ -46,6 +46,7 @@ enum class PassId {
   kLegalizationPasses,
   kPerformancePasses,
   kSizePasses,
+  kVulkanToWebGPUPasses,
 
   // SPIRV-Tools specific passes
   kNullPass,

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -83,6 +83,7 @@ EShMessages GetMessageRules(shaderc_util::Compiler::TargetEnv env,
     case Compiler::TargetEnv::OpenGL:
       result = static_cast<EShMessages>(result | EShMsgSpvRules);
       break;
+    case Compiler::TargetEnv::WebGPU:
     case Compiler::TargetEnv::Vulkan:
       result =
           static_cast<EShMessages>(result | EShMsgSpvRules | EShMsgVulkanRules);
@@ -143,10 +144,18 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   std::vector<uint32_t>& compilation_output_data = std::get<1>(result_tuple);
   size_t& compilation_output_data_size_in_bytes = std::get<2>(result_tuple);
 
+  // glslang doesn't currently support WebGPU, so we need fake it by having it
+  // generate Vulkan1.1 and then use spirv-opt later to convert to WebGPU.
+  bool is_webgpu = target_env_ == Compiler::TargetEnv::WebGPU;
+  TargetEnv internal_target_env =
+      !is_webgpu ? target_env_ : Compiler::TargetEnv::Vulkan;
+  TargetEnvVersion internal_target_env_version =
+      !is_webgpu ? target_env_version_ : Compiler::TargetEnvVersion::Vulkan_1_1;
+
   // Check target environment.
   const auto target_client_info = GetGlslangClientInfo(
-      error_tag, target_env_, target_env_version_, target_spirv_version_,
-      target_spirv_version_is_forced_);
+      error_tag, internal_target_env, internal_target_env_version,
+      target_spirv_version_, target_spirv_version_is_forced_);
   if (!target_client_info.error.empty()) {
     *error_stream << target_client_info.error;
     *total_warnings = 0;
@@ -248,8 +257,9 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   shader.setInvertY(invert_y_enabled_);
   shader.setNanMinMaxClamp(nan_clamp_);
 
-  const EShMessages rules = GetMessageRules(
-      target_env_, source_language_, hlsl_offsets_, generate_debug_info_);
+  const EShMessages rules =
+      GetMessageRules(internal_target_env, source_language_, hlsl_offsets_,
+                      generate_debug_info_);
 
   bool success = shader.parse(&limits_, default_version_, default_profile_,
                               force_version_profile_, kNotForwardCompatible,
@@ -298,10 +308,15 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   opt_passes.insert(opt_passes.end(), enabled_opt_passes_.begin(),
                     enabled_opt_passes_.end());
 
+  // WebGPU goes last, since it is converting the env.
+  if (is_webgpu) {
+    opt_passes.push_back(PassId::kVulkanToWebGPUPasses);
+  }
+
   if (!opt_passes.empty()) {
     std::string opt_errors;
-    if (!SpirvToolsOptimize(target_env_, target_env_version_, opt_passes,
-                            &spirv, &opt_errors)) {
+    if (!SpirvToolsOptimize(internal_target_env, internal_target_env_version,
+                            opt_passes, &spirv, &opt_errors)) {
       *error_stream << "shaderc: internal error: compilation succeeded but "
                        "failed to optimize: "
                     << opt_errors << "\n";
@@ -311,6 +326,8 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
 
   if (output_type == OutputType::SpirvAssemblyText) {
     std::string text_or_error;
+    // spirv-tools does know about WebGPU, so don't need to pun to Vulkan1.1
+    // here.
     if (!SpirvToolsDisassemble(target_env_, target_env_version_, spirv,
                                &text_or_error)) {
       *error_stream << "shaderc: internal error: compilation succeeded but "
@@ -408,6 +425,14 @@ void Compiler::SetSuppressWarnings() { suppress_warnings_ = true; }
 std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
     const std::string& error_tag, const string_piece& shader_source,
     const string_piece& shader_preamble, CountingIncluder& includer) const {
+  // glslang doesn't currently support WebGPU, so we need fake it by having it
+  // generate Vulkan1.1 and then use spirv-opt later to convert to WebGPU.
+  bool is_webgpu = target_env_ == Compiler::TargetEnv::WebGPU;
+  TargetEnv internal_target_env =
+      !is_webgpu ? target_env_ : Compiler::TargetEnv::Vulkan;
+  TargetEnvVersion internal_target_env_version =
+      !is_webgpu ? target_env_version_ : Compiler::TargetEnvVersion::Vulkan_1_1;
+
   // The stage does not matter for preprocessing.
   glslang::TShader shader(EShLangVertex);
   const char* shader_strings = shader_source.data();
@@ -417,8 +442,8 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
                                        &string_names, 1);
   shader.setPreamble(shader_preamble.data());
   auto target_client_info = GetGlslangClientInfo(
-      error_tag, target_env_, target_env_version_, target_spirv_version_,
-      target_spirv_version_is_forced_);
+      error_tag, internal_target_env, internal_target_env_version,
+      target_spirv_version_, target_spirv_version_is_forced_);
   if (!target_client_info.error.empty()) {
     return std::make_tuple(false, "", target_client_info.error);
   }
@@ -435,7 +460,8 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
   // flag.
   const auto rules = static_cast<EShMessages>(
       EShMsgOnlyPreprocessor |
-      GetMessageRules(target_env_, source_language_, hlsl_offsets_, false));
+      GetMessageRules(internal_target_env, source_language_, hlsl_offsets_,
+                      false));
 
   std::string preprocessed_shader;
   const bool success = shader.preprocess(

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -144,8 +144,8 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   std::vector<uint32_t>& compilation_output_data = std::get<1>(result_tuple);
   size_t& compilation_output_data_size_in_bytes = std::get<2>(result_tuple);
 
-  // glslang doesn't currently support WebGPU, so we need fake it by having it
-  // generate Vulkan1.1 and then use spirv-opt later to convert to WebGPU.
+  // glslang doesn't currently support WebGPU, so we need to fake it by having
+  // it generate Vulkan1.1 and then use spirv-opt later to convert to WebGPU.
   bool is_webgpu = target_env_ == Compiler::TargetEnv::WebGPU;
   TargetEnv internal_target_env =
       !is_webgpu ? target_env_ : Compiler::TargetEnv::Vulkan;
@@ -326,7 +326,7 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
 
   if (output_type == OutputType::SpirvAssemblyText) {
     std::string text_or_error;
-    // spirv-tools does know about WebGPU, so don't need to pun to Vulkan1.1
+    // spirv-tools does know about WebGPU, so don't need to punt to Vulkan1.1
     // here.
     if (!SpirvToolsDisassemble(target_env_, target_env_version_, spirv,
                                &text_or_error)) {
@@ -425,8 +425,8 @@ void Compiler::SetSuppressWarnings() { suppress_warnings_ = true; }
 std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
     const std::string& error_tag, const string_piece& shader_source,
     const string_piece& shader_preamble, CountingIncluder& includer) const {
-  // glslang doesn't currently support WebGPU, so we need fake it by having it
-  // generate Vulkan1.1 and then use spirv-opt later to convert to WebGPU.
+  // glslang doesn't currently support WebGPU, so we need to fake it by having
+  // it generate Vulkan1.1 and then use spirv-opt later to convert to WebGPU.
   bool is_webgpu = target_env_ == Compiler::TargetEnv::WebGPU;
   TargetEnv internal_target_env =
       !is_webgpu ? target_env_ : Compiler::TargetEnv::Vulkan;

--- a/libshaderc_util/src/spirv_tools_wrapper.cc
+++ b/libshaderc_util/src/spirv_tools_wrapper.cc
@@ -45,6 +45,8 @@ spv_target_env GetSpirvToolsTargetEnv(Compiler::TargetEnv env,
       return SPV_ENV_OPENGL_4_5;
     case Compiler::TargetEnv::OpenGLCompat:  // Deprecated
       return SPV_ENV_OPENGL_4_5;
+    case Compiler::TargetEnv::WebGPU:
+      return SPV_ENV_WEBGPU_0;
   }
   assert(false && "unexpected target environment or version");
   return SPV_ENV_VULKAN_1_0;
@@ -142,6 +144,9 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
         break;
       case PassId::kSizePasses:
         optimizer.RegisterSizePasses();
+        break;
+      case PassId::kVulkanToWebGPUPasses:
+        optimizer.RegisterVulkanToWebGPUPasses();
         break;
       case PassId::kNullPass:
         // We actually don't need to do anything for null pass.


### PR DESCRIPTION
For the WebGPUI environment, when generating SPIR-V first generate Vulkan1.1
SPIR-V, and then use the optimizer to convert it to WebGPU SPIR-V, since glslang
cannot natively emit it.

Fixes #1020