### PR TITLE
Roll third_party/glslang/ 142cb87f8..74e8f05b9 (9 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': '142cb87f803d42f5ae3dd2da8dff4f19f6f15e8c',
-  'googletest_revision': '0555b0eacbc56df1fd762c6aa87bb84be9e4ce7e',
-  're2_revision': '166dbbeb3b0ab7e733b278e8f42a84f6882b8a25',
-  'spirv_headers_revision': '7845730cab6ebbdeb621e7349b7dc1a59c3377be',
-  'spirv_tools_revision': 'f7da527757140ae701be58274ce6db2f4234d9ff',
+  'glslang_revision': '7f6559d2802d0653541060f0909e33d137b9c8ba',
+  'googletest_revision': '36d8eb532022d3b543bf55aa8ffa01b6e9f03490',
+  're2_revision': '9e5430536b59ad8a8aff8616a6e6b0f888594fac',
+  'spirv_headers_revision': '5ab5c96198f30804a6a29961b8905f292a8ae600',
+  'spirv_tools_revision': '671914c28e8249f0a555726a0f3f38691fe5c1df',
 }
 
 deps = {


### PR DESCRIPTION
https://github.com/KhronosGroup/glslang/compare/142cb87f803d...74e8f05b9fc7

$ git log 142cb87f8..74e8f05b9 --date=short --no-merges --format='%ad %ae %s'
2020-11-09 jhall1024 Implement GL_EXT_terminate_invocation (#2454)
2020-11-06 rdb Fix token-pasting macros not working in preprocessor directives. (#2453)
2020-11-06 laddoc Fix warning in iomapper. (#2449)
2020-11-04 TobyHector Add GL_EXT_shader_image_int64 support (#2409)
2020-11-04 laddoc 8. io mapping refine & qualifier member check & resolver expand (#2396)
2020-11-02 courtneygo Fix build error with Chromium & ANGLE (#2446)
2020-11-02 dev Add new SpirvToolsDisassemble API interface + Improve Doc on existing API interface (#2442)
2020-11-02 justsid Support for CapabilityShaderViewportIndex and CapabilityShaderLayer (#2432)
2020-11-02 jaebaek Do not use PropagateLineInfoPass and RedundantLineInfoElimPass (#2440)

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ 282877317..fbef0711c (11 commits)

https://github.com/google/googletest/compare/2828773179fa...fbef0711cfce

$ git log 282877317..fbef0711c --date=short --no-merges --format='%ad %ae %s'
2020-11-06 absl-team Googletest export
2020-11-06 absl-team Googletest export
2020-11-06 absl-team Googletest export
2020-11-05 ofats Googletest export
2020-10-27 elliott.brossard Add instructions for sanitizer integration
2020-09-16 hyuk.myeong Remove spaces between Google Test and Google Mock
2020-09-15 hyuk.myeong Add follow-up patch for more natural reading
2020-09-15 hyuk.myeong Apply the reviewed comment
2020-09-15 hyuk.myeong Remove a space
2020-09-15 hyuk.myeong Improve the tutorial that may be confusing
2020-02-17 krystian.kuzniarek remove a duplicated include

Created with:
  roll-dep third_party/googletest

Roll third_party/spirv-headers/ 7845730ca..5ab5c9619 (2 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/7845730cab6e...5ab5c96198f3

$ git log 7845730ca..5ab5c9619 --date=short --no-merges --format='%ad %ae %s'
2020-11-04 michael.kinsner Reserve additional loop control bit for Intel extension (NoFusionINTEL) (#175)
2020-11-02 4464295+XAMPPRocky Add EmbarkStudios/rust-gpu to vendor list. (#174)

Created with:
  roll-dep third_party/spirv-headers

Roll third_party/spirv-tools/ f7da52775..a61d07a72 (11 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/f7da52775714...a61d07a72763

$ git log f7da52775..a61d07a72 --date=short --no-merges --format='%ad %ae %s'
2020-11-05 46493288+sfricke-samsung spirv-val: Fix SPV_KHR_fragment_shading_rate VUID label (#4014)
2020-11-05 46493288+sfricke-samsung spirv-val: Label Layer and ViewportIndex VUIDs (#4013)
2020-11-05 alanbaker Add dead function elimination to -O (#4015)
2020-11-04 jaebaek Add DebugValue for invisible store in single_store_elim (#4002)
2020-11-04 dnovillo Fix SSA re-writing in the presence of variable pointers. (#4010)
2020-11-04 afdx spirv-fuzz: Fixes to pass management (#4011)
2020-11-03 afdx spirv-fuzz: Add support for reining in rogue fuzzer passes (#3987)
2020-11-03 vasniktel spirv-fuzz: Fix assertion failure in FuzzerPassAddCompositeExtract (#3995)
2020-11-03 vasniktel spirv-fuzz: Fix invalid equation facts (#4009)
2020-11-03 vasniktel spirv-fuzz: Fix bugs in TransformationFlattenConditionalBranch (#4006)
2020-11-03 andreperezmaselco.developer spirv-fuzz: Fix bug related to transformation applicability (#3990)

Created with:
  roll-dep third_party/spirv-tools