### PR TITLE
Rolling 6 dependencies and update expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,13 +4,13 @@ vars = {
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
 
-  'effcee_revision' : '98980e2b785403b5f43c23ed5a81e1a22e7297e8',
-  'glslang_revision': '4d2298bfd78a82f77f2325c4ade096ccdab1f00d',
-  'googletest_revision': 'e3f0319d89f4cbf32993de595d984183b1a9fc57',
-  're2_revision': 'ac65d4531798ffc9bf807d1f7c09efb0eec70480',
+  'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
+  'glslang_revision': '3f4e5c4563068f277141f5fb3d96ec02afc7ac95',
+  'googletest_revision': 'dcc92d0ab6c4ce022162a23566d44f673251eee4',
+  're2_revision': 'a5c78ae3ea906cdbd759d83511509a985b4b3c8f',
   'spirv_headers_revision': '2ad0492fb00919d99500f1da74abf5ad3c870e4e',
-  'spirv_tools_revision': 'ca5751590ed751fba8abaae9b345663002878865',
-  'spirv_cross_revision': '54658d62559a364319cb222afe826d0d68c55ad0',
+  'spirv_tools_revision': '61b7de3c39f01a0eeb717f444c86990547752e26',
+  'spirv_cross_revision': 'f38cbeb814c73510b85697adbe5e894f9eac978f',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -13,6 +13,7 @@ shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,False
 shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,True
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
+shaders-hlsl/frag/tex-sampling.frag,True
 shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
 shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
 shaders-msl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
@@ -24,8 +25,12 @@ shaders-msl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-msl-no-opt/vert/pass-array-by-value.force-native-array.vert,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,True
+shaders-msl/asm/frag/disable-renamed-output.frag-output.asm.frag,False
+shaders-msl/asm/frag/disable-renamed-output.frag-output.asm.frag,True
 shaders-msl/asm/frag/min-lod.msl22.asm.frag,False
 shaders-msl/asm/frag/min-lod.msl22.asm.frag,True
+shaders-msl/asm/vert/clip-distance-plain-variable.no-user-varying.asm.vert,False
+shaders-msl/asm/vert/clip-distance-plain-variable.no-user-varying.asm.vert,True
 shaders-msl/comp/basic.dispatchbase.comp,False
 shaders-msl/comp/basic.dispatchbase.comp,True
 shaders-msl/comp/basic.dispatchbase.msl11.comp,False
@@ -35,6 +40,9 @@ shaders-msl/comp/basic.inline-block.msl2.comp,True
 shaders-msl/comp/composite-array-initialization.force-native-array.comp,False
 shaders-msl/comp/composite-array-initialization.force-native-array.comp,True
 shaders-msl/comp/copy-array-of-arrays.force-native-array.comp,False
+shaders-msl/desktop-only/vert/clip-cull-distance..no-user-varying.desktop.vert,False
+shaders-msl/desktop-only/vert/clip-cull-distance..no-user-varying.desktop.vert,True
+shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag,True
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,True
 shaders-msl/frag/barycentric-nv.msl22.frag,False
@@ -49,8 +57,11 @@ shaders-msl/frag/image-query-lod.msl22.frag,False
 shaders-msl/frag/image-query-lod.msl22.frag,True
 shaders-msl/frag/subgroup-builtins.msl22.frag,False
 shaders-msl/frag/subgroup-builtins.msl22.frag,True
+shaders-msl/frag/swizzle.frag,True
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,False
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,True
+shaders-msl/vert/clip-distance-block.no-user-varying.vert,False
+shaders-msl/vert/clip-distance-block.no-user-varying.vert,True
 shaders-msl/vert/float-math.invariant-float-math.vert,False
 shaders-msl/vert/float-math.invariant-float-math.vert,True
 shaders-msl/vert/return-array.force-native-array.vert,False
@@ -93,3 +104,4 @@ shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
 shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,False
 shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,True
+shaders/frag/swizzle.frag,True

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -18,6 +18,7 @@ shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,False
 shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,True
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
+shaders-hlsl/frag/tex-sampling.frag,True
 shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
 shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
 shaders-msl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
@@ -48,8 +49,12 @@ shaders-msl-no-opt/packing/struct-packing.comp,False
 shaders-msl-no-opt/vert/pass-array-by-value.force-native-array.vert,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,True
+shaders-msl/asm/frag/disable-renamed-output.frag-output.asm.frag,False
+shaders-msl/asm/frag/disable-renamed-output.frag-output.asm.frag,True
 shaders-msl/asm/frag/min-lod.msl22.asm.frag,False
 shaders-msl/asm/frag/min-lod.msl22.asm.frag,True
+shaders-msl/asm/vert/clip-distance-plain-variable.no-user-varying.asm.vert,False
+shaders-msl/asm/vert/clip-distance-plain-variable.no-user-varying.asm.vert,True
 shaders-msl/comp/basic.dispatchbase.comp,False
 shaders-msl/comp/basic.dispatchbase.comp,True
 shaders-msl/comp/basic.dispatchbase.msl11.comp,False
@@ -59,6 +64,9 @@ shaders-msl/comp/basic.inline-block.msl2.comp,True
 shaders-msl/comp/composite-array-initialization.force-native-array.comp,False
 shaders-msl/comp/composite-array-initialization.force-native-array.comp,True
 shaders-msl/comp/copy-array-of-arrays.force-native-array.comp,False
+shaders-msl/desktop-only/vert/clip-cull-distance..no-user-varying.desktop.vert,False
+shaders-msl/desktop-only/vert/clip-cull-distance..no-user-varying.desktop.vert,True
+shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag,True
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,True
 shaders-msl/frag/barycentric-nv.msl22.frag,False
@@ -73,8 +81,11 @@ shaders-msl/frag/image-query-lod.msl22.frag,False
 shaders-msl/frag/image-query-lod.msl22.frag,True
 shaders-msl/frag/subgroup-builtins.msl22.frag,False
 shaders-msl/frag/subgroup-builtins.msl22.frag,True
+shaders-msl/frag/swizzle.frag,True
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,False
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,True
+shaders-msl/vert/clip-distance-block.no-user-varying.vert,False
+shaders-msl/vert/clip-distance-block.no-user-varying.vert,True
 shaders-msl/vert/float-math.invariant-float-math.vert,False
 shaders-msl/vert/float-math.invariant-float-math.vert,True
 shaders-msl/vert/return-array.force-native-array.vert,False
@@ -129,3 +140,4 @@ shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
 shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,False
 shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,True
+shaders/frag/swizzle.frag,True


### PR DESCRIPTION
Roll third_party/effcee/ 98980e2b7..5af957bbf (1 commit)

https://github.com/google/effcee/compare/98980e2b7854...5af957bbfc7d

$ git log 98980e2b7..5af957bbf --date=short --no-merges --format='%ad %ae %s'
2019-12-20 raj.khem Respect CMAKE_INSTALL_LIBDIR in installed CMake files

Roll third_party/glslang/ 4d2298bfd..3f4e5c456 (2 commits)

https://github.com/KhronosGroup/glslang/compare/4d2298bfd78a...3f4e5c456306

$ git log 4d2298bfd..3f4e5c456 --date=short --no-merges --format='%ad %ae %s'
2020-04-19 63069047+pmistryNV Add support for extension GL_ARB_shader_image_size (#2185)
2020-04-17 63069047+pmistryNV Add support for extension GL_ARB_shader_bit_encoding (#2183)

Roll third_party/googletest/ e3f0319d8..dcc92d0ab (7 commits)

https://github.com/google/googletest/compare/e3f0319d89f4...dcc92d0ab6c4

$ git log e3f0319d8..dcc92d0ab --date=short --no-merges --format='%ad %ae %s'
2020-04-10 absl-team Googletest export
2020-04-12 jbohl fix signed/unsigned comparison issue (on OpenBSD)
2020-04-09 malcolm.parsons Remove redundant .c_str()
2020-04-06 mail gtest-unittest-api_test - fix warning in clang build
2020-03-28 arthur.j.odwyer Replace the last instance of `throw()` with `noexcept`. NFC.
2020-03-28 arthur.j.odwyer Fix a typo in .travis.yml
2020-03-21 ngompa13 Ensure that gtest/gmock pkgconfig requirements specify version

Roll third_party/re2/ ac65d4531..a5c78ae3e (1 commit)

https://github.com/google/re2/compare/ac65d4531798...a5c78ae3ea90

$ git log ac65d4531..a5c78ae3e --date=short --no-merges --format='%ad %ae %s'
2020-04-19 junyer Use 64-bit integers for the BitState bitmap.

Roll third_party/spirv-cross/ 54658d625..f38cbeb81 (4 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/54658d62559a...f38cbeb814c7

$ git log 54658d625..f38cbeb81 --date=short --no-merges --format='%ad %ae %s'
2020-04-20 post MSL: Allow removing clip distance user varyings.
2020-04-18 godlike Reflection: Add specialization constant name
2020-04-15 cdavis MSL: Force disabled fragment builtins to have the right name.
2020-04-15 cdavis MSL: Only disable output variables in fragment shaders.

Roll third_party/spirv-tools/ ca5751590..61b7de3c3 (10 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/ca5751590ed7...61b7de3c39f0

$ git log ca5751590..61b7de3c3 --date=short --no-merges --format='%ad %ae %s'
2020-04-15 stevenperron Remove unreachable code. (#3304)
2020-04-15 afdx spirv-fuzz: Fix to outliner (#3302)
2020-04-14 afdx spirv-fuzz: Do not outline regions that produce pointer outputs (#3291)
2020-04-14 afdx spirv-fuzz: Handle OpRuntimeArray when replacing ids with synonyms (#3292)
2020-04-14 afdx spirv-fuzz: Handle image storage class in donation (#3290)
2020-04-14 afdx spirv-fuzz: Respect rules for OpSampledImage (#3287)
2020-04-14 afdx spirv-fuzz: Fix comment. (#3300)
2020-04-14 stevenperron Sampled images as read-only storage (#3295)
2020-04-14 alanbaker Remove implicit fallthrough (#3298)
2020-04-14 stevenperron Add tests for recently added command line option (#3297)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools