### PR TITLE
Rolling 5 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': '142cb87f803d42f5ae3dd2da8dff4f19f6f15e8c',
-  'googletest_revision': '2828773179fa425ee406df61890a150577178ea2',
-  're2_revision': '166dbbeb3b0ab7e733b278e8f42a84f6882b8a25',
-  'spirv_headers_revision': '7845730cab6ebbdeb621e7349b7dc1a59c3377be',
-  'spirv_tools_revision': 'f7da527757140ae701be58274ce6db2f4234d9ff',
+  'glslang_revision': 'c594de23cdd790d64ad5f9c8b059baae0ee2941d',
+  'googletest_revision': 'e5644f5f12ff3d5b2232dabc1c5ea272a52e8155',
+  're2_revision': '91420e899889cffd100b70e8cc50611b3031e959',
+  'spirv_headers_revision': 'f027d53ded7e230e008d37c8b47ede7cd308e19d',
+  'spirv_tools_revision': '3b85234542cadf0e496788fcc2f20697152e72f8',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ 142cb87f8..c594de23c (18 commits)

https://github.com/KhronosGroup/glslang/compare/142cb87f803d...c594de23cdd7

$ git log 142cb87f8..c594de23c --date=short --no-merges --format='%ad %ae %s'
2020-12-07 greg Update spirv-tools known-good #2 - Pick up ray tracing terminator fix (#2478)
2020-12-03 greg Update spirv-tools known-good (#2473)
2020-11-30 dgkoch update spirv-headers and fix handling of gl_HitTEXT (#2471)
2020-11-24 dgkoch Add ray query capability if acceleration structure or ray query types declared (#2469)
2020-11-23 dgkoch Updates for final Vulkan ray tracing extensions (#2466)
2020-11-16 ShabbyX Compile out code for GL_EXT_shader_image_int64 for ANGLE (#2463)
2020-11-12 mbechard tweak local_size comparison a bit (#2456)
2020-11-12 dneto Avoid spuriously adding Geometry capability for vert, tesc, tese (#2462)
2020-11-12 greg New nonuniform analysis (#2457)
2020-11-09 jhall1024 Implement GL_EXT_terminate_invocation (#2454)
2020-11-06 rdb Fix token-pasting macros not working in preprocessor directives. (#2453)
2020-11-06 laddoc Fix warning in iomapper. (#2449)
2020-11-04 TobyHector Add GL_EXT_shader_image_int64 support (#2409)
2020-11-04 laddoc 8. io mapping refine & qualifier member check & resolver expand (#2396)
2020-11-02 courtneygo Fix build error with Chromium & ANGLE (#2446)
2020-11-02 dev Add new SpirvToolsDisassemble API interface + Improve Doc on existing API interface (#2442)
2020-11-02 justsid Support for CapabilityShaderViewportIndex and CapabilityShaderLayer (#2432)
2020-11-02 jaebaek Do not use PropagateLineInfoPass and RedundantLineInfoElimPass (#2440)

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ 282877317..e5644f5f1 (35 commits)

https://github.com/google/googletest/compare/2828773179fa...e5644f5f12ff

$ git log 282877317..e5644f5f1 --date=short --no-merges --format='%ad %ae %s'
2020-12-08 absl-team Googletest export
2020-12-07 absl-team Googletest export
2020-12-07 absl-team Googletest export
2020-12-07 absl-team Googletest export
2020-12-05 paul.malcolm Fix typo in CLI help message
2020-12-03 absl-team Googletest export
2020-12-02 absl-team Googletest export
2020-12-02 absl-team Googletest export
2020-12-01 absl-team Googletest export
2020-11-30 dmauro Googletest export
2020-11-24 absl-team Googletest export
2020-11-23 absl-team Googletest export
2020-11-19 absl-team Googletest export
2020-11-13 vlee Initialize TestInfo member is_in_another_shard_ in constructor.
2020-11-12 absl-team Googletest export
2020-11-12 absl-team Googletest export
2020-11-12 absl-team Googletest export
2020-11-11 dmauro Googletest export
2020-11-11 dmauro Googletest export
2020-11-11 dmauro Googletest export
2020-11-11 absl-team Googletest export
2020-11-11 marius.brehler Refactor finding python
2020-11-06 absl-team Googletest export
2020-11-06 absl-team Googletest export
2020-10-29 knut Only save original working directory if death tests are enabled
2020-11-08 hyuk.myeong fix typos
2020-11-06 absl-team Googletest export
2020-11-05 ofats Googletest export
2020-10-27 elliott.brossard Add instructions for sanitizer integration
2020-09-16 hyuk.myeong Remove spaces between Google Test and Google Mock
2020-09-15 hyuk.myeong Add follow-up patch for more natural reading
2020-09-15 hyuk.myeong Apply the reviewed comment
2020-09-15 hyuk.myeong Remove a space
2020-09-15 hyuk.myeong Improve the tutorial that may be confusing
2020-02-17 krystian.kuzniarek remove a duplicated include

Created with:
  roll-dep third_party/googletest

Roll third_party/re2/ 166dbbeb3..91420e899 (3 commits)

https://github.com/google/re2/compare/166dbbeb3b0a...91420e899889

$ git log 166dbbeb3..91420e899 --date=short --no-merges --format='%ad %ae %s'
2020-11-25 junyer Remove a double space from mksyntaxgo for Go folks.
2020-11-17 junyer Make benchmarks use substrings of a random text buffer.
2020-11-15 twpayne Add note about Go Unicode character classes

Created with:
  roll-dep third_party/re2

Roll third_party/spirv-headers/ 7845730ca..f027d53de (7 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/7845730cab6e...f027d53ded7e

$ git log 7845730ca..f027d53de --date=short --no-merges --format='%ad %ae %s'
2020-11-26 dkoch remove HitTKHR
2020-11-12 dneto MeshShadingNV enables builtins PrimitiveId, Layer, and ViewportIndex
2020-10-16 dkoch de-alias/reassign OpIgnoreIntersectionKHR/OpTerminateRayKHR
2020-06-29 alele Raytracing and Rayquery updates for final
2020-06-15 alele Updated headers for new trace/executeCallable and acceleration structure cast.
2020-11-04 michael.kinsner Reserve additional loop control bit for Intel extension (NoFusionINTEL) (#175)
2020-11-02 4464295+XAMPPRocky Add EmbarkStudios/rust-gpu to vendor list. (#174)

Created with:
  roll-dep third_party/spirv-headers

Roll third_party/spirv-tools/ f7da52775..3b8523454 (39 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/f7da52775714...3b85234542ca

$ git log f7da52775..3b8523454 --date=short --no-merges --format='%ad %ae %s'
2020-12-08 46493288+sfricke-samsung spirv-val: Add last TessLevelOuter and TessLevelInner VUID (#4055)
2020-12-08 46493288+sfricke-samsung spirv-val: Add last ClipDistance and CullDistance VUID (#4054)
2020-12-08 46493288+sfricke-samsung spirv-val: Add last ViewportIndex and Layer VUID (#4053)
2020-12-08 46493288+sfricke-samsung spirv-val: Add last Position VUID (#4052)
2020-12-08 alanbaker Allow forward pointer to be used in types generally (#4044)
2020-12-07 marijns95 opt: Run DCE when SPV_KHR_shader_clock is used (#4049)
2020-12-07 dnovillo Update CHANGES to include latest ray tacing fixes.
2020-12-07 ehsannas Take new (raytracing) termination instructions into account. (#4050)
2020-12-03 dnovillo Start SPIRV-Tools v2020.7
2020-12-03 dnovillo Finalize SPIRV-Tools v2020.6
2020-12-02 dnovillo Update CHANGES
2020-12-02 ehsannas Do run DCE if SPV_KHR_ray_query is used. (#4047)
2020-12-02 dnovillo Update CHANGES
2020-12-01 greg Change ref_analysis to RefAnalysis to follow coding standards. (#4045)
2020-12-01 stevenperron Handle 8-bit index in elim dead member (#4043)
2020-12-01 dgkoch Add validation support for the ray tracing built-in variables (#4041)
2020-12-01 greg Add texel buffer out-of-bounds checking instrumentation (#4038)
2020-11-30 dgkoch Update spirv-header deps (#4040)
2020-11-27 afdx Reject SPIR-V that applies void to OpUndef, OpCopyObject, OpPhi (#4036)
2020-11-25 dneto BuildModule: optionally avoid adding new OpLine instructions (#4033)
2020-11-25 dneto Remove prototype for unimplemented method (#4031)
2020-11-25 afdx spirv-fuzz: Fix facts arising from CompositeConstruct (#4034)
2020-11-24 afdx spirv-fuzz: Do not flatten conditionals that create synonyms (#4030)
2020-11-23 dneto Update MeshShadingNV dependencies (and land Ray tracing updates) (#4028)
2020-11-18 greg Fix buffer oob instrumentation for matrix refs (#4025)
2020-11-13 afdx spirv-opt: Set parent when adding basic block (#4021)
2020-11-13 jaebaek spirv-opt: properly preserve DebugValue indexes operand (#4022)
2020-11-11 dneto Use less stack space when validating Vulkan builtins (#4019)
2020-11-05 46493288+sfricke-samsung spirv-val: Fix SPV_KHR_fragment_shading_rate VUID label (#4014)
2020-11-05 46493288+sfricke-samsung spirv-val: Label Layer and ViewportIndex VUIDs (#4013)
2020-11-05 alanbaker Add dead function elimination to -O (#4015)
2020-11-04 jaebaek Add DebugValue for invisible store in single_store_elim (#4002)
2020-11-04 dnovillo Fix SSA re-writing in the presence of variable pointers. (#4010)
2020-11-04 afdx spirv-fuzz: Fixes to pass management (#4011)
2020-11-03 afdx spirv-fuzz: Add support for reining in rogue fuzzer passes (#3987)
2020-11-03 vasniktel spirv-fuzz: Fix assertion failure in FuzzerPassAddCompositeExtract (#3995)
2020-11-03 vasniktel spirv-fuzz: Fix invalid equation facts (#4009)
2020-11-03 vasniktel spirv-fuzz: Fix bugs in TransformationFlattenConditionalBranch (#4006)
2020-11-03 andreperezmaselco.developer spirv-fuzz: Fix bug related to transformation applicability (#3990)

Created with:
  roll-dep third_party/spirv-tools