### PR TITLE
Roll 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': 'b60e067b43744ce88adea33ab347ac9997b923d8',
-  'googletest_revision': '3af06fe1664d30f98de1e78c53a7087e842a2547',
+  'glslang_revision': 'f257e0ea6b9aeab2dc7af3207ac6d29d2bbc01d0',
+  'googletest_revision': 'adeef192947fbc0f68fa14a6c494c8df32177508',
   're2_revision': 'ca11026a032ce2a3de4b3c389ee53d2bdc8794d6',
   'spirv_headers_revision': '3fdabd0da2932c276b25b9b4a988ba134eba1aa6',
-  'spirv_tools_revision': '2990a219264598311fa9f069999f56b774ad34e9',
-  'spirv_cross_revision': '82d1c43e408510793a73a0886b5998283ee84d7b',
+  'spirv_tools_revision': 'b8de4f57e9838c107bcbf17cf1e02608651c0e1d',
+  'spirv_cross_revision': '4c7944bb4260ab0466817c932a9673b6cf59438e',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ b60e067b4..f257e0ea6 (11 commits)

https://github.com/KhronosGroup/glslang/compare/b60e067b4374...f257e0ea6b9a

$ git log b60e067b4..f257e0ea6 --date=short --no-merges --format='%ad %ae %s'
2020-08-14 john Build: fix a build warning
2020-08-14 rafael.fariasmarinheiro Use --test-root to pass files to Bazel tests.
2020-08-14 john Fix #2366, fix #2358, correctly separate out numerical feature checking
2020-08-14 john Non-functional (almost): Refactor when 'extensionRequested' is called.
2020-08-14 john Non-functional: Remove reinventing the scalar type, note code issues
2020-08-11 john Non-functional: spellings of "destinaton" and "addPairConversion"
2020-08-12 alanbaker Update test expectations
2020-08-12 alanbaker Update SPIRV-Tools and SPIRV-Headers known good
2020-08-10 ezdiy GLSLANG_EXPORT for C APIs.
2020-08-07 john Non-functional: correctly do GL_EXT_buffer_reference2 semantic checking
2020-08-06 john Non-functional: consistently use 'const TSourceLoc&' to pass location.

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ 3af06fe16..adeef1929 (4 commits)

https://github.com/google/googletest/compare/3af06fe1664d...adeef192947f

$ git log 3af06fe16..adeef1929 --date=short --no-merges --format='%ad %ae %s'
2020-08-12 krzysio Googletest export
2020-08-11 absl-team Googletest export
2020-08-11 dmauro Googletest export
2020-08-10 absl-team Googletest export

Created with:
  roll-dep third_party/googletest

Roll third_party/spirv-cross/ 82d1c43e4..4c7944bb4 (1 commit)

https://github.com/KhronosGroup/SPIRV-Cross/compare/82d1c43e4085...4c7944bb4260

$ git log 82d1c43e4..4c7944bb4 --date=short --no-merges --format='%ad %ae %s'
2020-08-13 lehoangq Fix #1445: MSL: Enclose args when convert distance(a,b) to abs(a-b)

Created with:
  roll-dep third_party/spirv-cross

Roll third_party/spirv-tools/ 2990a2192..b8de4f57e (19 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/2990a2192645...b8de4f57e983

$ git log 2990a2192..b8de4f57e --date=short --no-merges --format='%ad %ae %s'
2020-08-16 jaebaek Allow DebugTypeTemplate for Type operand (#3702)
2020-08-14 antonikarp spirv-fuzz: Improve code coverage of tests (#3686)
2020-08-14 stefanomil spirv-fuzz: Fuzzer pass to randomly apply loop preheaders (#3668)
2020-08-14 vasniktel spirv-fuzz: Support identical predecessors in TransformationPropagateInstructionUp (#3689)
2020-08-13 alanbaker Improve non-semantic instruction handling in the optimizer (#3693)
2020-08-13 vasniktel Fix the bug (#3680)
2020-08-12 andreperezmaselco.developer spirv-fuzz: Check integer and float width capabilities (#3670)
2020-08-12 andreperezmaselco.developer spirv-fuzz: consider additional access chain instructions (#3672)
2020-08-12 andreperezmaselco.developer spirv-fuzz: Ignore specialization constants (#3664)
2020-08-12 vasniktel Fix the bug (#3683)
2020-08-12 vasniktel spirv-fuzz: Fix width in FuzzerPassAddEquationInstructions (#3685)
2020-08-12 jaebaek Preserve debug info in dead-insert-elim pass (#3652)
2020-08-12 jaebaek Validate more OpenCL.DebugInfo.100 instructions (#3684)
2020-08-11 alanbaker Only validation locations for appropriate execution models (#3656)
2020-08-11 andreperezmaselco.developer spirv-fuzz: Fix in operand type assertion (#3666)
2020-08-11 andreperezmaselco.developer spirv-opt: Add spvOpcodeIsAccessChain (#3682)
2020-08-11 vasniktel spirv-fuzz: FuzzerPassPropagateInstructionsUp (#3478)
2020-08-10 stevenperron Handle no index access chain in local access chain convert (#3678)
2020-08-10 rharrison Roll 2 dependencies (#3677)

Created with:
  roll-dep third_party/spirv-tools