### PR TITLE
Exposed GLSLang's option to combine textures and samplers automatically.

### DIFF
--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -1,4 +1,5 @@
 // Copyright 2015 The Shaderc Authors. All rights reserved.
+// MODIFIED BY Robin Quint
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -307,6 +308,8 @@ int main(int argc, char** argv) {
       }
     } else if (arg == "-fauto-bind-uniforms") {
       compiler.options().SetAutoBindUniforms(true);
+    } else if (arg == "-fupgrade-textures") {
+      compiler.options().SetUpgradeTextures(true);
     } else if (arg == "-fauto-map-locations") {
       compiler.options().SetAutoMapLocations(true);
     } else if (arg == "-fhlsl-iomap") {

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -1,4 +1,5 @@
 // Copyright 2015 The Shaderc Authors. All rights reserved.
+// MODIFIED BY Robin Quint
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -406,6 +407,9 @@ SHADERC_EXPORT void shaderc_compile_options_set_limit(
 // that aren't already explicitly bound in the shader source.
 SHADERC_EXPORT void shaderc_compile_options_set_auto_bind_uniforms(
     shaderc_compile_options_t options, bool auto_bind);
+
+SHADERC_EXPORT void shaderc_compile_options_set_upgrade_textures(
+    shaderc_compile_options_t options, bool upgrade);
 
 // Sets whether the compiler should use HLSL IO mapping rules for bindings.
 // Defaults to false.

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -1,4 +1,5 @@
 // Copyright 2015 The Shaderc Authors. All rights reserved.
+// MODIFIED BY Robin Quint
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -272,6 +273,10 @@ class CompileOptions {
   // that aren't already explicitly bound in the shader source.
   void SetAutoBindUniforms(bool auto_bind) {
     shaderc_compile_options_set_auto_bind_uniforms(options_, auto_bind);
+  }
+
+  void SetUpgradeTextures(bool upgrade) {
+    shaderc_compile_options_set_upgrade_textures(options_, upgrade);
   }
 
   // Sets whether the compiler should use HLSL IO mapping rules for bindings.

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -1,4 +1,5 @@
 // Copyright 2015 The Shaderc Authors. All rights reserved.
+// MODIFIED BY Robin Quint
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -495,6 +496,11 @@ void shaderc_compile_options_set_limit(shaderc_compile_options_t options,
 void shaderc_compile_options_set_auto_bind_uniforms(
     shaderc_compile_options_t options, bool auto_bind) {
   options->compiler.SetAutoBindUniforms(auto_bind);
+}
+
+void shaderc_compile_options_set_upgrade_textures(
+    shaderc_compile_options_t options, bool upgrade) {
+  options->compiler.SetUpgradeTextures(upgrade);
 }
 
 void shaderc_compile_options_set_hlsl_io_mapping(

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -1,4 +1,5 @@
 // Copyright 2015 The Shaderc Authors. All rights reserved.
+// MODIFIED BY Robin Quint
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -201,6 +202,7 @@ class Compiler {
         source_language_(SourceLanguage::GLSL),
         limits_(kDefaultTBuiltInResource),
         auto_bind_uniforms_(false),
+        upgrade_textures_(false),
         auto_binding_base_(),
         auto_map_locations_(false),
         hlsl_iomap_(false),
@@ -276,6 +278,8 @@ class Compiler {
   // Set whether the compiler automatically assigns bindings to
   // uniform variables that don't have explicit bindings.
   void SetAutoBindUniforms(bool auto_bind) { auto_bind_uniforms_ = auto_bind; }
+
+  void SetUpgradeTextures(bool upgrade) { upgrade_textures_ = upgrade; }
 
   // Sets the lowest binding number used when automatically assigning bindings
   // for uniform resources of the given type, for all shader stages.  The default
@@ -491,6 +495,8 @@ class Compiler {
   // True if the compiler should automatically bind uniforms that don't
   // have explicit bindings.
   bool auto_bind_uniforms_;
+
+  bool upgrade_textures_;
 
   // The base binding number per uniform type, per stage, used when automatically
   // binding uniforms that don't hzve explicit bindings in the shader source.

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -1,4 +1,5 @@
 // Copyright 2015 The Shaderc Authors. All rights reserved.
+// MODIFIED BY Robin Quint
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -264,6 +265,9 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   shader.setPreamble(preamble.c_str());
   shader.setEntryPoint(entry_point_name);
   shader.setAutoMapBindings(auto_bind_uniforms_);
+  if (upgrade_textures_) {
+    shader.setTextureSamplerTransformMode(EShTexSampTransUpgradeTextureRemoveSampler);
+  }
   shader.setAutoMapLocations(auto_map_locations_);
   const auto& bases = auto_binding_base_[static_cast<int>(used_shader_stage)];
   shader.setShiftImageBinding(bases[static_cast<int>(UniformKind::Image)]);


### PR DESCRIPTION
This pull request implements #1180 by exposing the GLSLang option TShader::setTextureSamplerTransformMode(). I am not quite sure how to name the respective functions, as I don't think setTextureSamplerTransformMode() really describes what the function does, so naming ideas are welcome.

The "MODIFIED BY  Robin Quint" notices are there to comply with Apache §4b, if that is not required, I can remove them quickly.