### PR TITLE
Rolling 5 dependencies and updated expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': 'ad1b588deac6b34fd8269c67dab05bb2d4499f6c',
-  'googletest_revision': '749148f1accc346d94825358a9a745b852961a11',
-  're2_revision': 'ca93436e5b1be02f9f4bfca79b8202c400161994',
+  'glslang_revision': '08c02ced798afe357349d0e422cd474aa1eb0c79',
+  'googletest_revision': '67cc66080d64e3fa5124fe57ed0cf15e2cecfdeb',
+  're2_revision': '209eda1b607909cf3c9ad084264039546155aeaa',
   'spirv_headers_revision': 'f8bf11a0253a32375c32cad92c841237b96696c0',
-  'spirv_tools_revision': '1c8bda3721e6b9302f694b58c26d32eff341b126',
-  'spirv_cross_revision': '871c85d7f0edc6b613e3959bc51d13bfbc2fe2df',
+  'spirv_tools_revision': 'fd773eb50d628c1981338addc093df879757c2cf',
+  'spirv_cross_revision': '9b3c5e12be12c55533f3bd3ab9cc617ec0f393d8',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -1,3 +1,6 @@
+shaders-hlsl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
+shaders-hlsl-no-opt/asm/temporary.zero-initialize.asm.frag,False
+shaders-hlsl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-hlsl/comp/access-chains.force-uav.comp,False
 shaders-hlsl/comp/access-chains.force-uav.comp,True
 shaders-hlsl/comp/num-workgroups-alone.comp,False
@@ -10,9 +13,12 @@ shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
 shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
 shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
+shaders-msl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
+shaders-msl-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-msl-no-opt/comp/basic.dynamic-buffer.msl2.invalid.comp,False
 shaders-msl-no-opt/comp/int64.invalid.msl22.comp,False
 shaders-msl-no-opt/frag/force-active-resources.msl2.argument..force-active.discrete.frag,False
+shaders-msl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-msl-no-opt/vert/pass-array-by-value.force-native-array.vert,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,True
@@ -47,6 +53,9 @@ shaders-msl/vert/return-array.force-native-array.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,False
 shaders-msl/vert/texture_buffer.texture-buffer-native.msl21.vert,True
 shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
+shaders-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
+shaders-no-opt/asm/temporary.zero-initialize.asm.frag,False
+shaders-no-opt/frag/variables.zero-initialize.frag,False
 shaders-reflection/asm/aliased-entry-point-names.asm.multi,False
 shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -1,6 +1,9 @@
+shaders-hlsl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
 shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
+shaders-hlsl-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-hlsl-no-opt/frag/constant-buffer-array.invalid.sm51.frag,False
 shaders-hlsl-no-opt/frag/fp16.invalid.desktop.frag,False
+shaders-hlsl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-hlsl/asm/comp/control-flow-hints.asm.comp,False
 shaders-hlsl/asm/comp/control-flow-hints.asm.comp,True
 shaders-hlsl/comp/access-chains.force-uav.comp,False
@@ -15,11 +18,13 @@ shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
 shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
 shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
+shaders-msl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
 shaders-msl-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-3.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-5.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding.asm.comp,False
 shaders-msl-no-opt/asm/packing/packed-vector-extract-insert.asm.comp,False
+shaders-msl-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-msl-no-opt/comp/basic.dynamic-buffer.msl2.invalid.comp,False
 shaders-msl-no-opt/comp/int64.invalid.msl22.comp,False
 shaders-msl-no-opt/frag/16bit-constants.invalid.frag,False
@@ -27,6 +32,7 @@ shaders-msl-no-opt/frag/force-active-resources.msl2.argument..force-active.discr
 shaders-msl-no-opt/frag/fp16.desktop.invalid.frag,False
 shaders-msl-no-opt/frag/min-max-clamp.invalid.asm.frag,False
 shaders-msl-no-opt/frag/shadow-compare-global-alias.invalid.frag,False
+shaders-msl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-msl-no-opt/packing/array-of-vec3.comp,False
 shaders-msl-no-opt/packing/load-store-col-rows.comp,False
 shaders-msl-no-opt/packing/matrix-2x3-scalar.comp,False
@@ -77,12 +83,15 @@ shaders-no-opt/asm/frag/do-while-continue-phi.asm.invalid.frag,False
 shaders-no-opt/asm/frag/for-loop-dedicated-merge-block-inverted.asm.invalid.frag,False
 shaders-no-opt/asm/frag/for-loop-dedicated-merge-block-non-inverted.asm.invalid.frag,False
 shaders-no-opt/asm/frag/loop-merge-to-continue.asm.invalid.frag,False
+shaders-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
 shaders-no-opt/asm/frag/selection-merge-to-continue.asm.invalid.frag,False
 shaders-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders-no-opt/asm/frag/switch-merge-to-continue.asm.invalid.frag,False
+shaders-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-no-opt/frag/16bit-constants.invalid.frag,False
 shaders-no-opt/frag/fp16.invalid.desktop.frag,False
 shaders-no-opt/frag/multi-dimensional.desktop.invalid.flatten_dim.frag,False
+shaders-no-opt/frag/variables.zero-initialize.frag,False
 shaders-reflection/asm/aliased-entry-point-names.asm.multi,False
 shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp,False


### PR DESCRIPTION
Roll third_party/glslang/ ad1b588de..08c02ced7 (1 commit)

https://github.com/KhronosGroup/glslang/compare/ad1b588deac6...08c02ced798a

$ git log ad1b588de..08c02ced7 --date=short --no-merges --format='%ad %ae %s'
2020-03-30 dsinclair Remove unused variables.

Roll third_party/googletest/ 749148f1a..67cc66080 (3 commits)

https://github.com/google/googletest/compare/749148f1accc...67cc66080d64

$ git log 749148f1a..67cc66080 --date=short --no-merges --format='%ad %ae %s'
2020-03-23 absl-team Googletest export
2019-07-11 adam.f.badura Add support for std::function in MockFunction (#2277)
2019-12-26 adam.f.badura Add tests for MockFunction deduction (#2277)

Roll third_party/re2/ ca93436e5..209eda1b6 (2 commits)

https://github.com/google/re2/compare/ca93436e5b1b...209eda1b6079

$ git log ca93436e5..209eda1b6 --date=short --no-merges --format='%ad %ae %s'
2020-03-27 junyer Aiieee. Add a missing underscore.
2020-03-27 junyer Include the pattern length in "DFA out of memory" errors.

Roll third_party/spirv-cross/ 871c85d7f..9b3c5e12b (1 commit)

https://github.com/KhronosGroup/SPIRV-Cross/compare/871c85d7f0ed...9b3c5e12be12

$ git log 871c85d7f..9b3c5e12b --date=short --no-merges --format='%ad %ae %s'
2020-03-26 post Add support for forcefully zero-initialized variables.

Roll third_party/spirv-tools/ 1c8bda372..fd773eb50 (5 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/1c8bda3721e6...fd773eb50d62

$ git log 1c8bda372..fd773eb50 --date=short --no-merges --format='%ad %ae %s'
2020-03-26 stevenperron Start SPIRV-Tools v2020.3
2020-03-26 stevenperron Finalize SPIRV-Tools v2020.2
2020-03-26 stevenperron Update CHANGES
2020-03-25 alanbaker Fix identification of Vulkan images and buffers (#3253)
2020-03-23 alanbaker Disallow phis of images, samplers and sampled images (#3246)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools