### PR TITLE
Rolling 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'glslang_revision': '2b0eafb1de5b4a1b77cf123545ea269d44248885',
-  'googletest_revision': '011959aafddcd30611003de96cfd8d7a7685c700',
-  're2_revision': '787495f0ba2e76dcadb21db84455ea0e2ce15beb',
-  'spirv_headers_revision': 'ac638f1815425403e946d0ab78bac71d2bdbf3be',
-  'spirv_tools_revision': '9cb2571a184c0fe571100c799301426a492f7407',
+  'glslang_revision': 'd39b8afc47a1f700b5670463c0d1068878acee6f',
+  'googletest_revision': '859bfe8981d6724c4ea06e73d29accd8588f3230',
+  're2_revision': 'aecba11114cf1fac5497aeb844b6966106de3eb6',
+  'spirv_headers_revision': '11d7637e7a43cd88cfd4e42c99581dcb682936aa',
+  'spirv_tools_revision': 'f050cca7ec474fc71873f4d68375d3916c969322',
   'spirv_cross_revision': 'd385bf096f5dabbc4cdaeb6872b0f64be1a63ad0',
 }
 


### PR DESCRIPTION
Roll third_party/glslang/ 2b0eafb1d..d39b8afc4 (4 commits)

https://github.com/KhronosGroup/glslang/compare/2b0eafb1de5b...d39b8afc47a1

$ git log 2b0eafb1d..d39b8afc4 --date=short --no-merges --format='%ad %ae %s'
2020-05-28 40001162+alelenv EXT_ray_tracing requires spv1.4 (#2237)
2020-05-28 shuizhuyuanluo fix warning unused parameter in release build (#2251)
2020-05-27 greg Fix missing patch decoration for TessFactor PCF arg (#2249)
2020-05-27 greg Update SPIRV-Tools to stable. Also SPIRV-Headers to TOT. (#2250)

Roll third_party/googletest/ 011959aaf..859bfe898 (18 commits)

https://github.com/google/googletest/compare/011959aafddc...859bfe8981d6

$ git log 011959aaf..859bfe898 --date=short --no-merges --format='%ad %ae %s'
2020-05-28 dmauro Googletest export
2020-05-28 dmauro Googletest export
2020-05-27 absl-team Googletest export
2020-05-27 dmauro Googletest export
2020-05-19 absl-team Googletest export
2020-05-18 absl-team Googletest export
2020-05-18 durandal Googletest export
2020-05-18 absl-team Googletest export
2020-05-14 absl-team Googletest export
2020-05-25 invalid_ms_user Use count function instead of handwritten loop
2020-05-10 mate.pek README.dm: Renamed related open source project name: Catch2 and Google Test Explorer -> C++ TestMate
2020-03-26 mvoorsluys Fix test with stack.
2020-03-26 mvoorsluys Fixed xml unit-tests and added extra tests
2020-03-26 mvoorsluys Fix multiple \n characters in xml file when using GTEST_SKIP.
2020-03-26 mvoorsluys Only write ">\n" once when there is failure and skipped tests.
2020-03-26 mvoorsluys Output skipped information in the xml file.
2020-02-06 59134746+aribibek fix a link to documentation
2020-01-17 hgsilverman Fix always false condition and clean function body

Roll third_party/re2/ 787495f0b..aecba1111 (1 commit)

https://github.com/google/re2/compare/787495f0ba2e...aecba11114cf

$ git log 787495f0b..aecba1111 --date=short --no-merges --format='%ad %ae %s'
2020-05-27 junyer Refuse to rewrite when MaxSubmatch() is too large.

Roll third_party/spirv-headers/ ac638f181..11d7637e7 (7 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/ac638f181542...11d7637e7a43

$ git log ac638f181..11d7637e7 --date=short --no-merges --format='%ad %ae %s'
2020-06-01 dneto spir-v.xml: Use plain ASCII quotes in comment
2020-05-29 cepheus Rebuild headers against the previous grammar commit.
2020-05-29 dmitry.sidorov Apply suggestions
2020-04-05 dmitry.sidorov Add Intel specific definitions from KhronosGroup/SPIRV-LLVM-Translator
2020-05-29 cepheus Header build from previous grammar update.
2020-05-25 michael.kinsner Propose bit allocation mechanism for the FP Fast Math Mode bitfield, following from the mechanism previously added for the loop control bitfield.
2020-04-05 dmitry.sidorov Add SPV_INTEL_function_pointers preview extension

Roll third_party/spirv-tools/ 9cb2571a1..f050cca7e (7 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/9cb2571a184c...f050cca7ec47

$ git log 9cb2571a1..f050cca7e --date=short --no-merges --format='%ad %ae %s'
2020-05-29 andreperezmaselco.developer spirv-fuzz: Add push id through variable transformation (#3359)
2020-05-27 rharrison Rolling 4 dependencies (#3380)
2020-05-27 stevenperron Start SPIRV-Tools v2020.4
2020-05-27 stevenperron Finalize SPIRV-Tools v2020.3
2020-05-27 stevenperron Update CHANGES
2020-05-26 andreperezmaselco.developer spirv-fuzz: Support bit width argument for int and float types (#3378)
2020-05-26 andreperezmaselco.developer Fix function use (#3372)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools