### PR TITLE
Rolling 5 dependencies, updating expectations, and fixing build issues

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'glslang_revision': '3f4e5c4563068f277141f5fb3d96ec02afc7ac95',
+  'glslang_revision': 'f03cb290ac10414dfc96017b26ebfaee8f3afb3e',
   'googletest_revision': 'dcc92d0ab6c4ce022162a23566d44f673251eee4',
-  're2_revision': 'a5c78ae3ea906cdbd759d83511509a985b4b3c8f',
-  'spirv_headers_revision': '2ad0492fb00919d99500f1da74abf5ad3c870e4e',
-  'spirv_tools_revision': '61b7de3c39f01a0eeb717f444c86990547752e26',
-  'spirv_cross_revision': 'f38cbeb814c73510b85697adbe5e894f9eac978f',
+  're2_revision': '209319c1bf57098455547c5779659614e62f3f05',
+  'spirv_headers_revision': 'c0df742ec0b8178ad58c68cff3437ad4b6a06e26',
+  'spirv_tools_revision': 'd0a87194f7b9a3b7659e837b08cd404ccc8af222',
+  'spirv_cross_revision': '7e0295abf81cc939ecb2644c88592d77407d18d3',
 }
 
 deps = {

--- a/libshaderc_spvc/src/spvcir_pass.cc
+++ b/libshaderc_spvc/src/spvcir_pass.cc
@@ -725,10 +725,10 @@ void SpvcIrPass::GenerateSpirvCrossIR(Instruction *inst) {
     }
 
       // opcode: 5341
-    case SpvOpTypeAccelerationStructureNV: {
+    case SpvOpTypeAccelerationStructureKHR: {
       uint32_t id = inst->result_id();
       auto &type = set<spirv_cross::SPIRType>(id);
-      type.basetype = spirv_cross::SPIRType::AccelerationStructureNV;
+      type.basetype = spirv_cross::SPIRType::AccelerationStructure;
       break;
     }
 

--- a/libshaderc_spvc/src/spvcir_test.cc
+++ b/libshaderc_spvc/src/spvcir_test.cc
@@ -623,7 +623,7 @@ TEST_F(SpvcIrParsingTest, OpTypeFunctionInstruction) {
 TEST_F(SpvcIrParsingTest, OpTypeAccelerationStructureNVInstruction) {
   const std::vector<const char*> middle = {
       // clang-format off
-      "%10 = OpTypeAccelerationStructureNV"
+      "%10 = OpTypeAccelerationStructureKHR"
       // clang-format on
   };
   std::string spirv = JoinAllInsts(Concat(Concat(before_, middle), after_));
@@ -638,7 +638,7 @@ TEST_F(SpvcIrParsingTest, OpTypeAccelerationStructureNVInstruction) {
 
   auto spir_var = maybe_get<spirv_cross::SPIRType>(10, &ir);
   ASSERT_NE(spir_var, nullptr);
-  EXPECT_EQ(spir_var->basetype, spirv_cross::SPIRType::AccelerationStructureNV);
+  EXPECT_EQ(spir_var->basetype, spirv_cross::SPIRType::AccelerationStructure);
 }
 
 

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -13,7 +13,6 @@ shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,False
 shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,True
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
-shaders-hlsl/frag/tex-sampling.frag,True
 shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
 shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
 shaders-msl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
@@ -21,6 +20,7 @@ shaders-msl-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-msl-no-opt/comp/basic.dynamic-buffer.msl2.invalid.comp,False
 shaders-msl-no-opt/comp/int64.invalid.msl22.comp,False
 shaders-msl-no-opt/frag/force-active-resources.msl2.argument..force-active.discrete.frag,False
+shaders-msl-no-opt/frag/subpass-input-function-argument.framebuffer-fetch.ios.frag,False
 shaders-msl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-msl-no-opt/vert/pass-array-by-value.force-native-array.vert,False
 shaders-msl/asm/comp/multiple-entry.asm.comp,False
@@ -42,7 +42,6 @@ shaders-msl/comp/composite-array-initialization.force-native-array.comp,True
 shaders-msl/comp/copy-array-of-arrays.force-native-array.comp,False
 shaders-msl/desktop-only/vert/clip-cull-distance..no-user-varying.desktop.vert,False
 shaders-msl/desktop-only/vert/clip-cull-distance..no-user-varying.desktop.vert,True
-shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag,True
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,True
 shaders-msl/frag/barycentric-nv.msl22.frag,False
@@ -57,7 +56,6 @@ shaders-msl/frag/image-query-lod.msl22.frag,False
 shaders-msl/frag/image-query-lod.msl22.frag,True
 shaders-msl/frag/subgroup-builtins.msl22.frag,False
 shaders-msl/frag/subgroup-builtins.msl22.frag,True
-shaders-msl/frag/swizzle.frag,True
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,False
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,True
 shaders-msl/vert/clip-distance-block.no-user-varying.vert,False
@@ -104,4 +102,3 @@ shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
 shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,False
 shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,True
-shaders/frag/swizzle.frag,True

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -18,7 +18,6 @@ shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,False
 shaders-hlsl/frag/readonly-coherent-ssbo.force-uav.frag,True
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,False
 shaders-hlsl/frag/separate-combined-fake-overload.sm30.frag,True
-shaders-hlsl/frag/tex-sampling.frag,True
 shaders-msl-no-opt/asm/comp/copy-logical-2.spv14.asm.comp,False
 shaders-msl-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
 shaders-msl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
@@ -27,6 +26,13 @@ shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-3.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-5.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding.asm.comp,False
 shaders-msl-no-opt/asm/packing/packed-vector-extract-insert.asm.comp,False
+shaders-msl-no-opt/asm/packing/scalar-array-float2.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-array-float3-one-element.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-array-float3.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float2x2-col-major.invalid.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float2x3-col-major.invalid.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float3x2-col-major.invalid.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float3x3-col-major.invalid.asm.frag,False
 shaders-msl-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-msl-no-opt/comp/basic.dynamic-buffer.msl2.invalid.comp,False
 shaders-msl-no-opt/comp/int64.invalid.msl22.comp,False
@@ -35,6 +41,7 @@ shaders-msl-no-opt/frag/force-active-resources.msl2.argument..force-active.discr
 shaders-msl-no-opt/frag/fp16.desktop.invalid.frag,False
 shaders-msl-no-opt/frag/min-max-clamp.invalid.asm.frag,False
 shaders-msl-no-opt/frag/shadow-compare-global-alias.invalid.frag,False
+shaders-msl-no-opt/frag/subpass-input-function-argument.framebuffer-fetch.ios.frag,False
 shaders-msl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-msl-no-opt/packing/array-of-vec3.comp,False
 shaders-msl-no-opt/packing/load-store-col-rows.comp,False
@@ -66,7 +73,6 @@ shaders-msl/comp/composite-array-initialization.force-native-array.comp,True
 shaders-msl/comp/copy-array-of-arrays.force-native-array.comp,False
 shaders-msl/desktop-only/vert/clip-cull-distance..no-user-varying.desktop.vert,False
 shaders-msl/desktop-only/vert/clip-cull-distance..no-user-varying.desktop.vert,True
-shaders-msl/frag/array-of-texture-swizzle.msl2.argument.discrete.swizzle.frag,True
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,False
 shaders-msl/frag/barycentric-nv-nopersp.msl22.frag,True
 shaders-msl/frag/barycentric-nv.msl22.frag,False
@@ -81,7 +87,6 @@ shaders-msl/frag/image-query-lod.msl22.frag,False
 shaders-msl/frag/image-query-lod.msl22.frag,True
 shaders-msl/frag/subgroup-builtins.msl22.frag,False
 shaders-msl/frag/subgroup-builtins.msl22.frag,True
-shaders-msl/frag/swizzle.frag,True
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,False
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,True
 shaders-msl/vert/clip-distance-block.no-user-varying.vert,False
@@ -140,4 +145,3 @@ shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False
 shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,False
 shaders/desktop-only/frag/image-size.no-qualifier-deduction.frag,True
-shaders/frag/swizzle.frag,True

--- a/spvc/test/unconfirmed_invalids
+++ b/spvc/test/unconfirmed_invalids
@@ -29,3 +29,10 @@ shaders-no-opt/asm/frag/switch-merge-to-continue.asm.invalid.frag,False
 shaders-no-opt/frag/16bit-constants.invalid.frag,False
 shaders-no-opt/frag/fp16.invalid.desktop.frag,False
 shaders-no-opt/frag/multi-dimensional.desktop.invalid.flatten_dim.frag,False
+shaders-msl-no-opt/asm/packing/scalar-array-float2.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-array-float3-one-element.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-array-float3.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float2x2-col-major.invalid.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float2x3-col-major.invalid.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float3x2-col-major.invalid.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float3x3-col-major.invalid.asm.frag,False


### PR DESCRIPTION
Roll third_party/glslang/ 3f4e5c456..f03cb290a (9 commits)

https://github.com/KhronosGroup/glslang/compare/3f4e5c456306...f03cb290ac10

$ git log 3f4e5c456..f03cb290a --date=short --no-merges --format='%ad %ae %s'
2020-04-27 63069047+pmistryNV Add support for extension GL_ARB_texture_query_lod. (#2194)
2020-04-28 dj2 Remove unused Es310Desktop430 (#2200)
2020-04-27 63069047+pmistryNV Add support for extension GL_ARB_shading_language_packing (#2192)
2020-04-27 cepheus Move to SPIR-V 1.5 Rev. 3, bump revision, remove a status from README.
2020-04-24 johnkslang Note about Build Status.
2020-04-24 cepheus Move to latest SPIR-V header, and bump glslang revision.
2020-04-22 63069047+pmistryNV Add support for extension GL_ARB_shader_storage_buffer_object (#2184)
2020-04-22 antidote.crk TPpToken: Fix compiling on clang-10 (#2189)
2020-04-21 mennovink20 xcode warnings fix (#2188)

Roll third_party/re2/ a5c78ae3e..209319c1b (5 commits)

https://github.com/google/re2/compare/a5c78ae3ea90...209319c1bf57

$ git log a5c78ae3e..209319c1b --date=short --no-merges --format='%ad %ae %s'
2020-04-23 junyer Compute first_byte_ eagerly.
2020-04-23 junyer Remove unused flags_ member from Prog class.
2020-04-23 junyer Replace some uses of "LL" and "ULL" suffixes.
2020-04-21 junyer Explain the need for double backslashes.
2020-04-20 junyer Remove memrchr() and the logic that calls it.

Roll third_party/spirv-cross/ f38cbeb81..7e0295abf (17 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/f38cbeb814c7...7e0295abf81c

$ git log f38cbeb81..7e0295abf --date=short --no-merges --format='%ad %ae %s'
2020-04-28 rharrison Update SPIR-V Headers to 1.5 rev 3
2020-04-27 post Work around odd deadlock in test_shaders.py in --parallel mode.
2020-04-27 post Implement OpAtomicLoad/OpAtomicStore.
2020-04-27 post MSL: Fix case where subpassInput is passed to leaf functions.
2020-04-27 alexis.payen Fixed recursion in combined_decoration_for_member Members in nested structs were not properly iterated on, and as a result, flags like row major for matrices could be not propagated properly.
2020-04-23 dsinclair Roll GLSLang, SPIRV-Tools and SPIRV-Headers.
2020-04-21 post GLSL: Support f16x2 <-> f32 bitcast.
2020-04-21 post Be a bit more careful what nonuniform state is propagated.
2020-04-21 post Handle RayQueryKHR type.
2020-04-21 post Update SPIR-V headers.
2020-04-18 devsh.graphicsprogramming Fix issue #1327
2020-04-21 post HLSL: Add parens in unpackUint2x32 for clarity.
2020-04-21 post HLSL: Only allow 64-bit integers in SM 6.0.
2020-04-21 post Ensure unpack/pack2x32 tests are compatible with test suite.
2020-04-17 bingkan GLSL/HLSL: Support packUint2x32 and unpackUint2x32
2020-04-21 post MSL: Deal correctly with initializers on Private variables.
2020-04-20 post MSL: Support edge case with DX layout in scalar block layout.

Roll third_party/spirv-headers/ 2ad0492fb..c0df742ec (5 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/2ad0492fb009...c0df742ec0b8

$ git log 2ad0492fb..c0df742ec --date=short --no-merges --format='%ad %ae %s'
2020-04-24 cepheus Update headers to SPIR-V 1.5 Revision 3
2020-04-24 cepheus Add a bunch of missing "version" : "None" for ray tracing.
2020-04-24 cepheus Rebuild the headers with the fixed grammar file.
2020-04-24 cepheus Add missing "version" : "None" for ShaderCallKHR
2020-04-24 cepheus Grammar: The ray-tracing updates were not done in numerical ordering.

Roll third_party/spirv-tools/ 61b7de3c3..d0a87194f (12 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/61b7de3c39f0...d0a87194f7b9

$ git log 61b7de3c3..d0a87194f --date=short --no-merges --format='%ad %ae %s'
2020-04-28 jaebaek Set DebugScope for termination instructions (#3323)
2020-04-28 afdx spirv-fuzz: Do not outline regions that end with a loop header (#3312)
2020-04-27 bclayton vscode: Handle '|' chains on BitEnum / ValueEnum (#3309)
2020-04-27 jaebaek Add debug information analysis (#3305)
2020-04-27 dneto Add spvtools::opt::Operand::AsLiteralUint64 (#3320)
2020-04-27 afdx spirv-fuzz: Pass on validator options during shrinking (#3317)
2020-04-27 afdx spirv-fuzz: Clamp statically out-of-bounds accesses in code donation (#3315)
2020-04-27 afdx spirv-fuzz: Fix memory management in the fact manager (#3313)
2020-04-27 afdx spirv-fuzz: Do not replace the Sample argument in OpImageTexelPointer (#3311)
2020-04-23 afdx Allow various validation options to be passed to spirv-opt (#3314)
2020-04-23 Chaitanyas0101 typo fix: in README.md exectuable->executable (#3306)
2020-04-20 afdx spirv-fuzz: Make handling of synonym facts more efficient (#3301)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools