### PR TITLE
Rolling 4 dependencies and expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'glslang_revision': '2cf9621d6d6f3b5e38f471709f45d35720a7ffee',
+  'glslang_revision': '2b0eafb1de5b4a1b77cf123545ea269d44248885',
   'googletest_revision': '011959aafddcd30611003de96cfd8d7a7685c700',
-  're2_revision': '52b4b94b00f094d4a86c9b6bbb8276b21ec53505',
+  're2_revision': '787495f0ba2e76dcadb21db84455ea0e2ce15beb',
   'spirv_headers_revision': 'ac638f1815425403e946d0ab78bac71d2bdbf3be',
-  'spirv_tools_revision': '55193b06e5ed8e7b41c63a166b465c61753afb9a',
-  'spirv_cross_revision': '287e93ff80ee8788f326c9bab46a20645b7595c5',
+  'spirv_tools_revision': '9cb2571a184c0fe571100c799301426a492f7407',
+  'spirv_cross_revision': '61cddd6307ef8a644462bc1263d196e1bae9ec67',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -1,7 +1,6 @@
 shaders-hlsl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
 shaders-hlsl-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-hlsl-no-opt/frag/variables.zero-initialize.frag,False
-shaders-hlsl/asm/comp/control-flow-hints.asm.comp,True
 shaders-hlsl/comp/access-chains.force-uav.comp,False
 shaders-hlsl/comp/access-chains.force-uav.comp,True
 shaders-hlsl/comp/image.nonwritable-uav-texture.comp,False
@@ -72,6 +71,7 @@ shaders-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
 shaders-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-no-opt/frag/variables.zero-initialize.frag,False
 shaders-reflection/asm/aliased-entry-point-names.asm.multi,False
+shaders-reflection/asm/comp/pointer-to-array-of-physical-pointer.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp,False
 shaders-reflection/asm/op-source-hlsl-uav-1.asm.comp,False
@@ -80,6 +80,8 @@ shaders-reflection/asm/op-source-none-ssbo-1.asm.comp,False
 shaders-reflection/asm/op-source-none-ssbo-2.asm.comp,False
 shaders-reflection/asm/op-source-none-uav-1.asm.comp,False
 shaders-reflection/asm/op-source-none-uav-2.asm.comp,False
+shaders-reflection/comp/array-of-physical-pointer.comp,False
+shaders-reflection/comp/physical-pointer.comp,False
 shaders-reflection/comp/struct-layout.comp,False
 shaders-reflection/comp/struct-packing.comp,False
 shaders-reflection/comp/workgroup-size-spec-constant.comp,False
@@ -96,13 +98,9 @@ shaders-reflection/vert/array-size-reflection.vert,False
 shaders-reflection/vert/read-from-row-major-array.vert,False
 shaders-reflection/vert/stride-reflection.vert,False
 shaders-reflection/vert/texture_buffer.vert,False
-shaders-ue4/asm/frag/global-constant-arrays.asm.frag,True
-shaders-ue4/asm/frag/padded-float-array-member-defef.asm.frag,True
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,False
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,True
-shaders-ue4/asm/frag/texture-atomics.asm.frag,True
 shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
-shaders-ue4/asm/vert/array-missing-copies.asm.vert,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -114,6 +114,7 @@ shaders-no-opt/frag/fp16.invalid.desktop.frag,False
 shaders-no-opt/frag/multi-dimensional.desktop.invalid.flatten_dim.frag,False
 shaders-no-opt/frag/variables.zero-initialize.frag,False
 shaders-reflection/asm/aliased-entry-point-names.asm.multi,False
+shaders-reflection/asm/comp/pointer-to-array-of-physical-pointer.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-2.asm.comp,False
 shaders-reflection/asm/op-source-hlsl-uav-1.asm.comp,False
