### PR TITLE
Roll dependencies to support Vulkan raytracing

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': '7f6559d2802d0653541060f0909e33d137b9c8ba',
+  'glslang_revision': 'ffccefddfd9a02ec0c0b6dd04ef5e1042279c97f',
   'googletest_revision': '36d8eb532022d3b543bf55aa8ffa01b6e9f03490',
   're2_revision': '9e5430536b59ad8a8aff8616a6e6b0f888594fac',
-  'spirv_headers_revision': '5ab5c96198f30804a6a29961b8905f292a8ae600',
-  'spirv_tools_revision': '671914c28e8249f0a555726a0f3f38691fe5c1df',
+  'spirv_headers_revision': '104ecc356c1bea4476320faca64440cd1df655a3',
+  'spirv_tools_revision': 'cd590fa3341284cd6d1ee82366155786cfd44c96',
 }
 
 deps = {


### PR DESCRIPTION
See
https://www.khronos.org/blog/vulkan-ray-tracing-final-specification-release

Roll third_party/glslang/ 7f6559d28..ffccefddf (1 commit)

https://github.com/KhronosGroup/glslang/compare/7f6559d2802d...ffccefddfd9a

$ git log 7f6559d28..ffccefddf --date=short --no-merges --format='%ad %ae %s'
2020-11-23 dgkoch Updates for final Vulkan ray tracing extensions (#2466)

Created with:
  roll-dep third_party/glslang

Roll third_party/spirv-headers/ 5ab5c9619..104ecc356 (4 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/5ab5c96198f3...104ecc356c1b

$ git log 5ab5c9619..104ecc356 --date=short --no-merges --format='%ad %ae %s'
2020-11-12 dneto MeshShadingNV enables builtins PrimitiveId, Layer, and ViewportIndex
2020-10-16 dkoch de-alias/reassign OpIgnoreIntersectionKHR/OpTerminateRayKHR
2020-06-29 alele Raytracing and Rayquery updates for final
2020-06-15 alele Updated headers for new trace/executeCallable and acceleration structure cast.

Created with:
  roll-dep third_party/spirv-headers

Roll third_party/spirv-tools/ 671914c28..cd590fa33 (1 commit)

https://github.com/KhronosGroup/SPIRV-Tools/compare/671914c28e82...cd590fa33412

$ git log 671914c28..cd590fa33 --date=short --no-merges --format='%ad %ae %s'
2020-11-23 dneto Update MeshShadingNV dependencies (and land Ray tracing updates) (#4028)

Created with:
  roll-dep third_party/spirv-tools