### PR TITLE
Roll 5 dependencies and update expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': '3ee5f2f1d3316e228916788b300d786bb574d337',
-  'googletest_revision': 'a781fe29bcf73003559a3583167fe3d647518464',
+  'glslang_revision': '2de6d657dde37a421ff8afb1bd820d522df5821d',
+  'googletest_revision': 'e6e2d3b7614ff4e6017d8968bd4c3f579133666e',
   're2_revision': 'ca11026a032ce2a3de4b3c389ee53d2bdc8794d6',
-  'spirv_headers_revision': '979924c8bc839e4cb1b69d03d48398551f369ce7',
-  'spirv_tools_revision': 'b63f0e5ed3e818870968ebf6af73317127fd07b0',
-  'spirv_cross_revision': '0376576d2dc0721edfb2c5a0257fdc275f6f39dc',
+  'spirv_headers_revision': '3fdabd0da2932c276b25b9b4a988ba134eba1aa6',
+  'spirv_tools_revision': '9f2223602411e7484c916f2e896b15924cb380c3',
+  'spirv_cross_revision': '82d1c43e408510793a73a0886b5998283ee84d7b',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ 3ee5f2f1d..2de6d657d (6 commits)

https://github.com/KhronosGroup/glslang/compare/3ee5f2f1d331...2de6d657dde3

$ git log 3ee5f2f1d..2de6d657d --date=short --no-merges --format='%ad %ae %s'
2020-08-04 john SPV: Standalone; sanity check the client GLSL input semantics option value.
2020-08-04 john SPV: Use more correct SPV-Tools environment, partially addressing #2290
2020-08-04 john SPV: Fix #2363: include trailing newline named text SPV output.
2020-07-03 ShabbyX Use GLSLANG_ANGLE to strip features to what ANGLE requires
2020-07-31 bclayton Revert changes that migrate to `thread_local`.
2020-07-27 dneto Avoid spurious warning about uninit var

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ a781fe29b..e6e2d3b76 (5 commits)

https://github.com/google/googletest/compare/a781fe29bcf7...e6e2d3b7614f

$ git log a781fe29b..e6e2d3b76 --date=short --no-merges --format='%ad %ae %s'
2020-07-28 absl-team Googletest export
2020-07-28 absl-team Googletest export
2020-07-26 ofats Googletest export
2020-07-19 jasjuang fix clang tidy modernize-use-equals-default warnings
2020-07-02 siliconearth Fix test failing when simple regex is used

Created with:
  roll-dep third_party/googletest

Roll third_party/spirv-cross/ 0376576d2..82d1c43e4 (7 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/0376576d2dc0...82d1c43e4085

$ git log 0376576d2..82d1c43e4 --date=short --no-merges --format='%ad %ae %s'
2020-08-03 cdavis MSL: Fix handling of matrices and structs in the output control point array.
2020-07-29 post Add some test cases for complex type aliasing scenario.
2020-07-29 post Ensure that we use primary alias type when emitting flattened members.
2020-07-29 post GLSL: Be more aggressive about using type_alias.
2020-07-29 post Only rewrite type aliases for the base type.
2020-07-28 post GLSL: Add option to force flattening IO blocks.
2020-07-23 tommek Adding BuiltInSampleMask in HLSL

Created with:
  roll-dep third_party/spirv-cross

Roll third_party/spirv-headers/ 979924c8b..3fdabd0da (4 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/979924c8bc83...3fdabd0da293

$ git log 979924c8b..3fdabd0da --date=short --no-merges --format='%ad %ae %s'
2020-08-03 44190824+mmerecki Reserve SPIR-V token range for upcoming Intel extensions. (#165)
2020-07-29 alanbaker Update BUILD.bazel and BUILD.gn (#166)
2020-07-29 alanbaker Publish the headers for the clspv embedded reflection non-semantic extended instruction set (#164)
2020-07-29 johnkslang Update the registry in spir-v.xml to modernize and split out opcodes. (#156)

Created with:
  roll-dep third_party/spirv-headers

Roll third_party/spirv-tools/ b63f0e5ed..9f2223602 (18 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/b63f0e5ed3e8...9f2223602411

$ git log b63f0e5ed..9f2223602 --date=short --no-merges --format='%ad %ae %s'
2020-08-04 vasniktel spirv-fuzz: Refactor boilerplate in TransformationAddParameter (#3625)
2020-08-03 vasniktel spirv-fuzz: TransformationMoveInstructionDown (#3477)
2020-07-31 jaebaek Remove DebugDeclare only for target variables in ssa-rewrite (#3511)
2020-07-31 vasniktel Fix typo in ASAN CI build (#3623)
2020-07-30 stefanomil spirv-fuzz: Transformation to add loop preheader (#3599)
2020-07-30 stefanomil spirv-fuzz: Pass to replace int operands with ints of opposite signedness (#3612)
2020-07-30 jaebaek Debug info preservation in loop-unroll pass (#3548)
2020-07-30 alanbaker Validator support for non-semantic clspv reflection (#3618)
2020-07-30 vasniktel spirv-fuzz: Fix memory bugs (#3622)
2020-07-29 andreperezmaselco.developer spirv-fuzz: Implement the OpOuterProduct linear algebra case (#3617)
2020-07-30 vasniktel spirv-fuzz: Compute corollary facts from OpBitcast (#3538)
2020-07-29 dj2 Update some language usage. (#3611)
2020-07-29 vasniktel spirv-fuzz: Relax type constraints in DataSynonym facts (#3602)
2020-07-29 vasniktel spirv-fuzz: Remove non-deterministic behaviour (#3608)
2020-07-29 afdx Avoid use of 'sanity' and 'sanity check' in the code base (#3585)
2020-07-27 andreperezmaselco.developer spirv-fuzz: Add condition to make functions livesafe (#3587)
2020-07-27 rharrison Rolling 4 dependencies (#3601)
2020-07-27 andreperezmaselco.developer spirv-fuzz: Implement the OpTranspose linear algebra case (#3589)

Created with:
  roll-dep third_party/spirv-tools