### PR TITLE
Support forcing storage buffers to be always declared as UAV

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -463,6 +463,12 @@ SHADERC_EXPORT shaderc_spvc_status
 shaderc_spvc_compile_options_set_hlsl_nonwritable_uav_texture_as_srv(
     shaderc_spvc_compile_options_t options, bool b);
 
+// Set storage buffers to be always declared as UAV, even if the read-only
+// declaration is used, see spirv_hlsl.hpp in SPIRV-Cross for more details.
+SHADERC_EXPORT shaderc_spvc_status
+shaderc_spvc_set_hlsl_force_storage_buffer_as_uav(
+    const shaderc_spvc_context_t context, uint32_t desc_set, uint32_t binding);
+
 // If true (default is false):
 //   GLSL: map depth from Vulkan/D3D style to GL style, i.e. [ 0,w] -> [-w,w]
 //   MSL : map depth from GL style to Vulkan/D3D style, i.e. [-w,w] -> [ 0,w]

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -570,6 +570,12 @@ class Context {
                                                    types->data(), &type_count);
   }
 
+  // Set storage buffers to be always declared as UAV, even if the read-only 
+  // declaration is used, see spirv_hlsl.hpp in SPIRV-Cross for more details.
+  shaderc_spvc_status SetHLSLForceStorageBufferAsUAV(uint32_t desc_set, uint32_t binding) {
+    return shaderc_spvc_set_hlsl_force_storage_buffer_as_uav(context_.get(), desc_set, binding);
+  }
+
  private:
   Context(const Context&) = delete;
   Context& operator=(const Context& other) = delete;

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -639,6 +639,17 @@ shaderc_spvc_compile_options_set_hlsl_nonwritable_uav_texture_as_srv(
   return shaderc_spvc_status_success;
 }
 
+shaderc_spvc_status shaderc_spvc_set_hlsl_force_storage_buffer_as_uav(
+    const shaderc_spvc_context_t context, uint32_t desc_set, uint32_t binding) {
+  CHECK_CONTEXT(context);
+  CHECK_CROSS_COMPILER(context, context->cross_compiler);
+
+  auto* hlsl_compiler = reinterpret_cast<spirv_cross::CompilerHLSL*>(
+      context->cross_compiler.get());
+  hlsl_compiler->set_hlsl_force_storage_buffer_as_uav(desc_set, binding);
+  return shaderc_spvc_status_success;
+}
+
 shaderc_spvc_status shaderc_spvc_compile_options_set_fixup_clipspace(
     shaderc_spvc_compile_options_t options, bool b) {
   CHECK_OPTIONS(nullptr, options);


### PR DESCRIPTION
Adds support for the corresponding SPIRV-Cross API [1] introduced to resolve WebGPU/Dawn issue related to forcing UAVs.

[1] https://github.com/KhronosGroup/SPIRV-Cross/issues/1368