### PR TITLE
Roll 5 dependencies and update expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': '3ee5f2f1d3316e228916788b300d786bb574d337',
-  'googletest_revision': 'a781fe29bcf73003559a3583167fe3d647518464',
+  'glslang_revision': 'b60e067b43744ce88adea33ab347ac9997b923d8',
+  'googletest_revision': '3af06fe1664d30f98de1e78c53a7087e842a2547',
   're2_revision': 'ca11026a032ce2a3de4b3c389ee53d2bdc8794d6',
-  'spirv_headers_revision': '979924c8bc839e4cb1b69d03d48398551f369ce7',
-  'spirv_tools_revision': 'b63f0e5ed3e818870968ebf6af73317127fd07b0',
-  'spirv_cross_revision': '0376576d2dc0721edfb2c5a0257fdc275f6f39dc',
+  'spirv_headers_revision': '3fdabd0da2932c276b25b9b4a988ba134eba1aa6',
+  'spirv_tools_revision': '2990a219264598311fa9f069999f56b774ad34e9',
+  'spirv_cross_revision': '82d1c43e408510793a73a0886b5998283ee84d7b',
 }
 
 deps = {

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -88,6 +88,10 @@ shaders-msl/tesc/load-control-point-array-of-struct.multi-patch.tesc,False
 shaders-msl/tesc/load-control-point-array-of-struct.multi-patch.tesc,True
 shaders-msl/tesc/load-control-point-array.multi-patch.tesc,False
 shaders-msl/tesc/load-control-point-array.multi-patch.tesc,True
+shaders-msl/tesc/matrix-output.multi-patch.tesc,False
+shaders-msl/tesc/matrix-output.multi-patch.tesc,True
+shaders-msl/tesc/struct-output.multi-patch.tesc,False
+shaders-msl/tesc/struct-output.multi-patch.tesc,True
 shaders-msl/tesc/water_tess.multi-patch.tesc,False
 shaders-msl/tesc/water_tess.multi-patch.tesc,True
 shaders-msl/vert/basic.for-tess.vert,False
@@ -109,6 +113,7 @@ shaders-no-opt/asm/comp/copy-logical.spv14.asm.comp,False
 shaders-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
 shaders-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-no-opt/frag/variables.zero-initialize.frag,False
+shaders-no-opt/vert/io-blocks.force-flattened-io.vert,False
 shaders-reflection/asm/aliased-entry-point-names.asm.multi,False
 shaders-reflection/asm/comp/pointer-to-array-of-physical-pointer.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -122,6 +122,10 @@ shaders-msl/tesc/load-control-point-array-of-struct.multi-patch.tesc,False
 shaders-msl/tesc/load-control-point-array-of-struct.multi-patch.tesc,True
 shaders-msl/tesc/load-control-point-array.multi-patch.tesc,False
 shaders-msl/tesc/load-control-point-array.multi-patch.tesc,True
+shaders-msl/tesc/matrix-output.multi-patch.tesc,False
+shaders-msl/tesc/matrix-output.multi-patch.tesc,True
+shaders-msl/tesc/struct-output.multi-patch.tesc,False
+shaders-msl/tesc/struct-output.multi-patch.tesc,True
 shaders-msl/tesc/water_tess.multi-patch.tesc,False
 shaders-msl/tesc/water_tess.multi-patch.tesc,True
 shaders-msl/vert/basic.for-tess.vert,False
@@ -155,6 +159,7 @@ shaders-no-opt/frag/16bit-constants.invalid.frag,False
 shaders-no-opt/frag/fp16.invalid.desktop.frag,False
 shaders-no-opt/frag/multi-dimensional.desktop.invalid.flatten_dim.frag,False
 shaders-no-opt/frag/variables.zero-initialize.frag,False
+shaders-no-opt/vert/io-blocks.force-flattened-io.vert,False
 shaders-reflection/asm/aliased-entry-point-names.asm.multi,False
 shaders-reflection/asm/comp/pointer-to-array-of-physical-pointer.asm.comp,False
 shaders-reflection/asm/op-source-glsl-ssbo-1.asm.comp,False


### PR DESCRIPTION
Roll third_party/glslang/ 3ee5f2f1d..b60e067b4 (8 commits)

https://github.com/KhronosGroup/glslang/compare/3ee5f2f1d331...b60e067b4374

$ git log 3ee5f2f1d..b60e067b4 --date=short --no-merges --format='%ad %ae %s'
2020-08-06 john SPV: Fix #1829: don't emit OpModuleProcessed use-storage-buffer
2020-08-05 john Build/Test: Dropping 2013 allows using the latest googletests.
2020-08-04 john SPV: Standalone; sanity check the client GLSL input semantics option value.
2020-08-04 john SPV: Use more correct SPV-Tools environment, partially addressing #2290
2020-08-04 john SPV: Fix #2363: include trailing newline named text SPV output.
2020-07-03 ShabbyX Use GLSLANG_ANGLE to strip features to what ANGLE requires
2020-07-31 bclayton Revert changes that migrate to `thread_local`.
2020-07-27 dneto Avoid spurious warning about uninit var

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ a781fe29b..3af06fe16 (12 commits)

https://github.com/google/googletest/compare/a781fe29bcf7...3af06fe1664d

$ git log a781fe29b..3af06fe16 --date=short --no-merges --format='%ad %ae %s'
2020-08-05 absl-team Googletest export
2020-08-03 absl-team Googletest export
2020-08-03 absl-team Googletest export
2020-08-05 zumix.cpp fix endif comment
2020-08-02 zumix.cpp fix tests
2020-07-29 franciscogthiesen Removing tiny-dnn from "Who is using.."
2020-07-28 absl-team Googletest export
2020-07-29 zumix.cpp fix GTEST_REMOVE_LEGACY_TEST_CASEAPI_ typo
2020-07-28 absl-team Googletest export
2020-07-26 ofats Googletest export
2020-07-19 jasjuang fix clang tidy modernize-use-equals-default warnings
2020-07-02 siliconearth Fix test failing when simple regex is used

Created with:
  roll-dep third_party/googletest

Roll third_party/spirv-cross/ 0376576d2..82d1c43e4 (7 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/0376576d2dc0...82d1c43e4085

$ git log 0376576d2..82d1c43e4 --date=short --no-merges --format='%ad %ae %s'
2020-08-03 cdavis MSL: Fix handling of matrices and structs in the output control point array.
2020-07-29 post Add some test cases for complex type aliasing scenario.
2020-07-29 post Ensure that we use primary alias type when emitting flattened members.
2020-07-29 post GLSL: Be more aggressive about using type_alias.
2020-07-29 post Only rewrite type aliases for the base type.
2020-07-28 post GLSL: Add option to force flattening IO blocks.
2020-07-23 tommek Adding BuiltInSampleMask in HLSL

Created with:
  roll-dep third_party/spirv-cross

Roll third_party/spirv-headers/ 979924c8b..3fdabd0da (4 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/979924c8bc83...3fdabd0da293

$ git log 979924c8b..3fdabd0da --date=short --no-merges --format='%ad %ae %s'
2020-08-03 44190824+mmerecki Reserve SPIR-V token range for upcoming Intel extensions. (#165)
2020-07-29 alanbaker Update BUILD.bazel and BUILD.gn (#166)
2020-07-29 alanbaker Publish the headers for the clspv embedded reflection non-semantic extended instruction set (#164)
2020-07-29 johnkslang Update the registry in spir-v.xml to modernize and split out opcodes. (#156)

Created with:
  roll-dep third_party/spirv-headers

Roll third_party/spirv-tools/ b63f0e5ed..2990a2192 (30 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/b63f0e5ed3e8...2990a2192645

$ git log b63f0e5ed..2990a2192 --date=short --no-merges --format='%ad %ae %s'
2020-08-10 stevenperron Avoid using /MP4 for clang on windows. (#3662)
2020-08-06 antonikarp spirv-fuzz: TransformationReplaceAddSubMulWithCarryingExtended (#3598)
2020-08-06 andreperezmaselco.developer spirv-fuzz: Add TransformationMakeVectorOperationDynamic (#3597)
2020-08-06 andreperezmaselco.developer spirv-fuzz: iterate over blocks in replace linear algebra pass (#3654)
2020-08-06 stefanomil spirv-fuzz: make outliner pass use additional transformations (#3604)
2020-08-05 jaebaek OpenCL.DebugInfo.100 DebugTypeArray with variable size (#3549)
2020-08-05 andreperezmaselco.developer spirv-opt: Improve the code of the Instruction class (#3610)
2020-08-05 vasniktel spirv-fuzz: Handle OpPhis in livesafe functions (#3642)
2020-08-05 vasniktel spirv-fuzz: Handle OpPhi during constant obfuscation (#3640)
2020-08-05 vasniktel spirv-fuzz: Fix FuzzerPassCopyObjects (#3638)
2020-08-04 vasniktel spirv-fuzz: Remove OpFunctionCall operands in correct order (#3630)
2020-08-04 vasniktel spirv-fuzz: Handle capabilities during module donation (#3651)
2020-08-04 vasniktel spirv-fuzz: Refactor boilerplate in TransformationAddParameter (#3625)
2020-08-03 vasniktel spirv-fuzz: TransformationMoveInstructionDown (#3477)
2020-07-31 jaebaek Remove DebugDeclare only for target variables in ssa-rewrite (#3511)
2020-07-31 vasniktel Fix typo in ASAN CI build (#3623)
2020-07-30 stefanomil spirv-fuzz: Transformation to add loop preheader (#3599)
2020-07-30 stefanomil spirv-fuzz: Pass to replace int operands with ints of opposite signedness (#3612)
2020-07-30 jaebaek Debug info preservation in loop-unroll pass (#3548)
2020-07-30 alanbaker Validator support for non-semantic clspv reflection (#3618)
2020-07-30 vasniktel spirv-fuzz: Fix memory bugs (#3622)
2020-07-29 andreperezmaselco.developer spirv-fuzz: Implement the OpOuterProduct linear algebra case (#3617)
2020-07-30 vasniktel spirv-fuzz: Compute corollary facts from OpBitcast (#3538)
2020-07-29 dj2 Update some language usage. (#3611)
2020-07-29 vasniktel spirv-fuzz: Relax type constraints in DataSynonym facts (#3602)
2020-07-29 vasniktel spirv-fuzz: Remove non-deterministic behaviour (#3608)
2020-07-29 afdx Avoid use of 'sanity' and 'sanity check' in the code base (#3585)
2020-07-27 andreperezmaselco.developer spirv-fuzz: Add condition to make functions livesafe (#3587)
2020-07-27 rharrison Rolling 4 dependencies (#3601)
2020-07-27 andreperezmaselco.developer spirv-fuzz: Implement the OpTranspose linear algebra case (#3589)

Created with:
  roll-dep third_party/spirv-tools