### PR TITLE
Rolling 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,11 +6,11 @@ vars = {
 
   'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
   'glslang_revision': 'b5f003d7a3ece37db45578a8a3140b370036fc64',
-  'googletest_revision': '0eea2e9fc63461761dea5f2f517bd6af2ca024fa',
-  're2_revision': '8aef3d19dba9feae76881c30fb8e88c420c140c5',
+  'googletest_revision': 'a09ea700d32bab83325aff9ff34d0582e50e3997',
+  're2_revision': '887c8072fbbc52017e768484e339cab2c8091ee5',
   'spirv_headers_revision': 'c0df742ec0b8178ad58c68cff3437ad4b6a06e26',
-  'spirv_tools_revision': '2e1d208ed9deab9048a00e60bb891d5e12a8332e',
-  'spirv_cross_revision': '92f7d36c72bc3cdbcc4aeff3534d096866013c0c',
+  'spirv_tools_revision': 'c8590c18bd0c70dcd1caa7d43c5f2d020439b012',
+  'spirv_cross_revision': 'd638d2df9c8c4a862e0af829cf49cc6dcbb235a2',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/googletest/ 0eea2e9fc..a09ea700d (4 commits)

https://github.com/google/googletest/compare/0eea2e9fc634...a09ea700d32b

$ git log 0eea2e9fc..a09ea700d --date=short --no-merges --format='%ad %ae %s'
2020-05-07 absl-team Googletest export
2020-05-04 absl-team Googletest export
2020-05-01 56075233+keshavgbpecdelhi Removed a typo in README.md
2020-03-18 calum.robinson Add GTEST_BRIEF option

Roll third_party/re2/ 8aef3d19d..887c8072f (3 commits)

https://github.com/google/re2/compare/8aef3d19dba9...887c8072fbbc

$ git log 8aef3d19d..887c8072f --date=short --no-merges --format='%ad %ae %s'
2020-05-11 junyer Refactor Regexp::RequiredPrefix().
2020-05-10 junyer Lower the memory budget in TestCompile.InsufficientMemory.
2020-05-05 junyer Remove first_byte from StartInfo and simplify accordingly.

Roll third_party/spirv-cross/ 92f7d36c7..d638d2df9 (4 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/92f7d36c72bc...d638d2df9c8c

$ git log 92f7d36c7..d638d2df9 --date=short --no-merges --format='%ad %ae %s'
2020-05-08 post Support gl_InstanceID in RT shaders.
2020-05-06 post MSL: Avoid packed arrays in more cases.
2020-05-06 post Add missing reference files from PR merge.
2020-05-06 lehoangq Fix #1359: MSL: If the packed type is scalar, don't emit "pack_" prefix.

Roll third_party/spirv-tools/ 2e1d208ed..c8590c18b (2 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/2e1d208ed9de...c8590c18bd0c

$ git log 2e1d208ed..c8590c18b --date=short --no-merges --format='%ad %ae %s'
2020-05-06 jaebaek Preserve debug info for wrap-opkill (#3331)
2020-05-05 jbolz Validate ShaderCallKHR memory scope (#3332)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools