### PR TITLE
Roll 4 dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': 'c594de23cdd790d64ad5f9c8b059baae0ee2941d',
-  'googletest_revision': 'e5644f5f12ff3d5b2232dabc1c5ea272a52e8155',
-  're2_revision': '91420e899889cffd100b70e8cc50611b3031e959',
+  'glslang_revision': '9325cc013e3df4f85a457c2d43e831a9e93713e1',
+  'googletest_revision': '389cb68b87193358358ae87cc56d257fd0d80189',
+  're2_revision': 'c33d1680c7e9ab7edea02d7465a8db13e80b558d',
   'spirv_headers_revision': 'f027d53ded7e230e008d37c8b47ede7cd308e19d',
-  'spirv_tools_revision': '3b85234542cadf0e496788fcc2f20697152e72f8',
+  'spirv_tools_revision': '1bb80d2778a3d0362365b2490e2174bd56453036',
 }
 
 deps = {


### PR DESCRIPTION
Roll third_party/glslang/ c594de23c..9325cc013 (10 commits)

https://github.com/KhronosGroup/glslang/compare/c594de23cdd7...9325cc013e3d

$ git log c594de23c..9325cc013 --date=short --no-merges --format='%ad %ae %s'
2020-12-23 shuizhuyuanluo Update ParseHelper.cpp
2020-12-17 greg Fix cut and paste error
2020-11-05 git Don't use roundEven() to implement round() in DX9 compatibility mode
2020-12-15 dneto Test updates for ImageRead result type validation
2020-12-15 dneto Update known_good, pick up ImageRead result validation
2020-12-15 e.proydakov Fixed compile warning in reflection.cpp for ENABLE_HLSL = 0 build. [-Wunused-parameter]
2020-12-12 dgkoch Fix SPV return type of rayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetEXT (#2484)
2020-12-11 greg Update README to avoid googletest breakage
2020-12-11 greg Fix Travis to use pre-breakage googletest (#2481)
2020-09-12 shuizhuyuanluo Fix build android ndk r16b

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ e5644f5f1..389cb68b8 (6 commits)

https://github.com/google/googletest/compare/e5644f5f12ff...389cb68b8719

$ git log e5644f5f1..389cb68b8 --date=short --no-merges --format='%ad %ae %s'
2020-12-21 absl-team Googletest export
2020-12-15 dmauro Googletest export
2020-12-11 absl-team Googletest export
2020-12-10 absl-team Googletest export
2020-12-10 dmauro Googletest export
2020-10-30 chuck.atkins Bump CMake minimum to 2.8.12

Created with:
  roll-dep third_party/googletest

Roll third_party/re2/ 91420e899..c33d1680c (2 commits)

https://github.com/google/re2/compare/91420e899889...c33d1680c7e9

$ git log 91420e899..c33d1680c --date=short --no-merges --format='%ad %ae %s'
2020-12-30 junyer Make RequiredPrefixForAccel() "see through" capturing groups.
2020-12-29 junyer Correct the WINVER check for SRWLOCK.

Created with:
  roll-dep third_party/re2

Roll third_party/spirv-tools/ 3b8523454..1bb80d277 (9 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/3b85234542ca...1bb80d2778a3

$ git log 3b8523454..1bb80d277 --date=short --no-merges --format='%ad %ae %s'
2021-01-05 46493288+sfricke-samsung spirv-val: Add Vulkan Group Operation VUID (#4086)
2020-12-17 46493288+sfricke-samsung spirv-val: Add first StandAlone VUID 04633 (#4077)
2020-12-17 46493288+sfricke-samsung spirv-val: Add Subgroup VUIDs (#4074)
2020-12-17 afdx spirv-fuzz: Fix OpPhi handling in DuplicateRegionWithSelection (#4065)
2020-12-15 dneto validation: validate return type of OpImageRead (#4072)
2020-12-14 dneto validation: tighter validation of multisampled images (#4059)
2020-12-10 dneto validate OpTypeImage Sampled values for environemnts (#4064)
2020-12-10 rharrison Force using Python 3 git-sync-deps (#4067)
2020-12-10 dneto validate StorageImageMultisampled capability (#4062)

Created with:
  roll-dep third_party/spirv-tools