### PR TITLE
Rolling 5 dependencies and updating expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': 'b5757b95005bbf6b0287096c5b708c5e25645311',
+  'glslang_revision': '4d2298bfd78a82f77f2325c4ade096ccdab1f00d',
   'googletest_revision': 'e3f0319d89f4cbf32993de595d984183b1a9fc57',
-  're2_revision': '58141dc9c92189ed8d046f494f5e034d5db91bea',
-  'spirv_headers_revision': 'f8bf11a0253a32375c32cad92c841237b96696c0',
-  'spirv_tools_revision': 'e95fbfb1f509ad7a7fdfb72ac35fe412d72fc4a4',
-  'spirv_cross_revision': '6637610b16aacfe43c77ad4060da62008a83cd12',
+  're2_revision': 'ac65d4531798ffc9bf807d1f7c09efb0eec70480',
+  'spirv_headers_revision': '2ad0492fb00919d99500f1da74abf5ad3c870e4e',
+  'spirv_tools_revision': 'ca5751590ed751fba8abaae9b345663002878865',
+  'spirv_cross_revision': '54658d62559a364319cb222afe826d0d68c55ad0',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -41,6 +41,8 @@ shaders-msl/frag/barycentric-nv.msl22.frag,False
 shaders-msl/frag/barycentric-nv.msl22.frag,True
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,False
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,True
+shaders-msl/frag/disable-frag-output.frag-output.frag,False
+shaders-msl/frag/disable-frag-output.frag-output.frag,True
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,False
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,True
 shaders-msl/frag/image-query-lod.msl22.frag,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -65,6 +65,8 @@ shaders-msl/frag/barycentric-nv.msl22.frag,False
 shaders-msl/frag/barycentric-nv.msl22.frag,True
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,False
 shaders-msl/frag/buffer-read-write.texture-buffer-native.msl21.frag,True
+shaders-msl/frag/disable-frag-output.frag-output.frag,False
+shaders-msl/frag/disable-frag-output.frag-output.frag,True
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,False
 shaders-msl/frag/huge-argument-buffer.device-argument-buffer.argument.msl2.frag,True
 shaders-msl/frag/image-query-lod.msl22.frag,False


### PR DESCRIPTION
Roll third_party/glslang/ b5757b950..4d2298bfd (5 commits)

https://github.com/KhronosGroup/glslang/compare/b5757b95005b...4d2298bfd78a

$ git log b5757b950..4d2298bfd --date=short --no-merges --format='%ad %ae %s'
2020-04-13 cnorthrop Support multiple swizzled out operands (#2175)
2020-04-12 cepheus Fix #2178: Allow specialization constants for texel offsets.
2020-04-10 h.baensch.92 Get rid of all warnings with MSVC and clang-cl (#2177)
2020-04-08 40001162+alelenv Add support for EXT_ray_flags_primitive_culling. (#2173)
2020-04-07 cepheus Error message: Finish addressing #2097, better texture error message.

Roll third_party/re2/ 58141dc9c..ac65d4531 (2 commits)

https://github.com/google/re2/compare/58141dc9c921...ac65d4531798

$ git log 58141dc9c..ac65d4531 --date=short --no-merges --format='%ad %ae %s'
2020-04-09 junyer Remove deprecated APIs. Bump SONAME accordingly.
2020-04-06 junyer Go back to using __builtin_ctzll(). Sigh.

Roll third_party/spirv-cross/ 6637610b1..54658d625 (3 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/6637610b16aa...54658d62559a

$ git log 6637610b1..54658d625 --date=short --no-merges --format='%ad %ae %s'
2020-04-10 cdavis MSL: Add options to control emission of fragment outputs.
2020-04-09 h.baensch.92 Improve compatibility with clang-cl
2020-04-07 post MSL: Do not use base expression with PhysicalTypeID OpCompositeExtract.

Roll third_party/spirv-headers/ f8bf11a02..2ad0492fb (1 commit)

https://github.com/KhronosGroup/SPIRV-Headers/compare/f8bf11a0253a...2ad0492fb009

$ git log f8bf11a02..2ad0492fb --date=short --no-merges --format='%ad %ae %s'
2020-04-13 cepheus Discuss generator magic number reservations.

Roll third_party/spirv-tools/ e95fbfb1f..ca5751590 (9 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/e95fbfb1f509...ca5751590ed7

$ git log e95fbfb1f..ca5751590 --date=short --no-merges --format='%ad %ae %s'
2020-04-14 dneto If SPIRV-Headers is in our tree, include it as subproject (#3299)
2020-04-13 stevenperron Struct CFG analysus and single block loop (#3293)
2020-04-13 jaebaek Preserve debug info in eliminate-dead-functions (#3251)
2020-04-13 stevenperron Update acorn version (#3294)
2020-04-09 stevenperron Handle more cases in dead member elim (#3289)
2020-04-09 h.baensch.92 Fix pch macro to ignore clang-cl (#3283)
2020-04-07 afdx spirv-fuzz: Improve the handling of equation facts (#3281)
2020-04-07 afdx spirv-fuzz: Handle more general SPIR-V in donation (#3280)
2020-04-06 afdx spirv-fuzz: Improve support for compute shaders in donation (#3277)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools