### PR TITLE
Adding support for the additional fixed sample mask in MSL

### DIFF
--- a/libshaderc_spvc/include/spvc/spvc.h
+++ b/libshaderc_spvc/include/spvc/spvc.h
@@ -443,6 +443,11 @@ SHADERC_EXPORT shaderc_spvc_status
 shaderc_spvc_compile_options_set_msl_buffer_size_buffer_index(
     shaderc_spvc_compile_options_t options, uint32_t index);
 
+// Set the additional fixed sample mask for MSL
+SHADERC_EXPORT shaderc_spvc_status
+shaderc_spvc_compile_options_set_msl_additional_fixed_sample_mask(
+    shaderc_spvc_compile_options_t options, uint32_t mask);
+
 // Set HLSL shader model.  Default is 30.
 SHADERC_EXPORT shaderc_spvc_status
 shaderc_spvc_compile_options_set_hlsl_shader_model(

--- a/libshaderc_spvc/include/spvc/spvc.hpp
+++ b/libshaderc_spvc/include/spvc/spvc.hpp
@@ -280,6 +280,12 @@ class CompileOptions {
         options_.get(), index);
   }
 
+  // Set the additional fixed sample mask for MSL
+  shaderc_spvc_status SetMSLAdditionalFixedSampleMask(uint32_t mask) {
+    return shaderc_spvc_compile_options_set_msl_additional_fixed_sample_mask(
+        options_.get(), mask);
+  }
+
   // Which HLSL shader model should be used.  Default is 30.
   shaderc_spvc_status SetHLSLShaderModel(uint32_t model) {
     return shaderc_spvc_compile_options_set_hlsl_shader_model(options_.get(),

--- a/libshaderc_spvc/src/spvc.cc
+++ b/libshaderc_spvc/src/spvc.cc
@@ -606,6 +606,15 @@ shaderc_spvc_compile_options_set_msl_buffer_size_buffer_index(
   return shaderc_spvc_status_success;
 }
 
+shaderc_spvc_status
+shaderc_spvc_compile_options_set_msl_additional_fixed_sample_mask(
+    shaderc_spvc_compile_options_t options, uint32_t mask) {
+  CHECK_OPTIONS(nullptr, options);
+
+  options->msl.additional_fixed_sample_mask = mask;
+  return shaderc_spvc_status_success;
+}
+
 shaderc_spvc_status shaderc_spvc_compile_options_set_hlsl_shader_model(
     shaderc_spvc_compile_options_t options, uint32_t model) {
   CHECK_OPTIONS(nullptr, options);

--- a/spvc/src/main.cc
+++ b/spvc/src/main.cc
@@ -89,6 +89,7 @@ Options:
   --msl-domain-lower-left
   --msl-argument-buffers
   --msl-discrete-descriptor-set=<number>
+  --msl-additional-fixed-sample-mask=<number>
   --emit-line-directives
   --hlsl-enable-compat
   --shader-model=<model>
@@ -295,6 +296,17 @@ int main(int argc, char** argv) {
         return 1;
       }
       msl_discrete_descriptor.push_back(descriptor_num);
+    } else if (arg.starts_with("--msl-additional-fixed-sample-mask=")) {
+      string_piece sample_mask_str;
+      GetOptionArgument(argc, argv, &i,
+                        "--msl-additional-fixed-sample-mask=", &sample_mask_str);
+      uint32_t sample_mask_num;
+      if (!shaderc_util::ParseUint32(sample_mask_str.str(), &sample_mask_num)) {
+        std::cerr << "spvc: error: invalid value '" << sample_mask_str
+                  << "' in --msl-additional-fixed-sample-mask=" << std::endl;
+        return 1;
+      }
+      options.SetMSLAdditionalFixedSampleMask(sample_mask_num);
     } else if (arg == "--emit-line-directives") {
       options.SetEmitLineDirectives(true);
     } else if (arg.starts_with("--shader-model=")) {


### PR DESCRIPTION
This includes updating a SPIRV-cross dependency.