### PR TITLE
Rolling 5 dependencies and updating expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': 'e157435c1e777aa1052f446dafed162b4a722e03',
-  'googletest_revision': '67cc66080d64e3fa5124fe57ed0cf15e2cecfdeb',
-  're2_revision': '209eda1b607909cf3c9ad084264039546155aeaa',
+  'glslang_revision': 'b5757b95005bbf6b0287096c5b708c5e25645311',
+  'googletest_revision': 'e3f0319d89f4cbf32993de595d984183b1a9fc57',
+  're2_revision': '58141dc9c92189ed8d046f494f5e034d5db91bea',
   'spirv_headers_revision': 'f8bf11a0253a32375c32cad92c841237b96696c0',
-  'spirv_tools_revision': 'fd773eb50d628c1981338addc093df879757c2cf',
-  'spirv_cross_revision': '9b3c5e12be12c55533f3bd3ab9cc617ec0f393d8',
+  'spirv_tools_revision': 'e95fbfb1f509ad7a7fdfb72ac35fe412d72fc4a4',
+  'spirv_cross_revision': '6637610b16aacfe43c77ad4060da62008a83cd12',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -3,6 +3,8 @@ shaders-hlsl-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-hlsl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-hlsl/comp/access-chains.force-uav.comp,False
 shaders-hlsl/comp/access-chains.force-uav.comp,True
+shaders-hlsl/comp/image.nonwritable-uav-texture.comp,False
+shaders-hlsl/comp/image.nonwritable-uav-texture.comp,True
 shaders-hlsl/comp/num-workgroups-alone.comp,False
 shaders-hlsl/comp/num-workgroups-alone.comp,True
 shaders-hlsl/comp/num-workgroups-with-builtins.comp,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -8,6 +8,8 @@ shaders-hlsl/asm/comp/control-flow-hints.asm.comp,False
 shaders-hlsl/asm/comp/control-flow-hints.asm.comp,True
 shaders-hlsl/comp/access-chains.force-uav.comp,False
 shaders-hlsl/comp/access-chains.force-uav.comp,True
+shaders-hlsl/comp/image.nonwritable-uav-texture.comp,False
+shaders-hlsl/comp/image.nonwritable-uav-texture.comp,True
 shaders-hlsl/comp/num-workgroups-alone.comp,False
 shaders-hlsl/comp/num-workgroups-alone.comp,True
 shaders-hlsl/comp/num-workgroups-with-builtins.comp,False


### PR DESCRIPTION
Roll third_party/glslang/ e157435c1..b5757b950 (3 commits)

https://github.com/KhronosGroup/glslang/compare/e157435c1e77...b5757b95005b

$ git log e157435c1..b5757b950 --date=short --no-merges --format='%ad %ae %s'
2020-04-03 rharrison Remove extra semicolons (#2170)
2020-04-02 mbechard Shader interface matching rework to fix #2136 (#2156)
2020-04-01 cepheus Build warning: Fix #2167: Remove nested reuse of 'unreachable'.

Roll third_party/googletest/ 67cc66080..e3f0319d8 (6 commits)

https://github.com/google/googletest/compare/67cc66080d64...e3f0319d89f4

$ git log 67cc66080..e3f0319d8 --date=short --no-merges --format='%ad %ae %s'
2020-04-01 absl-team Googletest export
2020-03-30 absl-team Googletest export
2020-03-24 krystian.kuzniarek remove chapters on Autotools, Meson and plain Makefiles
2020-03-24 krystian.kuzniarek remove dead code in googletest-output-test
2020-03-24 pkryger Swap settimer and sigaction calls to avoid SIGPROF
2019-11-11 krystian.kuzniarek add documentation for the premature-exit-file protocol

Roll third_party/re2/ 209eda1b6..58141dc9c (3 commits)

https://github.com/google/re2/compare/209eda1b6079...58141dc9c921

$ git log 209eda1b6..58141dc9c --date=short --no-merges --format='%ad %ae %s'
2020-04-05 junyer Return the fanout histogram in a vector, not a map.
2020-04-05 junyer Optimise fanout bucketing.
2020-04-05 junyer Add Clang 10 to the Travis CI matrix.

Roll third_party/spirv-cross/ 9b3c5e12b..6637610b1 (7 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/9b3c5e12be12...6637610b16aa

$ git log 9b3c5e12b..6637610b1 --date=short --no-merges --format='%ad %ae %s'
2020-04-03 post Expose a query if samplers or images are comparison resources.
2020-04-03 post Do not add NonWritable/NonReadable decorations for regular images.
2020-04-03 post MSL: Deal with cases where builtin is implicitly needed, declared, but unused.
2020-04-03 post HLSL: Add support for treating NonWritable UAV texture as SRV instead.
2020-04-03 troughton MSL: mark BuiltInFragCoord as implicitly used for subpass reads
2020-03-31 post MSL: Fix access chain for deep struct hierarchy on array of buffers.
2020-03-30 dsinclair Roll GLSLang, SPIRV-Tools and SPIRV-Headers

Roll third_party/spirv-tools/ fd773eb50..e95fbfb1f (9 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/fd773eb50d62...e95fbfb1f509

$ git log fd773eb50..e95fbfb1f --date=short --no-merges --format='%ad %ae %s'
2020-04-02 afdx spirv-fuzz: Transformation to add OpConstantNull (#3273)
2020-04-02 afdx spirv-fuzz: Handle isomorphic types property in composite construction (#3262)
2020-04-02 afdx spirv-fuzz: Limit adding of new variables to 'basic' types (#3257)
2020-04-02 afdx spirv-fuzz: Only replace regular ids with synonyms (#3255)
2020-04-02 afdx spirv-fuzz: Introduce TransformationContext (#3272)
2020-04-02 afdx spirv-fuzz: Add validator options (#3254)
2020-04-02 alanbaker Update dominates to check for null nodes (#3271)
2020-04-01 alanbaker Set wrapped kill basic block's parent (#3269)
2020-03-31 caio.oliveira Validate Buffer and BufferBlock apply only to struct types (#3259)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools