### PR TITLE
Rolling 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'glslang_revision': 'b5f003d7a3ece37db45578a8a3140b370036fc64',
-  'googletest_revision': 'a09ea700d32bab83325aff9ff34d0582e50e3997',
-  're2_revision': '887c8072fbbc52017e768484e339cab2c8091ee5',
+  'glslang_revision': '2e0f0a0517e4251ac8e0d6fd46e92af33fcb800d',
+  'googletest_revision': '011959aafddcd30611003de96cfd8d7a7685c700',
+  're2_revision': '52b4b94b00f094d4a86c9b6bbb8276b21ec53505',
   'spirv_headers_revision': 'c0df742ec0b8178ad58c68cff3437ad4b6a06e26',
-  'spirv_tools_revision': 'c8590c18bd0c70dcd1caa7d43c5f2d020439b012',
-  'spirv_cross_revision': 'd638d2df9c8c4a862e0af829cf49cc6dcbb235a2',
+  'spirv_tools_revision': '2b987c49a4e1558117095ad3b77c55fef7aa63ef',
+  'spirv_cross_revision': '29ad40e93ed826cfa04da0326a0cfd8717f88583',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ b5f003d7a..2e0f0a051 (12 commits)

https://github.com/KhronosGroup/glslang/compare/b5f003d7a3ec...2e0f0a0517e4

$ git log b5f003d7a..2e0f0a051 --date=short --no-merges --format='%ad %ae %s'
2020-05-20 cepheus Fix #2227, which was coded incorrectly, to be simpler/safer.
2020-05-19 cepheus Build: Fix #2228, by correcting the type used.
2020-05-20 lryer Code refine. (#2227)
2020-05-18 laddoc Add check for DOUBLE in low versions (#2223)
2020-05-18 greg Flatten all interface variables (#2217)
2020-05-18 cepheus Bump version.
2020-05-15 lryer Reserve unused std140 uniform block in reflection, and fix uniform block matrix layout (#2041)
2020-05-15 cepheus Bump version.
2020-05-14 duke.acacia Move to newer version of SPIRV-Tools
2020-05-12 cepheus Address #2211: Improve the copy constructor of TVarLivePair.
2020-05-11 xilefmai Fix Web build
2020-05-08 sebastian.neubauer Explicitly mark some enums as unsigned

Roll third_party/googletest/ a09ea700d..011959aaf (6 commits)

https://github.com/google/googletest/compare/a09ea700d32b...011959aafddc

$ git log a09ea700d..011959aaf --date=short --no-merges --format='%ad %ae %s'
2020-05-13 absl-team Googletest export
2020-05-13 absl-team Googletest export
2020-05-11 absl-team Googletest export
2020-05-08 martin Remove an explicit include of debugapi.h
2020-05-08 martin Revert "Googletest export"
2020-03-29 verdoialaurent Fix --gtest_print_time coloring

Roll third_party/re2/ 887c8072f..52b4b94b0 (15 commits)

https://github.com/google/re2/compare/887c8072fbbc...52b4b94b00f0

$ git log 887c8072f..52b4b94b0 --date=short --no-merges --format='%ad %ae %s'
2020-05-20 junyer Implement "front and back" prefix accel.
2020-05-19 junyer Generalise from "first byte" to "prefix accel".
2020-05-19 junyer have_first_byte now implies run_forward.
2020-05-19 junyer Tidy up the code around the memchr(3) calls.
2020-05-17 junyer Remove a pointer chase from Regexp::Walker<>.
2020-05-17 junyer Tidy up the code for NFA threads a bit more.
2020-05-17 junyer Argh. I overlooked the constructor and destructor.
2020-05-17 junyer Undo use of PODArray<> for NFA threads.
2020-05-17 junyer Use PODArray<> in a few more places.
2020-05-16 junyer Separate build/install for libre2.a and libre2.so.
2020-05-16 junyer Refine a preprocessor check for MSVC.
2020-05-15 junyer Compute first byte for forward Progs only.
2020-05-11 junyer Don't dereference params->start unconditionally.
2020-05-11 junyer Compute first_byte using the Regexp, not the Prog.
2020-05-11 junyer Implement Regexp::RequiredPrefixUnanchored().

Roll third_party/spirv-cross/ d638d2df9..29ad40e93 (4 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/d638d2df9c8c...29ad40e93ed8

$ git log d638d2df9..29ad40e93 --date=short --no-merges --format='%ad %ae %s'
2020-05-20 post GLSL: Add more test shaders for hit attribute types.
2020-05-20 post GLSL: Support ray payloads and hit attributes declared as Block.
2020-05-20 post GLSL: Add some more focused RT test shaders.
2020-05-19 post HLSL: Implement image queries for UAV images.

Roll third_party/spirv-tools/ c8590c18b..2b987c49a (17 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/c8590c18bd0c...2b987c49a4e1

$ git log c8590c18b..2b987c49a --date=short --no-merges --format='%ad %ae %s'
2020-05-20 jaebaek Handle OpConstantNull in ssa-rewrite (#3362)
2020-05-19 rharrison Add in a bunch of missed files to the BUILD.gn (#3360)
2020-05-19 rharrison Remove stale entries from BUILD.gn (#3358)
2020-05-19 vladimir.davidovich allow cross compiling for Windows Store, UWP, etc. (#3330)
2020-05-19 vasniktel spirv-fuzz: Remove FuzzerPassAddUsefulConstructs (#3341)
2020-05-19 vasniktel Add support for StorageBuffer (#3348)
2020-05-19 462213+sl1pkn07 Prevent Effcee install his things when build spirv-tools with testing enabled (#3256)
2020-05-19 stevenperron Don't register edges twice in merge return (#3350)
2020-05-14 stevenperron Revert "Revert "[spirv-opt] refactor inlining pass (#3328)" (#3342)" (#3345)
2020-05-14 afdx spirv-reduce: Remove unused struct members (#3329)
2020-05-14 andreperezmaselco.developer Add adjust branch weights transformation (#3336)
2020-05-13 stevenperron Revert "[spirv-opt] refactor inlining pass (#3328)" (#3342)
2020-05-13 jaebaek [spirv-opt] refactor inlining pass (#3328)
2020-05-13 afdx spirv-reduce: Remove unused uniforms and similar (#3321)
2020-05-13 afdx spirv-fuzz: Fix to fact manager (#3339)
2020-05-13 afdx spirv-fuzz: Get rid of unnecessary template method (#3340)
2020-05-12 stevenperron Do merge return if the return is not at the end of the function. (#3337)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools