### PR TITLE
Add minimum buffer size for dawn reflection

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -242,6 +242,7 @@ typedef struct {
   shaderc_spvc_texture_format_type texture_component_type;
   bool multisampled;
   shaderc_spvc_storage_texture_format storage_texture_format;
+  uint64_t minimum_buffer_size;
 } shaderc_spvc_binding_info;
 
 typedef struct {

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -1044,6 +1044,15 @@ shaderc_spvc_status shaderc_spvc_get_binding_info(
     bindings->id = shader_resource.id;
     bindings->base_type_id = shader_resource.base_type_id;
 
+    if (binding_type == shaderc_spvc_binding_type_uniform_buffer ||
+        binding_type == shaderc_spvc_binding_type_storage_buffer) {
+      // Determine buffer size, with a minimum of 1 element in the runtime array
+      spirv_cross::SPIRType type =
+          compiler->get_type(shader_resource.base_type_id);
+      bindings->minimum_buffer_size =
+          compiler->get_declared_struct_size_runtime_array(type, 1);
+    }
+
     switch (binding_type) {
       case shaderc_spvc_binding_type_sampled_texture: {
         spirv_cross::SPIRType::ImageType imageType =


### PR DESCRIPTION
In dawn, we need to validate buffer sizes for uniform and storage buffers to make sure bound buffers are large enough. [https://github.com/gpuweb/gpuweb/pull/678](https://github.com/gpuweb/gpuweb/pull/678) decided that we should require for runtime arrays at least 1 element, so that we can clamp indices. Luckily, there is a function that does this already. This patch adds to the bindings reflection info the minimum buffer size so we can use it in dawn.

The relevant dawn CL is [https://dawn-review.googlesource.com/c/dawn/+/22421](https://dawn-review.googlesource.com/c/dawn/+/22421), which does the same thing using spirv-cross in ShaderModule.cpp.

The variable name can be changed if another one makes more sense?