### PR TITLE
Rolling 5 dependencies and update expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'glslang_revision': 'd39b8afc47a1f700b5670463c0d1068878acee6f',
-  'googletest_revision': '859bfe8981d6724c4ea06e73d29accd8588f3230',
-  're2_revision': 'aecba11114cf1fac5497aeb844b6966106de3eb6',
+  'glslang_revision': '68b2e15ee016487a28c4178a9d142186c58c8dd0',
+  'googletest_revision': '4fe018038f87675c083d0cfb6a6b57c274fb1753',
+  're2_revision': '2b25567a8ee3b6e97c3cd05d616f296756c52759',
   'spirv_headers_revision': '11d7637e7a43cd88cfd4e42c99581dcb682936aa',
-  'spirv_tools_revision': 'f050cca7ec474fc71873f4d68375d3916c969322',
-  'spirv_cross_revision': 'd385bf096f5dabbc4cdaeb6872b0f64be1a63ad0',
+  'spirv_tools_revision': '7c213720bb46ea9a81caa9f8dc24df0f1957de05',
+  'spirv_cross_revision': '92fcd7d2b026700ace0304af25f254a561778d77',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -1,5 +1,6 @@
 shaders-hlsl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
 shaders-hlsl-no-opt/asm/temporary.zero-initialize.asm.frag,False
+shaders-hlsl-no-opt/frag/native-16bit-types.fxconly.nofxc.sm62.native-16bit.frag,False
 shaders-hlsl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-hlsl/comp/access-chains.force-uav.comp,False
 shaders-hlsl/comp/access-chains.force-uav.comp,True

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -3,6 +3,7 @@ shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,Fals
 shaders-hlsl-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-hlsl-no-opt/frag/constant-buffer-array.invalid.sm51.frag,False
 shaders-hlsl-no-opt/frag/fp16.invalid.desktop.frag,False
+shaders-hlsl-no-opt/frag/native-16bit-types.fxconly.nofxc.sm62.native-16bit.frag,False
 shaders-hlsl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-hlsl/asm/comp/control-flow-hints.asm.comp,False
 shaders-hlsl/asm/comp/control-flow-hints.asm.comp,True


### PR DESCRIPTION
Roll third_party/glslang/ d39b8afc4..68b2e15ee (11 commits)

https://github.com/KhronosGroup/glslang/compare/d39b8afc47a1...68b2e15ee016

$ git log d39b8afc4..68b2e15ee --date=short --no-merges --format='%ad %ae %s'
2020-06-09 rharrison Use correct type for var storing returned value (#2263)
2020-06-09 lryer Fix xfb stride limit issue (#2088)
2020-06-04 laddoc Add Shared/Std140 SSBO process & top-level array elements related (#2231)
2020-06-04 apinheiro spirv: Support initializers on uniforms (#1588)
2020-06-03 47594367+rg3igalia Add SPIR-V capabilities needed for spec constants (#2199)
2020-06-02 rdb HLSL: Add better diagnostic when using in/out qualifiers in global scope (#2258)
2020-06-02 rdb HLSL: Recognize POSITION semantic et al in DX9 compatibility mode (#2255)
2020-06-02 rdb HLSL: fix handling of uniform qualifier in entry point parameters (#2254)
2020-06-01 40001162+alelenv Add default descriptorset decoration for acceleration structure (#2257)
2020-06-01 cepheus Update news for header location change and recommendation.
2020-06-02 dj2 Remove install to the SPIRV/ folder. (#2256)

Roll third_party/googletest/ 859bfe898..4fe018038 (9 commits)

https://github.com/google/googletest/compare/859bfe8981d6...4fe018038f87

$ git log 859bfe898..4fe018038 --date=short --no-merges --format='%ad %ae %s'
2020-06-04 dmauro Googletest export
2020-06-03 absl-team Googletest export
2020-06-02 absl-team Googletest export
2020-06-01 absl-team Googletest export
2020-03-07 krystian.kuzniarek make UniversalPrinter<std::any> support RTTI
2020-03-07 krystian.kuzniarek specialize UniversalPrinter<> for std::any (without support for RTTI)
2020-03-07 krystian.kuzniarek specialize UniversalPrinter<> for std::optional
2020-03-07 krystian.kuzniarek specialize UniversalPrinter<> for std::variant
2020-03-21 ngompa13 Set the version for the libraries

Roll third_party/re2/ aecba1111..2b25567a8 (2 commits)

https://github.com/google/re2/compare/aecba11114cf...2b25567a8ee3

$ git log aecba1111..2b25567a8 --date=short --no-merges --format='%ad %ae %s'
2020-06-08 junyer Don't pass `-pthread` when building for WebAssembly.
2020-06-06 junyer Add a clarifying comment about case folding.

Roll third_party/spirv-cross/ d385bf096..92fcd7d2b (7 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/d385bf096f5d...92fcd7d2b026

$ git log d385bf096..92fcd7d2b --date=short --no-merges --format='%ad %ae %s'
2020-06-08 post GLSL: Handle the rest of GL_ARB_sparse_texture_clamp.
2020-06-08 post GLSL: Support uint code for sparse residency query.
2020-06-05 post Refactor texture fetch function generation.
2020-06-06 AlexanderMeissner Fix missing switch cases in Y'CbCr conversion
2020-06-04 post GLSL: Implement sparse feedback.
2020-06-04 post MSL: Remove obsolete MSLVertexAttr members.
2020-06-04 post HLSL: Add native support for 16-bit types.

Roll third_party/spirv-tools/ f050cca7e..7c213720b (6 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/f050cca7ec47...7c213720bb46

$ git log f050cca7e..7c213720b --date=short --no-merges --format='%ad %ae %s'
2020-06-05 vasniktel spirv-fuzz: Fix replayer bug (#3401)
2020-06-05 andreperezmaselco.developer Add value instruction condition (#3385)
2020-06-05 andreperezmaselco.developer Fix instruction function use (#3390)
2020-06-05 vasniktel spirv-fuzz: Fix regression (#3396)
2020-06-04 paulthomson Fix googletest inclusion (#3398)
2020-06-02 jaebaek Add tests for merge-return debug info preservation (#3389)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools