### PR TITLE
Deprecate WebGPU SPIRV support

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -9,7 +9,7 @@ vars = {
   'googletest_revision': '389cb68b87193358358ae87cc56d257fd0d80189',
   're2_revision': 'c33d1680c7e9ab7edea02d7465a8db13e80b558d',
   'spirv_headers_revision': 'f027d53ded7e230e008d37c8b47ede7cd308e19d',
-  'spirv_tools_revision': '1bb80d2778a3d0362365b2490e2174bd56453036',
+  'spirv_tools_revision': 'ee39b5db5f1d51bbdb0422d529d1e99615627bcf',
 }
 
 deps = {

--- a/libshaderc/include/shaderc/env.h
+++ b/libshaderc/include/shaderc/env.h
@@ -29,6 +29,8 @@ typedef enum {
   shaderc_target_env_opengl_compat,  // SPIR-V under OpenGL semantics,
                                      // including compatibility profile
                                      // functions
+  shaderc_target_env_webgpu,         // Deprecated, SPIR-V under WebGPU
+                                     // semantics
   shaderc_target_env_default = shaderc_target_env_vulkan
 } shaderc_target_env;
 
@@ -43,6 +45,7 @@ typedef enum {
   // See glslang/Standalone/Standalone.cpp
   // TODO(dneto): Glslang doesn't accept a OpenGL client version of 460.
   shaderc_env_version_opengl_4_5 = 450,
+  shaderc_env_version_webgpu,  // Deprecated, WebGPU env never defined versions
 } shaderc_env_version;
 
 // The known versions of SPIR-V.

--- a/libshaderc/include/shaderc/env.h
+++ b/libshaderc/include/shaderc/env.h
@@ -29,7 +29,6 @@ typedef enum {
   shaderc_target_env_opengl_compat,  // SPIR-V under OpenGL semantics,
                                      // including compatibility profile
                                      // functions
-  shaderc_target_env_webgpu,         // SPIR-V under WebGPU semantics
   shaderc_target_env_default = shaderc_target_env_vulkan
 } shaderc_target_env;
 
@@ -44,9 +43,6 @@ typedef enum {
   // See glslang/Standalone/Standalone.cpp
   // TODO(dneto): Glslang doesn't accept a OpenGL client version of 460.
   shaderc_env_version_opengl_4_5 = 450,
-  // Currently WebGPU doesn't have versioning, since it isn't finalized. This
-  // will have to be updated once the spec is finished.
-  shaderc_env_version_webgpu,
 } shaderc_env_version;
 
 // The known versions of SPIR-V.

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -278,6 +278,8 @@ shaderc_util::Compiler::TargetEnv GetCompilerTargetEnv(shaderc_target_env env) {
       return shaderc_util::Compiler::TargetEnv::OpenGL;
     case shaderc_target_env_opengl_compat:
       return shaderc_util::Compiler::TargetEnv::OpenGLCompat;
+    case shaderc_target_env_webgpu:
+      assert(false);
     case shaderc_target_env_vulkan:
     default:
       break;

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -280,6 +280,7 @@ shaderc_util::Compiler::TargetEnv GetCompilerTargetEnv(shaderc_target_env env) {
       return shaderc_util::Compiler::TargetEnv::OpenGLCompat;
     case shaderc_target_env_webgpu:
       assert(false);
+      break;
     case shaderc_target_env_vulkan:
     default:
       break;

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -278,8 +278,6 @@ shaderc_util::Compiler::TargetEnv GetCompilerTargetEnv(shaderc_target_env env) {
       return shaderc_util::Compiler::TargetEnv::OpenGL;
     case shaderc_target_env_opengl_compat:
       return shaderc_util::Compiler::TargetEnv::OpenGLCompat;
-    case shaderc_target_env_webgpu:
-      return shaderc_util::Compiler::TargetEnv::WebGPU;
     case shaderc_target_env_vulkan:
     default:
       break;

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -76,7 +76,6 @@ class Compiler {
     Vulkan,        // Default to Vulkan 1.0
     OpenGL,        // Default to OpenGL 4.5
     OpenGLCompat,  // Deprecated.
-    WebGPU,        // Deprecated.
   };
 
   // Target environment versions.  These numbers match those used by Glslang.

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -76,7 +76,7 @@ class Compiler {
     Vulkan,        // Default to Vulkan 1.0
     OpenGL,        // Default to OpenGL 4.5
     OpenGLCompat,  // Deprecated.
-    WebGPU,
+    WebGPU,        // Deprecated.
   };
 
   // Target environment versions.  These numbers match those used by Glslang.

--- a/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
+++ b/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
@@ -46,7 +46,6 @@ enum class PassId {
   kLegalizationPasses,
   kPerformancePasses,
   kSizePasses,
-  kVulkanToWebGPUPasses,
 
   // SPIRV-Tools specific passes
   kNullPass,

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -184,17 +184,9 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   std::vector<uint32_t>& compilation_output_data = std::get<1>(result_tuple);
   size_t& compilation_output_data_size_in_bytes = std::get<2>(result_tuple);
 
-  // glslang doesn't currently support WebGPU, so we need to fake it by having
-  // it generate Vulkan1.1 and then use spirv-opt later to convert to WebGPU.
-  bool is_webgpu = target_env_ == Compiler::TargetEnv::WebGPU;
-  TargetEnv internal_target_env =
-      !is_webgpu ? target_env_ : Compiler::TargetEnv::Vulkan;
-  TargetEnvVersion internal_target_env_version =
-      !is_webgpu ? target_env_version_ : Compiler::TargetEnvVersion::Vulkan_1_1;
-
   // Check target environment.
   const auto target_client_info = GetGlslangClientInfo(
-      error_tag, internal_target_env, internal_target_env_version,
+      error_tag, target_env_, target_env_version_,
       target_spirv_version_, target_spirv_version_is_forced_);
   if (!target_client_info.error.empty()) {
     *error_stream << target_client_info.error;
@@ -297,7 +289,7 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   shader.setNanMinMaxClamp(nan_clamp_);
 
   const EShMessages rules =
-      GetMessageRules(internal_target_env, source_language_, hlsl_offsets_,
+      GetMessageRules(target_env_, source_language_, hlsl_offsets_,
                       generate_debug_info_);
 
   bool success = shader.parse(&limits_, default_version_, default_profile_,
@@ -347,14 +339,9 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   opt_passes.insert(opt_passes.end(), enabled_opt_passes_.begin(),
                     enabled_opt_passes_.end());
 
-  // WebGPU goes last, since it is converting the env.
-  if (is_webgpu) {
-    opt_passes.push_back(PassId::kVulkanToWebGPUPasses);
-  }
-
   if (!opt_passes.empty()) {
     std::string opt_errors;
-    if (!SpirvToolsOptimize(internal_target_env, internal_target_env_version,
+    if (!SpirvToolsOptimize(target_env_, target_env_version_,
                             opt_passes, &spirv, &opt_errors)) {
       *error_stream << "shaderc: internal error: compilation succeeded but "
                        "failed to optimize: "
@@ -365,8 +352,6 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
 
   if (output_type == OutputType::SpirvAssemblyText) {
     std::string text_or_error;
-    // spirv-tools does know about WebGPU, so don't need to punt to Vulkan1.1
-    // here.
     if (!SpirvToolsDisassemble(target_env_, target_env_version_, spirv,
                                &text_or_error)) {
       *error_stream << "shaderc: internal error: compilation succeeded but "
@@ -464,14 +449,6 @@ void Compiler::SetSuppressWarnings() { suppress_warnings_ = true; }
 std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
     const std::string& error_tag, const string_piece& shader_source,
     const string_piece& shader_preamble, CountingIncluder& includer) const {
-  // glslang doesn't currently support WebGPU, so we need to fake it by having
-  // it generate Vulkan1.1 and then use spirv-opt later to convert to WebGPU.
-  bool is_webgpu = target_env_ == Compiler::TargetEnv::WebGPU;
-  TargetEnv internal_target_env =
-      !is_webgpu ? target_env_ : Compiler::TargetEnv::Vulkan;
-  TargetEnvVersion internal_target_env_version =
-      !is_webgpu ? target_env_version_ : Compiler::TargetEnvVersion::Vulkan_1_1;
-
   // The stage does not matter for preprocessing.
   glslang::TShader shader(EShLangVertex);
   const char* shader_strings = shader_source.data();
@@ -481,7 +458,7 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
                                        &string_names, 1);
   shader.setPreamble(shader_preamble.data());
   auto target_client_info = GetGlslangClientInfo(
-      error_tag, internal_target_env, internal_target_env_version,
+      error_tag, target_env_, target_env_version_,
       target_spirv_version_, target_spirv_version_is_forced_);
   if (!target_client_info.error.empty()) {
     return std::make_tuple(false, "", target_client_info.error);
@@ -499,7 +476,7 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
   // flag.
   const auto rules = static_cast<EShMessages>(
       EShMsgOnlyPreprocessor |
-      GetMessageRules(internal_target_env, source_language_, hlsl_offsets_,
+      GetMessageRules(target_env_, source_language_, hlsl_offsets_,
                       false));
 
   std::string preprocessed_shader;

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -84,7 +84,6 @@ EShMessages GetMessageRules(shaderc_util::Compiler::TargetEnv env,
     case Compiler::TargetEnv::OpenGL:
       result = static_cast<EShMessages>(result | EShMsgSpvRules);
       break;
-    case Compiler::TargetEnv::WebGPU:
     case Compiler::TargetEnv::Vulkan:
       result =
           static_cast<EShMessages>(result | EShMsgSpvRules | EShMsgVulkanRules);

--- a/libshaderc_util/src/spirv_tools_wrapper.cc
+++ b/libshaderc_util/src/spirv_tools_wrapper.cc
@@ -45,7 +45,7 @@ spv_target_env GetSpirvToolsTargetEnv(Compiler::TargetEnv env,
       return SPV_ENV_OPENGL_4_5;
     case Compiler::TargetEnv::OpenGLCompat:  // Deprecated
       return SPV_ENV_OPENGL_4_5;
-    case Compiler::TargetEnv::WebGPU:
+    case Compiler::TargetEnv::WebGPU:  // Deprecated
       return SPV_ENV_WEBGPU_0;
   }
   assert(false && "unexpected target environment or version");
@@ -144,9 +144,6 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
         break;
       case PassId::kSizePasses:
         optimizer.RegisterSizePasses();
-        break;
-      case PassId::kVulkanToWebGPUPasses:
-        optimizer.RegisterVulkanToWebGPUPasses();
         break;
       case PassId::kNullPass:
         // We actually don't need to do anything for null pass.

--- a/libshaderc_util/src/spirv_tools_wrapper.cc
+++ b/libshaderc_util/src/spirv_tools_wrapper.cc
@@ -45,8 +45,6 @@ spv_target_env GetSpirvToolsTargetEnv(Compiler::TargetEnv env,
       return SPV_ENV_OPENGL_4_5;
     case Compiler::TargetEnv::OpenGLCompat:  // Deprecated
       return SPV_ENV_OPENGL_4_5;
-    case Compiler::TargetEnv::WebGPU:  // Deprecated
-      return SPV_ENV_WEBGPU_0;
   }
   assert(false && "unexpected target environment or version");
   return SPV_ENV_VULKAN_1_0;


### PR DESCRIPTION
Roll third_party/spirv-tools/ 1bb80d277..ee39b5db5 (16 commits)

https://github.com/KhronosGroup/SPIRV-Tools/compare/1bb80d2778a3...ee39b5db5f1d

$ git log 1bb80d277..ee39b5db5 --date=short --no-merges --format='%ad %ae %s'
2021-01-15 46493288+sfricke-samsung spirv-val: Add Vulkan Addressing Model check (#4107)
2021-01-14 rharrison Remove WebGPU support (#4108)
2021-01-14 46493288+sfricke-samsung spirv-val: Vulkan atomic storage class (#4079)
2021-01-13 jaebaek Avoid integrity check failures caused by propagating line instructions (#4096)
2021-01-13 pierremoreau Linker usability improvements (#4084)
2021-01-12 dj2 Revert "Generate differentiated error codes for buffer oob checking (#4097)" (#4100)
2021-01-11 greg Generate differentiated error codes for buffer oob checking (#4097)
2021-01-07 dneto use std::string::empty() to test for emptiness (#4098)
2021-01-07 46493288+sfricke-samsung spirv-val: Label standalone Vulkan VUID (#4091)
2021-01-06 46493288+sfricke-samsung spirv-val: Add Vulkan decroation VUID (#4090)
2021-01-06 stevenperron Fix binding number calculation in desc sroa (#4095)
2021-01-06 stevenperron Build deps: dump ini from 1.3.5 to 1.3.7 in tools/sva (#4092)
2021-01-06 46493288+sfricke-samsung spirv-val: Add Vulkan FP Mode VUID (#4088)
2021-01-06 46493288+sfricke-samsung spirv-val: Fix Vulkan image sampled check (#4085)
2021-01-06 46493288+sfricke-samsung spirv-val: Add Vulkan ForwardPointer VUID (#4089)
2021-01-06 46493288+sfricke-samsung spirv-val: Add Vulkan ImageTexelPointer format check (#4087)

Created with:
  roll-dep third_party/spirv-tools

Fixes #1166