### PR TITLE
Roll 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': '517f39eee46f27c83527117d831c4d7e2f7c9fe3',
-  'googletest_revision': 'df6b75949b1efab7606ba60c0f0a0125ac95c5af',
-  're2_revision': 'ca11026a032ce2a3de4b3c389ee53d2bdc8794d6',
-  'spirv_headers_revision': '3fdabd0da2932c276b25b9b4a988ba134eba1aa6',
-  'spirv_tools_revision': '8a0ebd40f86d1f18ad42ea96c6ac53915076c3c7',
+  'glslang_revision': '142cb87f803d42f5ae3dd2da8dff4f19f6f15e8c',
+  'googletest_revision': '2828773179fa425ee406df61890a150577178ea2',
+  're2_revision': '166dbbeb3b0ab7e733b278e8f42a84f6882b8a25',
+  'spirv_headers_revision': '7845730cab6ebbdeb621e7349b7dc1a59c3377be',
+  'spirv_tools_revision': 'f7da527757140ae701be58274ce6db2f4234d9ff',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ 517f39eee..142cb87f8 (35 commits)

https://github.com/KhronosGroup/glslang/compare/517f39eee46f...142cb87f803d

$ git log 517f39eee..142cb87f8 --date=short --no-merges --format='%ad %ae %s'
2020-10-23 rex.xu HLSL: Add support for printf().
2020-10-21 bclayton Fix GN build and presubmits
2020-10-20 john SPV: Update to the latest SPIR-V header, includes variable-rate shading
2020-07-02 laddoc Add GL_EXT_fragment_shading_rate
2020-10-20 bclayton Kokoro: Add configurations for GN presubmit
2020-10-19 bclayton Fix uninitialized use of TIntermediate::resource (#2424)
2020-10-16 bclayton Add GN build instructions to README.md
2020-10-16 bclayton Add basic GN configurations
2020-10-12 hwguy.siplus SPIR-V: Remove SpvTools.h include from disassemble.cpp (#2417)
2020-10-12 rverschelde Remove executable bits from code/data files (#2420)
2020-10-07 dneto Add test case for read-only storage texture passed to helper function (#2414)
2020-10-07 8729214+jonahryandavis Disable -Wno-conversion on MSVC compiler (#2410)
2020-10-05 cepheus Revert "Add new SpirvToolsDisassemble API interface + Improve Doc on existing API interface (#2408)"
2020-10-05 dev Add new SpirvToolsDisassemble API interface + Improve Doc on existing API interface (#2408)
2020-09-27 cepheus Revert "Add more flexible SpirvToolsDisassemble interface to allow specifying spv_target_env for disassembly output. (#2406)"
2020-09-27 dev Add more flexible SpirvToolsDisassemble interface to allow specifying spv_target_env for disassembly output. (#2406)
2020-09-26 cstout [spirv-remap] Fix undefined behavior in hashing (#2403)
2020-09-26 cstout [Wconversion] Suppress glslang issue (#2404)
2020-09-24 greg Update spirv-tools and spirv-headers known goods (#2401)
2020-09-18 rex.xu SPIRV: Add more utility functions to build some opcodes (#2398)
2020-09-15 laddoc Preprocessor related issue fix (#2378)
2020-09-14 rex.xu SPIRV: Add disassembly support for multiple literal strings (#2397)
2020-09-14 laddoc Fix scope definition in ES 100. (#2379)
2020-09-14 john Fix #2385: guard against constant_id on non-const.
2020-09-12 shuizhuyuanluo Try to find python interpreter from host first
2020-09-11 ShabbyX Allow subpassLoad for ANGLE
2020-09-09 greg Add texture sample to nonuniform test
2020-09-08 greg Add buffer store to nonuniform tests
2020-09-03 bas SPV: Add NonUniform decoration for constructors.
2020-09-03 bas SPV: Add NonUniform decoration for OpImages created during lowering.
2020-08-24 bas SPV: Add NonUniform decorations for stores.
2020-09-08 tobias.hector Added missing copyright amendment
2020-09-07 rex.xu SPIRV: Fix some disassembly issues
2020-09-03 tobias.hector Error when initializing rayQuery with assignment
2020-09-02 rex.xu Parser: Fix wrong names of extension macros

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ df6b75949..282877317 (41 commits)

https://github.com/google/googletest/compare/df6b75949b1e...2828773179fa

$ git log df6b75949..282877317 --date=short --no-merges --format='%ad %ae %s'
2020-10-27 absl-team Googletest export
2020-10-26 absl-team Googletest export
2020-10-20 sonzogniarthur Fix typo "definedin in" => "defined in"
2020-10-15 absl-team Googletest export
2020-10-15 absl-team Googletest export
2020-10-15 dmauro Googletest export
2020-10-14 absl-team Googletest export
2020-10-14 dmauro Googletest export
2020-10-14 dmauro Googletest export
2020-10-14 absl-team Googletest export
2020-10-14 dmauro Googletest export
2020-10-14 absl-team Googletest export
2020-10-13 dmauro Googletest export
2020-10-13 dmauro Googletest export
2020-10-13 absl-team Googletest export
2020-10-13 absl-team Googletest export
2020-10-09 ofats Googletest export
2020-10-09 absl-team Googletest export
2020-10-08 absl-team Googletest export
2020-10-12 peternewman Fix a typo
2020-10-07 manavrion Improve FilePath::Normalize method
2020-10-07 pravin1992 Issue 2135: Change template args in NiceMock, NaggyMock and StrictMock from A1, A2, ... to TArg1, TArg2,... to avoid clash with legacy header files
2020-09-29 absl-team Googletest export
2020-10-01 63450189+ranodeepbanerjee A slight Gramatical change.
2020-09-29 dmauro Googletest export
2020-09-29 absl-team Googletest export
2020-09-25 absl-team Googletest export
2020-09-27 56075233+keshavgbpecdelhi Update cook_book.md
2020-09-23 absl-team Googletest export
2020-09-23 absl-team Googletest export
2020-09-21 absl-team Googletest export
2020-09-24 thomas.barbier Fix warning maybe-uninitialized
2020-09-18 absl-team Googletest export
2020-09-17 absl-team Googletest export
2020-09-18 63900998+JethroSama Update README.md, added missing 'a'
2020-09-08 absl-team Googletest export
2020-09-02 dmauro Googletest export
2020-09-01 absl-team Googletest export
2020-09-01 absl-team Googletest export
2020-08-25 27jf Add timestamp to in old method mock macro guide
2020-05-05 igor.n.nazarenko Detect proto messages based on presense of DebugString.

Created with:
  roll-dep third_party/googletest

Roll third_party/re2/ ca11026a0..166dbbeb3 (25 commits)

https://github.com/google/re2/compare/ca11026a032c...166dbbeb3b0a

$ git log ca11026a0..166dbbeb3 --date=short --no-merges --format='%ad %ae %s'
2020-10-26 junyer Fix symbol visibility and add test coverage.
2020-10-13 junyer Get the conditional right this time. Sigh.
2020-10-13 junyer Don't support ParseFrom() on MSVC. It can cause ICEs.
2020-10-09 junyer Ensure that RE2::Arg works even with overloaded ParseFrom().
2020-10-08 junyer Refactor the RE2::Arg templates for readability.
2020-10-07 junyer Rename namespace internal to namespace re2_internal.
2020-10-07 junyer Address `-Wunused-parameter' warnings.
2020-10-07 junyer Add missing #include. Mea culpa.
2020-10-07 junyer Rework RE2::Arg with templates instead of macros.
2020-10-06 junyer Write `typename' in templates rather than `class'.
2020-09-27 junyer Fix some indentation.
2020-09-27 junyer Set BAZELISK_GITHUB_TOKEN.
2020-09-25 junyer Point to the official Python wrapper.
2020-09-25 junyer Disable fail-fast in GitHub Actions.
2020-09-25 junyer Fix a template that will break with GCC 11.x.
2020-09-22 junyer Try to use the Clang packages instead.
2020-09-22 junyer Try to make the Clang containers work.
2020-09-22 junyer Configure a build matrix for Clang using containers.
2020-09-22 junyer Address `-Wclass-memaccess' warnings from GCC 10.x.
2020-09-22 junyer Configure a build matrix for GCC using containers.
2020-09-22 junyer Migrate from Kokoro to GitHub Actions for Bazel.
2020-09-22 junyer Migrate from Kokoro to GitHub Actions for CMake.
2020-09-22 junyer Remove Travis CI configuration.
2020-09-22 junyer Initial GitHub Actions CI configuration.
2020-09-22 junyer Improve the comments for RE2::FullMatch() et al.

Created with:
  roll-dep third_party/re2

Roll third_party/spirv-headers/ 3fdabd0da..7845730ca (7 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/3fdabd0da293...7845730cab6e

$ git log 3fdabd0da..7845730ca --date=short --no-merges --format='%ad %ae %s'
2020-10-23 john Bump revision to 4, for SPIR-V 1.5.
2020-10-19 TobyHector Add SPV_EXT_shader_image_int64 (#170)
2020-10-19 TobyHector Added SPV_KHR_fragment_shading_rate (#172)
2020-10-12 hwguy.siplus  Register the Xenia emulator as a generator (#171)
2020-09-27 atyuwen Register the Messiah SPIR-V CodeGen (#169)
2020-09-10 syoussefi Register the ANGLE compiler (#168)
2020-09-08 cepheus Rebuild of latest headers, which slightly moves OpTerminateInvocation

Created with:
  roll-dep third_party/spirv-headers

Roll third_party/spirv-tools/ 8a0ebd40f..f7da52775 (138 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/8a0ebd40f86d...f7da52775714

$ git log 8a0ebd40f..f7da52775 --date=short --no-merges --format='%ad %ae %s'
2020-10-30 jaebaek Temporarily add EmptyPass to prevent glslang from failing (#4004)
2020-10-30 Junda.Liu spirv-opt: Add support to prevent functions from being inlined if they have DontInline flag (#3858)
2020-10-29 jaebaek Propagate OpLine to all applied instructions in spirv-opt (#3951)
2020-10-29 bclayton CMake: Add SPIRV_TOOLS_BUILD_STATIC flag (#3910)
2020-10-29 dneto Avoid copying a ref in a loop (#4000)
2020-10-28 justsid spirv-val: Allow the ViewportIndex and Layer built-ins on SPIR-V 1.5 (#3986)
2020-10-28 dnovillo Simplify logic to decide whether CCP modified the IR (#3997)
2020-10-27 jaebaek Add DebugValue for DebugDecl invisible to value assignment (#3973)
2020-10-26 greg Fix bounds check instrumentation to handle 16-bit values (#3983)
2020-10-23 andreperezmaselco.developer spirv-fuzz: Add expand vector reduction transformation (#3869)
2020-10-23 vasniktel spirv-fuzz: Don't replace irrelevant indices in OpAccessChain (#3988)
2020-10-23 vasniktel spirv-fuzz: Add FuzzerPassAddCompositeExtract (#3904)
2020-10-22 afdx spirv-fuzz: Fix mismatch with shrinker step limit (#3985)
2020-10-22 afdx spirv-fuzz: Fix off-by-one error in replayer (#3982)
2020-10-22 afdx spirv-fuzz: Get order right for OpSelect arguments (#3974)
2020-10-22 afdx spirv-fuzz: Do not add synonym-creating loops in dead blocks (#3975)
2020-10-22 afdx spirv-fuzz: Skip OpTypeSampledImage when propagating up (#3976)
2020-10-22 afdx spirv-fuzz: Pass OpUndef in function call if needed (#3978)
2020-10-22 afdx spirv-fuzz: Fix off-by-one in TransformationCompositeConstruct (#3979)
2020-10-22 afdx spirv-fuzz: Tolerate absent ids in data synonym fact management (#3966)
2020-10-21 afdx spirv-fuzz: Fix to id availability (#3971)
2020-10-21 afdx spirv-fuzz: Fix operand types (#3962)
2020-10-21 8729214+jonahryandavis Update SPIRV-Headers revision in DEPS file (#3961)
2020-10-21 afdx spirv-fuzz: Don't flatten conditional if condition is irrelevant (#3944)
2020-10-21 afdx spirv-fuzz: Do not produce OpPhis of type OpTypeSampledImage (#3964)
2020-10-21 afdx spirv-fuzz: Restrict fuzzer pass to reachable blocks (#3970)
2020-10-21 afdx spirv-fuzz: Handle more types when extending OpPhi instructions (#3969)
2020-10-21 afdx spirv-fuzz: Skip early terminator wrappers when merging returns (#3968)
2020-10-21 afdx spirv-fuzz: Avoid irrelevant constants in synonym-creating loops (#3967)
2020-10-21 afdx spirv-fuzz: Skip dead blocks in FuzzerPassAddOpPhiSynonyms (#3965)
2020-10-21 afdx spirv-fuzz: Avoid the type manager when looking for struct types (#3963)
2020-10-20 afdx spirv-fuzz: Fix to TransformationDuplicateRegionWithSelection (#3941)
2020-10-20 afdx spirv-fuzz: Skip OpFunction when replacing irrelevant ids (#3932)
2020-10-20 afdx spirv-fuzz: Use component-wise selectors when flattening conditional branches (#3921)
2020-10-20 TobyHector Add SPV_EXT_shader_image_int64 (#3852)
2020-10-20 TobyHector Support SPV_KHR_fragment_shading_rate (#3943)
2020-10-19 afdx spirv-val: Fix validation of OpPhi instructions (#3919)
2020-10-19 afdx spirv-fuzz: Avoid void struct member when outlining functions (#3936)
2020-10-19 afdx spirv-fuzz: Do not allow Block-decorated structs when adding parameters (#3931)
2020-10-19 afdx spirv-fuzz: Fix to operand id type (#3937)
2020-10-19 afdx spirv-fuzz: Handle dead blocks in TransformationEquationInstruction (#3933)
2020-10-19 afdx spirv-fuzz: Do not allow sampled image load when flattening conditionals (#3930)
2020-10-19 afdx spirv-fuzz: Take care of OpPhi instructions when inlining (#3939)
2020-10-16 afdx spirv-fuzz: Fix to TransformationInlineFunction (#3913)
2020-10-16 afdx spirv-fuzz: Wrap early terminators before merging returns (#3925)
2020-10-16 jaebaek Add DebugValue for function param regardless of scope (#3923)
2020-10-16 afdx Temporary fix to make GoogleTest compile. (#3922)
2020-10-15 afdx spirv-fuzz: Lower probability of adding bit instruction synonyms (#3917)
2020-10-15 afdx spirv-fuzz: Fix handling of OpPhi in FlattenConditionalBranch (#3916)
2020-10-13 afdx spirv-fuzz: Avoid creating blocks without parents (#3908)
(...)
2020-09-24 ehsannas Start SPIRV-Tools v2020.6
2020-09-24 ehsannas Finalize SPIRV-Tools v2020.5
2020-09-24 ehsannas Update CHANGES
2020-09-24 vasniktel spirv-fuzz: Support dead blocks in TransformationAddSynonym (#3832)
2020-09-24 vasniktel spirv-fuzz: Move IRContext parameter into constructor (#3837)
2020-09-24 Simran-B Add missing backticks around <result-id> (#3840)
2020-09-23 rharrison Validate SPIRV Version number when parsing binary header (#3834)
2020-09-23 stefanomil spirv-fuzz: Create synonym of int constant using a loop (#3790)
2020-09-22 58573781+richard-lunarg Fix compiler error on macOS with XCode12 (#3836)
2020-09-22 vasniktel spirv-fuzz: Handle OpPhis in TransformationInlineFunction (#3833)
2020-09-22 stevenperron Update CHANGES
2020-09-22 afdx spirv-fuzz: Refactor fuzzer, replayer and shrinker (#3818)
2020-09-18 afdx spirv-fuzz: Add pass recommendations (#3757)
2020-09-18 stefanomil spirv-fuzz: Consider all ids from dead blocks irrelevant (#3795)
2020-09-18 afdx Fix header guard macros (#3811)
2020-09-18 antonikarp spirv-fuzz: Fix TransformationDuplicateRegionWithSelection (#3815)
2020-09-17 46493288+sfricke-samsung spirv-val: Add DeviceIndex (#3812)
2020-09-16 rharrison Fix missed modification flagging (#3814)
2020-09-16 andreperezmaselco.developer spirv-fuzz: Use an irrelevant id for the unused components (#3810)
2020-09-16 stefanomil spirv-fuzz: Improvements to random number generation (#3809)
2020-09-16 greg Add buffer oob check to bindless instrumentation (#3800)
2020-09-16 vasniktel spirv-fuzz: Remove CanFindOrCreateZeroConstant (#3807)
2020-09-15 andreperezmaselco.developer spirv-fuzz: Add bit instruction synonym transformation (#3775)
2020-09-16 vasniktel spirv-fuzz: Skip unreachable blocks (#3729)
2020-09-15 afdx Fix build errors (#3804)
2020-09-15 vasniktel spirv-fuzz: Handle invalid ids in fact manager (#3742)
2020-09-15 vasniktel spirv-fuzz: Support memory instructions MoveInstructionDown (#3700)
2020-09-15 stefanomil spirv-fuzz: Pass submanagers to other submanagers when necessary (#3796)
2020-09-15 stefanomil spirv-fuzz: Transformation to flatten conditional branch (#3667)
2020-09-14 46493288+sfricke-samsung spirv-val: Add BaseInstance, BaseVertex, DrawIndex, and ViewIndex (#3782)
2020-09-14 dnovillo Properly mark IR changed if instruction folder creates more than one constant. (#3799)
2020-09-11 afdx Add missing file to BUILD.gn (#3798)
2020-09-11 antonikarp spirv-fuzz: Add TransformationDuplicateRegionWithSelection (#3773)
2020-09-11 afdx spirv-reduce: Support reducing a specific function (#3774)
2020-09-10 afdx spirv-reduce: Refactoring (#3793)
2020-09-10 afdx Favour 'integrity' over 'coherence' as a replacement for 'sanity'. (#3619)
2020-09-10 antonikarp spirv-fuzz: Fix header guards in transformations/fuzzer passes (#3784)
2020-09-10 paulthomson spirv-fuzz: Add SPIRV_FUZZ_PROTOC_COMMAND (#3789)
2020-09-10 paulthomson Add missing include (#3788)
2020-09-09 paulthomson Improve spirv-fuzz CMake code (#3781)
2020-09-08 stevenperron Allow SPV_KHR_8bit_storage extension. (#3780)
2020-09-08 stefanomil spirv-opt: Add function to compute nesting depth of a block (#3771)
2020-09-03 stefanomil spirv-fuzz: Transformation to convert OpSelect to conditional branch (#3681)
2020-09-02 46493288+sfricke-samsung spirv-val: Add Vulkan VUID labels to BuiltIn (#3756)
2020-09-02 vasniktel spirv-fuzz: Add support for BuiltIn decoration (#3736)
2020-09-02 stefanomil spirv-fuzz: Fix GetIdEquivalenceClasses (#3767)
2020-09-02 stefanomil spirv-fuzz: Replace id in OpPhi coming from a dead predecessor (#3744)
2020-09-01 stefanomil spirv-fuzz: Transformation to replace the use of an irrelevant id (#3697)
2020-09-01 vasniktel spirv-fuzz: TransformationMutatePointer (#3737)
2020-09-01 stefanomil spirv-fuzz: Compute interprocedural loop nesting depth of blocks (#3753)

Created with:
  roll-dep third_party/spirv-tools