### PR TITLE
Add interface for enabling 16-bit types

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -458,6 +458,11 @@ SHADERC_EXPORT shaderc_spvc_status
 shaderc_spvc_compile_options_set_hlsl_point_coord_compat(
     shaderc_spvc_compile_options_t options, bool b);
 
+// If true, enable 16-bit types.  Default is false.
+SHADERC_EXPORT shaderc_spvc_status
+shaderc_spvc_compile_options_set_hlsl_enable_16bit_types(
+    shaderc_spvc_compile_options_t options, bool b);
+
 // If true, set non-writable storage images to be SRV, see spirv_hlsl.hpp in
 // SPIRV-Cross for more details.
 SHADERC_EXPORT shaderc_spvc_status

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -295,6 +295,12 @@ class CompileOptions {
         options_.get(), b);
   }
 
+  // If true, enable 16-bit types.  Default is false.
+  shaderc_spvc_status SetHLSLEnable16BitTypes(bool b) {
+    return shaderc_spvc_compile_options_set_hlsl_enable_16bit_types(
+        options_.get(), b);
+  }
+
   // If true, set non-writable storage images to be SRV, see spirv_hlsl.hpp in
   // SPIRV-Cross for more details.
   shaderc_spvc_status SetHLSLNonWritableUAVTextureAsSRV(bool b) {

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -630,6 +630,14 @@ shaderc_spvc_status shaderc_spvc_compile_options_set_hlsl_point_coord_compat(
   return shaderc_spvc_status_success;
 }
 
+shaderc_spvc_status shaderc_spvc_compile_options_set_hlsl_enable_16bit_types(
+    shaderc_spvc_compile_options_t options, bool b) {
+  CHECK_OPTIONS(nullptr, options);
+
+  options->hlsl.enable_16bit_types = b;
+  return shaderc_spvc_status_success;
+}
+
 shaderc_spvc_status
 shaderc_spvc_compile_options_set_hlsl_nonwritable_uav_texture_as_srv(
     shaderc_spvc_compile_options_t options, bool b) {


### PR DESCRIPTION
From https://github.com/KhronosGroup/SPIRV-Cross/issues/1381, HLSL 16-bit types had been introduced by https://github.com/KhronosGroup/SPIRV-Cross/issues/1381. So export the interface in shaderc. Thank you.