### PR TITLE
Fixed too many initializers error

### DIFF
--- a/libshaderc_util/src/resources.cc
+++ b/libshaderc_util/src/resources.cc
@@ -125,7 +125,6 @@ const TBuiltInResource kDefaultTBuiltInResource = {
     /* .maxTaskWorkGroupSizeY_NV = */ 1,
     /* .maxTaskWorkGroupSizeZ_NV = */ 1,
     /* .maxMeshViewCountNV = */ 4,
-    /* .maxDualSourceDrawBuffersEXT = */ 1,
     // This is the glslang TLimits structure.
     // It defines whether or not the following features are enabled.
     // We want them to all be enabled.


### PR DESCRIPTION
I upgraded our submodule to `v2020.3` tag and I was getting `too many initializers` build error. I figured `TBuiltInResource::maxDualSourceDrawBuffersEXT` doesnt exist any more.