### PR TITLE
Roll 4 dependencies and updated expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,12 +5,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': 'f257e0ea6b9aeab2dc7af3207ac6d29d2bbc01d0',
-  'googletest_revision': 'adeef192947fbc0f68fa14a6c494c8df32177508',
+  'glslang_revision': '983698bb34ecfbf8a172a59ee4edc2ab7bdfa3b8',
+  'googletest_revision': '1e315c5b1a62707fac9b8f1d4e03180ee7507f98',
   're2_revision': 'ca11026a032ce2a3de4b3c389ee53d2bdc8794d6',
   'spirv_headers_revision': '3fdabd0da2932c276b25b9b4a988ba134eba1aa6',
-  'spirv_tools_revision': 'b8de4f57e9838c107bcbf17cf1e02608651c0e1d',
-  'spirv_cross_revision': '4c7944bb4260ab0466817c932a9673b6cf59438e',
+  'spirv_tools_revision': '4dd122392f3ad757e70951a1198479bf233d4cd8',
+  'spirv_cross_revision': '685f86471e9d26b3eb7676695a2e2cefb4551ae9',
 }
 
 deps = {

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -1,4 +1,5 @@
 shaders-hlsl-no-opt/asm/frag/phi.zero-initialize.asm.frag,False
+shaders-hlsl-no-opt/asm/frag/struct-packing-last-element-array-matrix-rule.invalid.asm.frag,False
 shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders-hlsl-no-opt/asm/temporary.zero-initialize.asm.frag,False
 shaders-hlsl-no-opt/frag/constant-buffer-array.invalid.sm51.frag,False

--- a/spvc/test/unconfirmed_invalids
+++ b/spvc/test/unconfirmed_invalids
@@ -1,3 +1,4 @@
+shaders-hlsl-no-opt/asm/frag/struct-packing-last-element-array-matrix-rule.invalid.asm.frag,False
 shaders-hlsl-no-opt/asm/frag/switch-block-case-fallthrough.asm.invalid.frag,False
 shaders-hlsl-no-opt/frag/constant-buffer-array.invalid.sm51.frag,False
 shaders-hlsl-no-opt/frag/fp16.invalid.desktop.frag,False
@@ -6,6 +7,13 @@ shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-3.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding-5.asm.comp,False
 shaders-msl-no-opt/asm/packing/load-packed-no-forwarding.asm.comp,False
 shaders-msl-no-opt/asm/packing/packed-vector-extract-insert.asm.comp,False
+shaders-msl-no-opt/asm/packing/scalar-array-float2.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-array-float3-one-element.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-array-float3.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float2x2-col-major.invalid.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float2x3-col-major.invalid.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float3x2-col-major.invalid.asm.frag,False
+shaders-msl-no-opt/asm/packing/scalar-float3x3-col-major.invalid.asm.frag,False
 shaders-msl-no-opt/frag/16bit-constants.invalid.frag,False
 shaders-msl-no-opt/frag/fp16.desktop.invalid.frag,False
 shaders-msl-no-opt/frag/min-max-clamp.invalid.asm.frag,False
@@ -29,10 +37,3 @@ shaders-no-opt/asm/frag/switch-merge-to-continue.asm.invalid.frag,False
 shaders-no-opt/frag/16bit-constants.invalid.frag,False
 shaders-no-opt/frag/fp16.invalid.desktop.frag,False
 shaders-no-opt/frag/multi-dimensional.desktop.invalid.flatten_dim.frag,False
-shaders-msl-no-opt/asm/packing/scalar-array-float2.asm.frag,False
-shaders-msl-no-opt/asm/packing/scalar-array-float3-one-element.asm.frag,False
-shaders-msl-no-opt/asm/packing/scalar-array-float3.asm.frag,False
-shaders-msl-no-opt/asm/packing/scalar-float2x2-col-major.invalid.asm.frag,False
-shaders-msl-no-opt/asm/packing/scalar-float2x3-col-major.invalid.asm.frag,False
-shaders-msl-no-opt/asm/packing/scalar-float3x2-col-major.invalid.asm.frag,False
-shaders-msl-no-opt/asm/packing/scalar-float3x3-col-major.invalid.asm.frag,False


### PR DESCRIPTION
Roll third_party/glslang/ f257e0ea6..983698bb3 (2 commits)

https://github.com/KhronosGroup/glslang/compare/f257e0ea6b9a...983698bb34ec

$ git log f257e0ea6..983698bb3 --date=short --no-merges --format='%ad %ae %s'
2020-08-23 john Revert "Merge pull request #2371 from RafaelMarinheiro/master"
2020-08-21 julius.ikkala Obey ENABLE_PCH CMake option

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ adeef1929..1e315c5b1 (14 commits)

https://github.com/google/googletest/compare/adeef192947f...1e315c5b1a62

$ git log adeef1929..1e315c5b1 --date=short --no-merges --format='%ad %ae %s'
2020-08-20 absl-team Googletest export
2020-08-17 absl-team Googletest export
2020-08-12 robert.earhart Export LICENSE
2020-08-03 amatanhead Remove ThrowsMessageHasSubstr and fix some nits after review
2020-07-13 amatanhead Cleanup a bulky expression, document implementation details
2020-07-07 amatanhead Fix build under msvc
2020-07-07 amatanhead Update tests after changing an error message
2020-07-07 amatanhead Fix build under msvc
2020-07-07 amatanhead Add a test to ensure that the `Throws` matcher only invokes its argument once.
2020-07-07 amatanhead Add a test for duplicate catch clauses in throw matchers, fix a couple of nitpicks.
2020-07-03 amatanhead Add missing documentation piece
2020-06-20 amatanhead Small improvements: code style and property name
2020-06-20 amatanhead Add matchers for testing exception properties
2018-05-01 lantw44 Avoid using environ on FreeBSD

Created with:
  roll-dep third_party/googletest

Roll third_party/spirv-cross/ 4c7944bb4..685f86471 (6 commits)

https://github.com/KhronosGroup/SPIRV-Cross/compare/4c7944bb4260...685f86471e9d

$ git log 4c7944bb4..685f86471 --date=short --no-merges --format='%ad %ae %s'
2020-08-24 post Run format_all.sh.
2020-08-24 post Work around annoying warning on GCC 10.2.
2020-08-21 post Overhaul how we deal with reserved identifiers.
2020-08-20 post HLSL: Fix FragCoord.w.
2020-08-20 post HLSL: Deal with partially filled 16-byte word in cbuffers.
2020-08-20 post HLSL: Fix bug in is_packing_standard for cbuffer.

Created with:
  roll-dep third_party/spirv-cross

Roll third_party/spirv-tools/ b8de4f57e..4dd122392 (9 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/b8de4f57e983...4dd122392f3a

$ git log b8de4f57e..4dd122392 --date=short --no-merges --format='%ad %ae %s'
2020-08-21 andreperezmaselco.developer spirv-fuzz: Add words instead of logical operands (#3728)
2020-08-20 dnovillo CCP should mark IR changed if it created new constants. (#3732)
2020-08-19 antonikarp spirv-fuzz: add FuzzerPassAddCompositeInserts (#3606)
2020-08-19 antonikarp spirv-fuzz: Support pointer types in FuzzerPassAddParameters (#3627)
2020-08-18 jaebaek Let ADCE pass check DebugScope (#3703)
2020-08-18 andreperezmaselco.developer spirv-opt: Implement opt::Function::HasEarlyReturn function (#3711)
2020-08-17 andreperezmaselco.developer spirv-fuzz: Check termination instructions when donating modules (#3710)
2020-08-17 jackoalan Fix -Wrange-loop-analysis warning (#3712)
2020-08-17 andreperezmaselco.developer spirv-fuzz: Check header dominance when adding dead block (#3694)

Created with:
  roll-dep third_party/spirv-tools