### PR TITLE
Roll 6 dependencies and update expectations.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'glslang_revision': '839704450200e407490c538418f4d1a493b789ab',
-  'googletest_revision': 'c6e309b268d4fb9138bed7d0f56b7709c29f102f',
-  're2_revision': '14d3193228e3b3cfd21094474d64434a4840bae9',
-  'spirv_headers_revision': '11d7637e7a43cd88cfd4e42c99581dcb682936aa',
-  'spirv_tools_revision': 'd4b9f576ebb48e716efe14c7ea634a11427fa34d',
-  'spirv_cross_revision': 'f9ae06512ef744a1379d564ed0a202b12dc3478b',
+  'glslang_revision': 'f5ed7a69d5d64bd3ac802712c24995c6c12d23f8',
+  'googletest_revision': '356f2d264a485db2fcc50ec1c672e0d37b6cb39b',
+  're2_revision': 'fe8a81adc2ef24b99d44fb87e882d7f2cd504b91',
+  'spirv_headers_revision': '308bd07424350a6000f35a77b5f85cd4f3da319e',
+  'spirv_tools_revision': '6a4da9da421560f3f2b073e4e8e4691787c3c732',
+  'spirv_cross_revision': '559b21c6c91f65ba52cdfa7a76e1185cd3c8f144',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -24,6 +24,7 @@ shaders-msl-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-msl-no-opt/comp/basic.dynamic-buffer.msl2.invalid.comp,False
 shaders-msl-no-opt/comp/int64.invalid.msl22.comp,False
 shaders-msl-no-opt/frag/force-active-resources.msl2.argument..force-active.discrete.frag,False
+shaders-msl-no-opt/frag/subpass-input-attachment-index-fallback.msl20.ios.framebuffer-fetch.frag,False
 shaders-msl-no-opt/frag/subpass-input-function-argument.framebuffer-fetch.ios.frag,False
 shaders-msl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-msl-no-opt/vert/pass-array-by-value.force-native-array.vert,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -48,6 +48,7 @@ shaders-msl-no-opt/frag/force-active-resources.msl2.argument..force-active.discr
 shaders-msl-no-opt/frag/fp16.desktop.invalid.frag,False
 shaders-msl-no-opt/frag/min-max-clamp.invalid.asm.frag,False
 shaders-msl-no-opt/frag/shadow-compare-global-alias.invalid.frag,False
+shaders-msl-no-opt/frag/subpass-input-attachment-index-fallback.msl20.ios.framebuffer-fetch.frag,False
 shaders-msl-no-opt/frag/subpass-input-function-argument.framebuffer-fetch.ios.frag,False
 shaders-msl-no-opt/frag/variables.zero-initialize.frag,False
 shaders-msl-no-opt/packing/array-of-vec3.comp,False


### PR DESCRIPTION
Roll third_party/glslang/ 839704450..f5ed7a69d (30 commits)

https://github.com/KhronosGroup/glslang/compare/839704450200...f5ed7a69d5d6

$ git log 839704450..f5ed7a69d --date=short --no-merges --format='%ad %ae %s'
2020-07-03 marcin.slusarz Add --quiet option.
2020-07-05 ShabbyX gn: Fix dawn tests in Chromium
2020-07-05 ShabbyX gn: Fix `gn gen --check` by adding missing dependency
2020-07-03 bclayton Add GLSLANG_BUILD_PIC CMake flag
2020-07-03 ShabbyX gn: Optionally disable optimizations and HLSL
2020-07-03 bclayton Don't use add_link_options() on old CMake versions
2020-07-03 bclayton License headers: s/Google/The Khronos Group
2020-07-03 bclayton Kokoro: Correct the `build_file' path to build.sh
2020-07-02 bclayton Add config for license-checker and Kokoro scripts.
2020-07-02 bclayton Fix GLSLANG_IS_SHARED_LIBRARY define
2020-07-01 bclayton Add missing copyright headers
2020-07-02 cepheus Bump revision.
2020-07-01 cepheus SPIRV-Tools and tests: Update to location-validation in SPIRV-Tools.
2020-07-01 cepheus Tests: More broadly use automapping binding/location.
2020-07-01 bclayton Add additional licenses in use to LICENSE.txt
2020-07-01 cepheus HLSL: Catch error cases earlier, preventing a later assert.
2020-06-29 bclayton glslang: Only export public interface for SOs
2020-06-29 bclayton CMake: break up glslang into smaller static libs
2020-06-30 cepheus SPV: RelaxedPrecision: use the result precision for texture sampling.
2020-06-30 cepheus SPV: RelaxedPrecision: Generalize fix #2293 to cover more operations.
2020-06-24 e.proydakov Fixed GCC -Wunused-parameter in hlslParseables.cpp.
2020-06-29 bclayton CMake: Compile with -fPIC when building SOs
2020-06-29 bclayton CMake: Error on unresolved symbols
2020-06-29 bclayton Remove root kokoro/linux-*-cmake configs
2020-06-26 cepheus SPV: Fix #2293: keep relaxed precision on arg passed to relaxed param
2020-06-26 cepheus SPV: Partially address #2293: correct "const in" precision matching.
2020-06-25 lriki.net Add pack_matrix test
2020-06-12 lriki.net HLSL: Fix #pragma pack_matrix(row_major) not work on global uniforms
2020-06-24 bclayton Kokoro: Split linux cmake cfgs into static/shared
2020-06-23 e.proydakov Fixed msvc 2019 nmake compiler warnings with RTTI. By default cmake generates cxx_flags with `/GR` parameter. I updated CMAKE_CXX_FLAGS string and replaced `/GR` -> `/GR-`

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ c6e309b26..356f2d264 (10 commits)

https://github.com/google/googletest/compare/c6e309b268d4...356f2d264a48

$ git log c6e309b26..356f2d264 --date=short --no-merges --format='%ad %ae %s'
2020-07-01 absl-team Googletest export
2020-06-26 absl-team Googletest export
2020-06-25 absl-team Googletest export
2020-06-24 absl-team Googletest export
2020-06-24 absl-team Googletest export
2020-06-19 mayur.shingote Updated googletest issue tracker url.
2020-06-10 rharrison Fix build issue for MinGW
2020-02-21 nini16041988-gitbucket Add missing call for gtest_list_output_unittest_ unitTest. Add unitTest for fixed TEST_P line number. Use CodeLocation TestInfo struct.
2020-02-18 nini16041988-gitbucket Fix: shadow member
2020-02-18 nini16041988-gitbucket Add correct line number to TEST_P test cases for gtest_output.

Created with:
  roll-dep third_party/googletest

Roll third_party/re2/ 14d319322..fe8a81adc (3 commits)

https://github.com/google/re2/compare/14d3193228e3...fe8a81adc2ef

$ git log 14d319322..fe8a81adc --date=short --no-merges --format='%ad %ae %s'
2020-07-05 junyer Bump SONAME, which missing ')' versus unexpected ')' needed.
2020-07-03 courbet Make the compiler inline the hot RE2::DFA loop.
2020-06-25 Shikugawa change bazel cpu symbol from wasm to wasm32

Created with:
  roll-dep third_party/re2

Roll third_party/spirv-cross/ f9ae06512..559b21c6c (14 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/f9ae06512ef7...559b21c6c91f

$ git log f9ae06512..559b21c6c --date=short --no-merges --format='%ad %ae %s'
2020-07-06 dsinclair Roll deps.
2020-07-01 post MSL: Do not emit swizzled writes in packing fixups.
2020-07-01 post MSL: Workaround broken vector -> scalar access chain in MSL.
2020-07-06 post MSL: Use input attachment index directly for resource index fallback.
2020-07-06 post GLSL: Support I/O flattening with arrays as final type.
2020-07-03 post GLSL: Support multi-level struct flattening for I/O.
2020-07-01 post Run format_all.sh.
2020-07-01 post test: Use --hlsl-dx9-compatible when attempting to compile SM 3.0 shaders.
2020-06-30 post GLSL: Fix nested legacy switch workarounds.
2020-06-29 post GLSL: Implement switch on ESSL 1.0.
2020-06-29 post GLSL: Use for-loop fallback instead of do/while for legacy ESSL.
2020-06-29 post Implement context-sensitive expression read tracking.
2020-06-29 post Fix bug with control dependent expression tracking.
2020-06-23 post HLSL: Workaround FXC bugs with degenerate switch blocks.

Created with:
  roll-dep third_party/spirv-cross

Roll third_party/spirv-headers/ 11d7637e7..308bd0742 (1 commit)

https://github.com/KhronosGroup/SPIRV-Headers/compare/11d7637e7a43...308bd0742435

$ git log 11d7637e7..308bd0742 --date=short --no-merges --format='%ad %ae %s'
2020-06-26 dj2 Register the Tint compiler

Created with:
  roll-dep third_party/spirv-headers

Roll third_party/spirv-tools/ d4b9f576e..6a4da9da4 (16 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/d4b9f576ebb4...6a4da9da4215

$ git log d4b9f576e..6a4da9da4 --date=short --no-merges --format='%ad %ae %s'
2020-07-06 jaebaek Debug info preservation in copy-prop-array pass (#3444)
2020-07-03 vasniktel spirv-fuzz: TransformationInvertComparisonOperator (#3475)
2020-07-02 vasniktel Fix regression (#3481)
2020-07-02 vasniktel spirv-fuzz: Add fuzzerutil::FindOrCreate* (#3479)
2020-06-30 vasniktel spirv-fuzz: Add FuzzerPassAddCopyMemoryInstructions (#3391)
2020-06-30 vasniktel spirv-fuzz: Add one parameter at a time (#3469)
2020-06-29 jaebaek Fix ADCE pass bug for mulitple entries (#3470)
2020-06-26 ehsannas Add gl_BaseInstance to the name mapper. (#3462)
2020-06-26 andreperezmaselco.developer Implement the OpMatrixTimesScalar linear algebra case (#3450)
2020-06-25 jaebaek Clear debug information for kill and replacement (#3459)
2020-06-25 alanbaker Validate location assignments (#3308)
2020-06-23 ehsannas Support OpCompositeExtract pattern in desc_sroa (#3456)
2020-06-23 vasniktel spirv-fuzz: Implement FuzzerPassAddParameters (#3399)
2020-06-23 vasniktel spirv-fuzz: Add GetParameters (#3454)
2020-06-23 vasniktel spirv-fuzz: Permute OpPhi instruction operands (#3421)
2020-06-22 rharrison Add support for different default/trunks in roll-deps (#3442)

Created with:
  roll-dep third_party/spirv-tools