### PR TITLE
Roll 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,13 +4,13 @@ vars = {
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
 
-  'effcee_revision' : '5af957bbfc7da4e9f7aa8cac11379fa36dd79b84',
-  'glslang_revision': 'e8c9fd602f11d746fa251ef6bf445057a58e5d56',
-  'googletest_revision': '356f2d264a485db2fcc50ec1c672e0d37b6cb39b',
+  'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
+  'glslang_revision': 'b481744aea1ecf52ee4591afaa0f5e270b9d1636',
+  'googletest_revision': '70b90929b1da20580cad9ed996397cf04ef8f16d',
   're2_revision': 'fe8a81adc2ef24b99d44fb87e882d7f2cd504b91',
   'spirv_headers_revision': '308bd07424350a6000f35a77b5f85cd4f3da319e',
-  'spirv_tools_revision': '6a4da9da421560f3f2b073e4e8e4691787c3c732',
-  'spirv_cross_revision': '559b21c6c91f65ba52cdfa7a76e1185cd3c8f144',
+  'spirv_tools_revision': 'c9b254d045ebcff627163445fddb1cb9ec7a14e6',
+  'spirv_cross_revision': '6575e451f5bffded6e308988362224dd076b0f2b',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/effcee/ 5af957bbf..2ec8f8738 (3 commits)

https://github.com/google/effcee/compare/5af957bbfc7d...2ec8f8738118

$ git log 5af957bbf..2ec8f8738 --date=short --no-merges --format='%ad %ae %s'
2020-06-16 dneto Start v2020.0-dev
2020-06-16 dneto Finalize v2019.1
2020-06-15 dneto Update CHANGES

Created with:
  roll-dep third_party/effcee

Roll third_party/glslang/ e8c9fd602..b481744ae (19 commits)

https://github.com/KhronosGroup/glslang/compare/e8c9fd602f11...b481744aea1e

$ git log e8c9fd602..b481744ae --date=short --no-merges --format='%ad %ae %s'
2020-07-14 bclayton Give build_info.py the executable bit
2020-07-14 cepheus Fix recently found non-determinism with gl_WorldToObject3x4EXT.
2020-07-14 cepheus Non-determinism: Remove test file that seems to trigger non-determinism.
2020-07-13 bclayton Add bison license to LICENSE.txt
2020-07-13 bclayton CMake: Move project() to top of CMakeLists.txt
2020-07-13 bclayton Kokoro: Print test output to stdout
2020-07-13 cepheus Fix comma in licence checker.
2020-07-13 cepheus Revert "Merge pull request #2330 from ShabbyX/optimize_for_angle"
2020-07-13 cepheus Fix a couple lines that were too long, to retrigger bots.
2020-07-13 cepheus Fix #2329: don't use invalid initializers.
2020-07-12 bclayton Add missing comma from license-checker.cfg
2020-07-12 ccom Common: include standard headers before doing any defines
2020-07-10 bclayton Fix CMake rules when nesting CMake projects
2020-07-10 bclayton Attempt to fix chromium builds
2020-06-17 bclayton Generate build information from CHANGES.md
2020-07-03 ShabbyX Customize glslang.y to GLSLANG_ANGLE
2020-07-03 ShabbyX Use GLSLANG_ANGLE to strip features to what ANGLE requires
2020-07-07 rharrison Make sure glslang_angle has a definition in BUILD.gn
2020-07-07 bclayton Use CMake's builtin functionality for PCHs

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ 356f2d264..70b90929b (7 commits)

https://github.com/google/googletest/compare/356f2d264a48...70b90929b1da

$ git log 356f2d264..70b90929b --date=short --no-merges --format='%ad %ae %s'
2020-07-09 absl-team Googletest export
2020-07-07 ofats Googletest export
2020-07-07 absl-team Googletest export
2020-07-07 absl-team Googletest export
2020-04-11 olivier.ldff use target_compile_features to use c++11 if cmake > 3.8
2020-05-30 eli fix compilation on OpenBSD 6.7
2020-01-22 mjvk Fixes extensions missing for QNX

Created with:
  roll-dep third_party/googletest

Roll third_party/spirv-cross/ 559b21c6c..6575e451f (2 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/559b21c6c91f...6575e451f5bf

$ git log 559b21c6c..6575e451f --date=short --no-merges --format='%ad %ae %s'
2020-07-11 post MSVC 2013: Fix silently broken builds.
2020-07-07 troughton MSL: Ensure OpStore source operands are marked for inclusion in function arguments

Created with:
  roll-dep third_party/spirv-cross

Roll third_party/spirv-tools/ 6a4da9da4..c9b254d04 (17 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/6a4da9da4215...c9b254d045eb

$ git log 6a4da9da4..c9b254d04 --date=short --no-merges --format='%ad %ae %s'
2020-07-14 andreperezmaselco.developer spirv-fuzz: Support adding dead break from back-edge block (#3519)
2020-07-14 andreperezmaselco.developer Support OpPhi when replacing boolean constant operand (#3518)
2020-07-12 vasniktel spirv-fuzz: TransformationAddSynonyms (#3447)
2020-07-11 vasniktel spirv-fuzz: Remove unused functions (#3510)
2020-07-11 vasniktel spirv-fuzz: Minor refactoring (#3507)
2020-07-10 greg Preserve OpenCL.DebugInfo.100 through elim-local-single-store (#3498)
2020-07-10 jaebaek Preserve debug info in vector DCE pass (#3497)
2020-07-10 stefano.milizia00 Implement transformation to record synonymous constants. (#3494)
2020-07-09 jaebaek Fix build failure (#3508)
2020-07-09 greg Upgrade elim-local-single-block for OpenCL.DebugInfo.100 (#3451)
2020-07-09 vasniktel spirv-fuzz: TransformationReplaceParameterWithGlobal (#3434)
2020-07-09 andreperezmaselco.developer Implement the OpMatrixTimesVector linear algebra case (#3500)
2020-07-08 jaebaek Preserve OpenCL.100.DebugInfo in reduce-load-size pass (#3492)
2020-07-08 andreperezmaselco.developer spirv-fuzz: Add image sample unused components transformation (#3439)
2020-07-07 andreperezmaselco.developer spirv-fuzz: Add variables with workgroup storage class (#3485)
2020-07-07 andreperezmaselco.developer spirv-fuzz: Implement the OpVectorTimesMatrix linear algebra case (#3489)
2020-07-07 vasniktel spirv-fuzz: fuzzerutil::MaybeGetConstant* #3487

Created with:
  roll-dep third_party/spirv-tools