### PR TITLE
Roll 3 dependencies and update expectations

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': '983698bb34ecfbf8a172a59ee4edc2ab7bdfa3b8',
-  'googletest_revision': '1e315c5b1a62707fac9b8f1d4e03180ee7507f98',
+  'glslang_revision': '517f39eee46f27c83527117d831c4d7e2f7c9fe3',
+  'googletest_revision': 'df6b75949b1efab7606ba60c0f0a0125ac95c5af',
   're2_revision': 'ca11026a032ce2a3de4b3c389ee53d2bdc8794d6',
   'spirv_headers_revision': '3fdabd0da2932c276b25b9b4a988ba134eba1aa6',
-  'spirv_tools_revision': '4dd122392f3ad757e70951a1198479bf233d4cd8',
+  'spirv_tools_revision': '8a0ebd40f86d1f18ad42ea96c6ac53915076c3c7',
   'spirv_cross_revision': '685f86471e9d26b3eb7676695a2e2cefb4551ae9',
 }
 

--- a/spvc/test/known_failures
+++ b/spvc/test/known_failures
@@ -74,6 +74,7 @@ shaders-msl/frag/sample-mask-not-used.fixed-sample-mask.frag,False
 shaders-msl/frag/sample-mask-not-used.fixed-sample-mask.frag,True
 shaders-msl/frag/sample-mask.fixed-sample-mask.frag,False
 shaders-msl/frag/sample-mask.fixed-sample-mask.frag,True
+shaders-msl/frag/shader-arithmetic-8bit.frag,True
 shaders-msl/frag/subgroup-builtins.msl22.frag,False
 shaders-msl/frag/subgroup-builtins.msl22.frag,True
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,False

--- a/spvc/test/known_spvc_failures
+++ b/spvc/test/known_spvc_failures
@@ -109,6 +109,7 @@ shaders-msl/frag/sample-mask-not-used.fixed-sample-mask.frag,False
 shaders-msl/frag/sample-mask-not-used.fixed-sample-mask.frag,True
 shaders-msl/frag/sample-mask.fixed-sample-mask.frag,False
 shaders-msl/frag/sample-mask.fixed-sample-mask.frag,True
+shaders-msl/frag/shader-arithmetic-8bit.frag,True
 shaders-msl/frag/subgroup-builtins.msl22.frag,False
 shaders-msl/frag/subgroup-builtins.msl22.frag,True
 shaders-msl/frag/texture-cube-array.ios.emulate-cube-array.frag,False


### PR DESCRIPTION
Roll third_party/glslang/ 983698bb3..517f39eee (1 commit)

https://github.com/KhronosGroup/glslang/compare/983698bb34ec...517f39eee46f

$ git log 983698bb3..517f39eee --date=short --no-merges --format='%ad %ae %s'
2020-08-26 jmadill Suppress two override suggestion warnings.

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ 1e315c5b1..df6b75949 (1 commit)

https://github.com/google/googletest/compare/1e315c5b1a62...df6b75949b1e

$ git log 1e315c5b1..df6b75949 --date=short --no-merges --format='%ad %ae %s'
2020-08-26 absl-team Googletest export

Created with:
  roll-dep third_party/googletest

Roll third_party/spirv-tools/ 4dd122392..8a0ebd40f (14 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/4dd122392f3a...8a0ebd40f86d

$ git log 4dd122392..8a0ebd40f --date=short --no-merges --format='%ad %ae %s'
2020-08-31 jaebaek Correctly replace debug lexical scope of instruction (#3718)
2020-08-28 afdx spirv-fuzz: Remove opaque pointer design pattern (#3755)
2020-08-27 stefanomil spirv-fuzz: Create synonym via OpPhi and existing synonyms (#3701)
2020-08-27 stefanomil Add LoopNestingDepth function to StructuredCFGAnalysis (#3754)
2020-08-27 afdx spirv-fuzz: Do not make synonyms of void result ids (#3747)
2020-08-26 greg Do not register DebugFunction for functions optimized away. (#3749)
2020-08-26 jaebaek Handle DebugScope in compact-ids pass (#3724)
2020-08-26 afdx spirv-fuzz: Overflow ids (#3734)
2020-08-25 greg Fix DebugNoScope to not output InlinedAt operand. (#3748)
2020-08-25 vasniktel spirv-fuzz: Split the fact manager into multiple files (#3699)
2020-08-25 andreperezmaselco.developer spirv-fuzz: Add inline function transformation (#3517)
2020-08-25 vasniktel spirv-fuzz: Fix MaybeGetZeroConstant (#3740)
2020-08-24 greg Fix SSA-rewrite to remove DebugDeclare for variables without loads (#3719)
2020-08-24 stevenperron Add undef for inlined void function (#3720)

Created with:
  roll-dep third_party/spirv-tools