### PR TITLE
Add concept of comparison sampler to API

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -92,10 +92,11 @@ typedef enum {
   shaderc_spvc_binding_type_storage_buffer = 0x00000001,
   shaderc_spvc_binding_type_readonly_storage_buffer = 0x00000002,
   shaderc_spvc_binding_type_sampler = 0x00000003,
-  shaderc_spvc_binding_type_sampled_texture = 0x00000004,
-  shaderc_spvc_binding_type_storage_texture = 0x00000005,
-  shaderc_spvc_binding_type_readonly_storage_texture = 0x00000006,
-  shaderc_spvc_binding_type_writeonly_storage_texture = 0x00000007,
+  shaderc_spvc_binding_type_comparison_sampler = 0x00000004,
+  shaderc_spvc_binding_type_sampled_texture = 0x00000005,
+  shaderc_spvc_binding_type_storage_texture = 0x00000006,
+  shaderc_spvc_binding_type_readonly_storage_texture = 0x00000007,
+  shaderc_spvc_binding_type_writeonly_storage_texture = 0x00000008,
 } shaderc_spvc_binding_type;
 
 typedef enum {

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -1066,6 +1066,21 @@ shaderc_spvc_status shaderc_spvc_get_binding_info(
             imageType.dim, imageType.arrayed);
         bindings->multisampled = imageType.ms;
       } break;
+      case shaderc_spvc_binding_type_sampler: {
+        // The inheritance hierarchy here is odd, it goes
+        // Compiler->CompilerGLSL->Compiler*. CompilerGLSL is an intermediate
+        // super class for all of the other leaf classes. The method we need is
+        // defined on CompilerGLSL, not Compiler.
+        // This cast is safe, since we only should ever have a CompilerGLSL or
+        // Compiler* in |cross_compiler|.
+        auto* glsl_compiler = reinterpret_cast<spirv_cross::CompilerGLSL*>(
+            context->cross_compiler.get());
+        if (glsl_compiler->variable_is_depth_or_compare(shader_resource.id)) {
+          bindings->binding_type = shaderc_spvc_binding_type_comparison_sampler;
+        } else {
+          bindings->binding_type = shaderc_spvc_binding_type_sampler;
+        }
+      } break;
       default:
         bindings->binding_type = binding_type;
     }


### PR DESCRIPTION
This exposes the data that is available from variable_is_depth_or_compar for
Dawn.

Fixes #1034