### PR TITLE
Use glslang's new GLSLANG_BUILD_PIC CMake flag

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,7 +5,7 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'glslang_revision': '839704450200e407490c538418f4d1a493b789ab',
+  'glslang_revision': '257e9a3f1927ae09401d16eaee11587e74ed4f61',
   'googletest_revision': 'c6e309b268d4fb9138bed7d0f56b7709c29f102f',
   're2_revision': '14d3193228e3b3cfd21094474d64434a4840bae9',
   'spirv_headers_revision': '11d7637e7a43cd88cfd4e42c99581dcb682936aa',

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -33,7 +33,6 @@ if(${SHADERC_ENABLE_TESTS})
 endif()
 
 set(OLD_PLATFORM_TOOLSET ${CMAKE_GENERATOR_TOOLSET})
-check_cxx_compiler_flag(-fPIC COMPILER_SUPPORTS_PIC)
 
 
 if (IS_DIRECTORY ${SHADERC_SPIRV_HEADERS_DIR})
@@ -65,17 +64,8 @@ endif()
 
 if (NOT TARGET glslang)
   if (IS_DIRECTORY ${SHADERC_GLSLANG_DIR})
-    # Add -fPIC to glslang build, if supported
-    if (COMPILER_SUPPORTS_PIC)
-      set(CXX_BACK ${CMAKE_CXX_FLAGS})
-      set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-fPIC")
-      # cmake inserts a semicolon, change it to a space.
-      string(REGEX REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-      add_subdirectory(${SHADERC_GLSLANG_DIR} glslang)
-      set(CMAKE_CXX_FLAGS ${CXX_BACK})
-    else()
-      add_subdirectory(${SHADERC_GLSLANG_DIR} glslang)
-    endif()
+    set(GLSLANG_BUILD_PIC 1)
+    add_subdirectory(${SHADERC_GLSLANG_DIR} glslang)
   endif()
   if (NOT TARGET glslang)
     message(FATAL_ERROR "glslang was not found - required for compilation")
@@ -93,6 +83,7 @@ if (SHADERC_ENABLE_SPVC)
   if (NOT TARGET spirv-cross-core)
     if (IS_DIRECTORY ${SHADERC_SPIRV_CROSS_DIR})
       # Add -fPIC to SPIRV-Cross build, if supported
+      check_cxx_compiler_flag(-fPIC COMPILER_SUPPORTS_PIC)
       if (COMPILER_SUPPORTS_PIC)
         set(CXX_BACK ${CMAKE_CXX_FLAGS})
         set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-fPIC")


### PR DESCRIPTION
Instead of pushing / popping `CMAKE_CXX_FLAGS` with `-fPIC`.

This reverts "Glslang third party build needs -fPIC (#1093)"