### PR TITLE
Rewrite mutex initialization for GlslangInitializer

### DIFF
--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -52,10 +52,13 @@ class GlslangInitializer {
 
  private:
   static unsigned int initialize_count_;
+  static std::once_flag initialize_lock_flag_;
 
   // Using a bare pointer here to avoid any global class construction at the
   // beginning of the execution.
   static std::mutex* glslang_mutex_;
+
+  void InitializeLock();
 };
 
 // Maps macro names to their definitions.  Stores string_pieces, so the


### PR DESCRIPTION
This uses more modern C++ and is slightly faster if a user naively
creates and destroys instances of shaderc instead of retaining it.