### PR TITLE
Rolling 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'glslang_revision': '3641ff7378189664f64b3f8b84718058c628a084',
-  'googletest_revision': '4fe018038f87675c083d0cfb6a6b57c274fb1753',
-  're2_revision': '2b25567a8ee3b6e97c3cd05d616f296756c52759',
+  'glslang_revision': 'ebf55a0711b81ad1d0701d85c1c018b831243613',
+  'googletest_revision': '8567b09290fe402cf01923e2131c5635b8ed851b',
+  're2_revision': 'e9d517989f66f2e0a24cde42f4d2424dd3e4a9b9',
   'spirv_headers_revision': '11d7637e7a43cd88cfd4e42c99581dcb682936aa',
-  'spirv_tools_revision': '7c213720bb46ea9a81caa9f8dc24df0f1957de05',
-  'spirv_cross_revision': '92fcd7d2b026700ace0304af25f254a561778d77',
+  'spirv_tools_revision': '30bf46dbe06f6e1b58657fae1e13c1900eb9d8d3',
+  'spirv_cross_revision': '9e3df69d4e994776103dfa6070c0c343cffac4a4',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ 3641ff737..ebf55a071 (2 commits)

https://github.com/KhronosGroup/glslang/compare/3641ff737818...ebf55a0711b8

$ git log 3641ff737..ebf55a071 --date=short --no-merges --format='%ad %ae %s'
2020-06-15 rdb HLSL: Fix incorrect case in name of DX9-style cube sampler type (#2265)
2020-06-11 bclayton Fix signed / unsigned mismatch warning (#2266)

Roll third_party/googletest/ 4fe018038..8567b0929 (5 commits)

https://github.com/google/googletest/compare/4fe018038f87...8567b09290fe

$ git log 4fe018038..8567b0929 --date=short --no-merges --format='%ad %ae %s'
2020-06-12 dmauro Googletest export
2020-06-10 absl-team Googletest export
2020-06-08 absl-team Googletest export
2020-06-08 absl-team Googletest export
2020-06-05 dmauro Googletest export

Roll third_party/re2/ 2b25567a8..e9d517989 (1 commit)

https://github.com/google/re2/compare/2b25567a8ee3...e9d517989f66

$ git log 2b25567a8..e9d517989 --date=short --no-merges --format='%ad %ae %s'
2020-06-14 junyer Implement linear-time append for patch lists.

Roll third_party/spirv-cross/ 92fcd7d2b..9e3df69d4 (1 commit)

https://github.com/KhronosGroup/SPIRV-Cross/compare/92fcd7d2b026...9e3df69d4e99

$ git log 92fcd7d2b..9e3df69d4 --date=short --no-merges --format='%ad %ae %s'
2020-06-12 git GLSL: Require GL_ARB_draw_instanced for gl_InstanceID in GLSL < 1.40

Roll third_party/spirv-tools/ 7c213720b..30bf46dbe (5 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/7c213720bb46...30bf46dbe06f

$ git log 7c213720b..30bf46dbe --date=short --no-merges --format='%ad %ae %s'
2020-06-13 vasniktel Fix operand access (#3427)
2020-06-12 jaebaek Debug info preservation in ccp pass (#3420)
2020-06-10 dneto Fix round trip tests that weren't instantiated (#3417)
2020-06-10 vasniktel spirv-fuzz: Add a test (#3238)
2020-06-10 vasniktel spirv-fuzz: Add support for OpSpecConstant* (#3373)

Created with:
  roll-dep third_party/effcee third_party/glslang third_party/googletest third_party/re2 third_party/spirv-cross third_party/spirv-headers third_party/spirv-tools