### PR TITLE
copyright check: Exclude .venv in source tree

### DIFF
--- a/utils/add_copyright.py
+++ b/utils/add_copyright.py
@@ -62,7 +62,7 @@ def filtered_descendants(glob):
     """Returns glob-matching filenames under the current directory, but skips
     some irrelevant paths."""
     return find('.', glob, ['third_party', 'external', 'build*', 'out*',
-                            'CompilerIdCXX'])
+                            'CompilerIdCXX', '.venv'])
 
 
 def skip(line):


### PR DESCRIPTION
Fixes #1137