### PR TITLE
Add support for Dawn using deprecated Options constructor

### DIFF
--- a/libshaderc_spvc/src/spvc_cpp_test.cc
+++ b/libshaderc_spvc/src/spvc_cpp_test.cc
@@ -25,6 +25,10 @@ namespace {
 
 class CompileTest : public testing::Test {
  public:
+  CompileTest()
+      : options_(shaderc_spvc_spv_env_vulkan_1_1,
+                 shaderc_spvc_spv_env_vulkan_1_1) {}
+
   Context context_;
   CompileOptions options_;
   CompilationResult result_;

--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -166,6 +166,7 @@ shaderc_spvc_status translate_spirv(shaderc_spvc_context* context,
   }
 
   if (options->robust_buffer_access_pass) {
+    registered_pass = true;
     opt.RegisterPass(spvtools::CreateGraphicsRobustAccessPass());
   }
 

--- a/libshaderc_spvc/src/spvc_private.cc
+++ b/libshaderc_spvc/src/spvc_private.cc
@@ -136,14 +136,6 @@ shaderc_spvc_status translate_spirv(shaderc_spvc_context* context,
     return shaderc_spvc_status_transformation_error;
   }
 
-  // TODO: Remove special case for SPIRV 1.0 once the deprecated options
-  // constructor with defaults is removed.
-  if (source_env == target_env && source_env != SPV_ENV_UNIVERSAL_1_0) {
-    target->resize(source_len);
-    memcpy(target->data(), source, source_len * sizeof(uint32_t));
-    return shaderc_spvc_status_success;
-  }
-
   spvtools::Optimizer opt(source_env);
   opt.SetMessageConsumer(std::bind(
       consume_spirv_tools_message, context, std::placeholders::_1,

--- a/libshaderc_spvc/src/spvc_test.cc
+++ b/libshaderc_spvc/src/spvc_test.cc
@@ -28,7 +28,7 @@ class CompileTest : public testing::Test {
   void SetUp() override {
     context_ = shaderc_spvc_context_create();
     options_ = shaderc_spvc_compile_options_create(
-        shaderc_spvc_spv_env_vulkan_1_0, shaderc_spvc_spv_env_vulkan_1_0);
+        shaderc_spvc_spv_env_vulkan_1_1, shaderc_spvc_spv_env_vulkan_1_1);
     result_ = shaderc_spvc_result_create();
   }
 


### PR DESCRIPTION
This is a workaround to unblock work going on in Dawn while I finish
off converting Dawn to use the new API.