@@ -122,6 +123,8 @@ shaders-reflection/asm/op-source-none-ssbo-1.asm.comp,False
 shaders-reflection/asm/op-source-none-ssbo-2.asm.comp,False
 shaders-reflection/asm/op-source-none-uav-1.asm.comp,False
 shaders-reflection/asm/op-source-none-uav-2.asm.comp,False
+shaders-reflection/comp/array-of-physical-pointer.comp,False
+shaders-reflection/comp/physical-pointer.comp,False
 shaders-reflection/comp/struct-layout.comp,False
 shaders-reflection/comp/struct-packing.comp,False
 shaders-reflection/comp/workgroup-size-spec-constant.comp,False
@@ -138,13 +141,9 @@ shaders-reflection/vert/array-size-reflection.vert,False
 shaders-reflection/vert/read-from-row-major-array.vert,False
 shaders-reflection/vert/stride-reflection.vert,False
 shaders-reflection/vert/texture_buffer.vert,False
-shaders-ue4/asm/frag/global-constant-arrays.asm.frag,True
-shaders-ue4/asm/frag/padded-float-array-member-defef.asm.frag,True
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,False
 shaders-ue4/asm/frag/subpass-input.ios.framebuffer-fetch.asm.frag,True
-shaders-ue4/asm/frag/texture-atomics.asm.frag,True
 shaders-ue4/asm/frag/texture-atomics.asm.graphics-robust-access.frag,True
-shaders-ue4/asm/vert/array-missing-copies.asm.vert,True
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,False
 shaders/asm/frag/image-fetch-no-sampler.no-samplerless.asm.vk.frag,True
 shaders/asm/frag/image-query-no-sampler.no-samplerless.vk.asm.frag,False


### PR DESCRIPTION
Roll third_party/re2/ 52b4b94b0..787495f0b (4 commits)

https://github.com/google/re2/compare/52b4b94b00f0...787495f0ba2e

$ git log 52b4b94b0..787495f0b --date=short --no-merges --format='%ad %ae %s'
2020-05-22 junyer Use CMAKE_CXX_STANDARD now that we can.
2020-05-22 junyer Make "front and back" prefix accel work with MSVC.
2020-05-22 junyer Rename to Regexp::RequiredPrefixForAccel().
2020-05-22 junyer Add a basic test for prefix accel.

Roll third_party/glslang/ 2cf9621d6..2b0eafb1d (1 commit)

https://github.com/KhronosGroup/glslang/compare/2cf9621d6d6f...2b0eafb1de5b

$ git log 2cf9621d6..2b0eafb1d --date=short --no-merges --format='%ad %ae %s'
2020-05-25 alanbaker Update spirv tools (#2246)

Roll third_party/spirv-cross/ 287e93ff8..61cddd630 (3 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/287e93ff80ee...61cddd6307ef

$ git log 287e93ff8..61cddd630 --date=short --no-merges --format='%ad %ae %s'
2020-05-25 post Handle physical pointers in reflection API.
2020-05-22 post GLSL: Improve support for GL_ARB_shader_draw_parameters in desktop GLSL.
2020-05-21 dsinclair Roll SPIRV-Tools, SPIRV-Headers and GLSLang.

Roll third_party/spirv-tools/ 55193b06e..9cb2571a1 (6 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/55193b06e5ed...9cb2571a184c

$ git log 55193b06e..9cb2571a1 --date=short --no-merges --format='%ad %ae %s'
2020-05-25 jaebaek spirv-val: allow DebugInfoNone for DebugTypeComposite.Size (#3374)
2020-05-25 47594367+rg3igalia Add validation support for ImageGatherBiasLodAMD (#3363)
2020-05-21 38433336+AnastasiaStulova Fix validation failure on OpDecorationGroup (#3365)
2020-05-21 greg Remove deprecated interfaces from instrument passes (#3361)
2020-05-21 jaebaek Preserve debug info in inline pass (#3349)
2020-05-21 dnovillo Reject folding comparisons with unfoldable types. (#3370)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools