### PR TITLE
Update license-checker.cfg with simplified rules

### DIFF
--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -1,39 +1,42 @@
-{
-    "paths": [
-        {
-            "exclude": [
-                ".clang-format",
-                ".gitignore",
-                "*.md",
-                "AUTHORS",
-                "CHANGES",
-                "CONTRIBUTORS",
-                "DEPS",
-                "cmake/*.pc.in",
-                "glslc/README.asciidoc",
-                "kokoro/img/*.png",
-                "libshaderc_spvc/README.md",
-                "libshaderc_util/testdata/dir/subdir/include_file.2",
-                "libshaderc_util/testdata/include_file.1",
-                "libshaderc/README.md",
-                "LICENSE",
-                "spvc/README.asciidoc",
-                "spvc/test/known_failures",
-                "spvc/test/known_invalids",
-                "spvc/test/known_spvc_failures",
-                "spvc/test/unconfirmed_invalids",
+[
+    {
+        "licenses": [ "Apache-2.0-Header" ],
+        "paths": [
+            {
+                "exclude": [
+                    "**.md",
+                    "**.png",
+                    "**/README.asciidoc",
 
-                "spvc/test/reference/shaders-hlsl-no-opt/asm/vert/*.asm.vert",
-                "spvc/test/shaders-hlsl-no-opt/asm/*",
-                "third_party",
+                    ".*",
+                    "AUTHORS",
+                    "CHANGES",
+                    "CONTRIBUTORS",
+                    "DEPS",
+                    "LICENSE",
 
-                "spvc/test/shaders-hlsl-no-opt/asm/**.vert",
-                "third_party/**"
-            ]
-        }
-    ],
-    "licenses": [
-        "Apache-2.0-Header",
-        "BSD-3-Clause"
-    ]
-}
+                    "cmake/*.pc.in",
+                    "libshaderc_util/testdata/dir/subdir/include_file.2",
+                    "libshaderc_util/testdata/include_file.1",
+                    "spvc/README.asciidoc",
+                    "spvc/test/known_failures",
+                    "spvc/test/known_invalids",
+                    "spvc/test/known_spvc_failures",
+                    "spvc/test/unconfirmed_invalids",
+                    "spvc/test/**.vert",
+
+                    "utils/git-sync-deps",
+
+                    "third_party/**"
+                ]
+            }
+        ]
+    },
+    {
+        "licenses": [ "BSD-3-Clause" ],
+        "paths": [
+            { "exclude": [ "**" ] },
+            { "include": [ "utils/git-sync-deps" ] }
+        ]
+    }
+]


### PR DESCRIPTION
`license-checker` has been updated to support `**` wildcards simplifying the rules, and multiple license configs.

Add a new config for the `git-sync-deps` file, as this is the only file with a non-apache license type.