### PR TITLE
Update SPIRV-Tools with raytracing fix

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': 'ffccefddfd9a02ec0c0b6dd04ef5e1042279c97f',
+  'glslang_revision': 'dd69df7f3dac26362e10b0f38efb9e47990f7537',
   'googletest_revision': '36d8eb532022d3b543bf55aa8ffa01b6e9f03490',
   're2_revision': '9e5430536b59ad8a8aff8616a6e6b0f888594fac',
-  'spirv_headers_revision': '104ecc356c1bea4476320faca64440cd1df655a3',
-  'spirv_tools_revision': 'cd590fa3341284cd6d1ee82366155786cfd44c96',
+  'spirv_headers_revision': 'f027d53ded7e230e008d37c8b47ede7cd308e19d',
+  'spirv_tools_revision': 'b27b1afd12d05bf238ac7368bb49de73cd620a8e',
 }
 
 deps = {


### PR DESCRIPTION
Incorporate SPIRV-Tools fixes for new terminator
instructions in Vulkan raytracing extensions.
https://github.com/KhronosGroup/SPIRV-Tools/pull/4050