### PR TITLE
Rolling 5 dependencies and fixing build

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'glslang_revision': 'f03cb290ac10414dfc96017b26ebfaee8f3afb3e',
-  'googletest_revision': 'dcc92d0ab6c4ce022162a23566d44f673251eee4',
-  're2_revision': '209319c1bf57098455547c5779659614e62f3f05',
+  'glslang_revision': 'b5f003d7a3ece37db45578a8a3140b370036fc64',
+  'googletest_revision': '0eea2e9fc63461761dea5f2f517bd6af2ca024fa',
+  're2_revision': '8aef3d19dba9feae76881c30fb8e88c420c140c5',
   'spirv_headers_revision': 'c0df742ec0b8178ad58c68cff3437ad4b6a06e26',
-  'spirv_tools_revision': 'd0a87194f7b9a3b7659e837b08cd404ccc8af222',
-  'spirv_cross_revision': '7e0295abf81cc939ecb2644c88592d77407d18d3',
+  'spirv_tools_revision': '2e1d208ed9deab9048a00e60bb891d5e12a8332e',
+  'spirv_cross_revision': '92f7d36c72bc3cdbcc4aeff3534d096866013c0c',
 }
 
 deps = {

--- a/libshaderc_util/src/resources.cc
+++ b/libshaderc_util/src/resources.cc
@@ -125,7 +125,7 @@ const TBuiltInResource kDefaultTBuiltInResource = {
     /* .maxTaskWorkGroupSizeY_NV = */ 1,
     /* .maxTaskWorkGroupSizeZ_NV = */ 1,
     /* .maxMeshViewCountNV = */ 4,
-
+    /* .maxDualSourceDrawBuffersEXT = */ 1,
     // This is the glslang TLimits structure.
     // It defines whether or not the following features are enabled.
     // We want them to all be enabled.


### PR DESCRIPTION
Roll third_party/glslang/ f03cb290a..b5f003d7a (7 commits)

https://github.com/KhronosGroup/glslang/compare/f03cb290ac10...b5f003d7a3ec

$ git log f03cb290a..b5f003d7a --date=short --no-merges --format='%ad %ae %s'
2020-05-01 cepheus Fix #2191: Error check for indexing reference containing unsize array.
2020-05-01 cepheus GLSL: Separate out swizzle handling (potentially fixing bugs).
2020-04-21 pmistry Add support for es extension GL_EXT_blend_func_extended * Introduces builtin variables gl_SecondaryFragColorEXT and gl_SecondaryFragDataEXT * Introduces builtin constant gl_MaxDualSourceDrawBuffersEXT * enables support for layout qualifier "index" in es profile
2020-04-30 63069047+pmistryNV Add support for extension GL_EXT_shader_integer_mix (#2203)
2020-04-26 pmistry Add support for extension GL_EXT_shader_implicit_conversions Updated extension management in TIntermediate class.
2020-04-30 cepheus Fix #2201: Improve const and copy constructor for TVarLivePair.
2020-04-29 63069047+pmistryNV Add support for extension GL_ARB_vertex_attrib_64bit (#2193)

Roll third_party/googletest/ dcc92d0ab..0eea2e9fc (16 commits)

https://github.com/google/googletest/compare/dcc92d0ab6c4...0eea2e9fc634

$ git log dcc92d0ab..0eea2e9fc --date=short --no-merges --format='%ad %ae %s'
2020-04-30 absl-team Googletest export
2020-04-28 absl-team Googletest export
2020-04-27 absl-team Googletest export
2020-04-24 absl-team Googletest export
2020-04-23 absl-team Googletest export
2020-04-20 absl-team Googletest export
2020-04-20 absl-team Googletest export
2020-04-17 absl-team Googletest export
2020-03-28 arthur.j.odwyer Add -Wdeprecated to the build configuration.
2020-04-16 arthur.j.odwyer Fix a -Wdeprecated warning.
2020-04-16 arthur.j.odwyer Fix a -Wdeprecated warning.
2020-04-16 arthur.j.odwyer Fix a -Wdeprecated warning.
2020-04-16 arthur.j.odwyer Remove all uses of GTEST_DISALLOW_{MOVE_,}ASSIGN_.
2020-04-19 igor.n.nazarenko Enable protobuf printing for open-source proto messages.
2020-04-16 arthur.j.odwyer VariadicMatcher needs a non-defaulted move constructor for compile-time performance.
2020-04-05 jijyunneng Remove duplicate codes existed in get-nprocessors.sh

Roll third_party/re2/ 209319c1b..8aef3d19d (1 commit)

https://github.com/google/re2/compare/209319c1bf57...8aef3d19dba9

$ git log 209319c1b..8aef3d19d --date=short --no-merges --format='%ad %ae %s'
2020-05-02 junyer `^' is a caret, not a carat.

Roll third_party/spirv-cross/ 7e0295abf..92f7d36c7 (2 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/7e0295abf81c...92f7d36c72bc

$ git log 7e0295abf..92f7d36c7 --date=short --no-merges --format='%ad %ae %s'
2020-04-30 post MSL: Redirect member indices when buffer has been sorted by Offset.
2020-04-30 cwallez Fix -Wmicrosoft-enum-value

Roll third_party/spirv-tools/ d0a87194f..2e1d208ed (4 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/d0a87194f7b9...2e1d208ed9de

$ git log d0a87194f..2e1d208ed --date=short --no-merges --format='%ad %ae %s'
2020-05-01 afdx spirv-fuzz: Do not allow adding stores to read-only pointers (#3316)
2020-04-30 paulthomson reduce: increase default step limit (#3327)
2020-04-30 afdx Generalize IsReadOnlyVariable() to apply to pointers (#3325)
2020-04-28 stevenperron Delete nullptr in function bb list immedietly (#3326)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools

Fixes #1056