### PR TITLE
Update license-checker.cfg with updated license names

### DIFF
--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -1,6 +1,6 @@
 [
     {
-        "licenses": [ "Apache-2.0-Header" ],
+        "licenses": [ "Apache-2.0" ],
         "paths": [
             {
                 "exclude": [


### PR DESCRIPTION
The golang license library that license-checker uses changed the naming of `Apache-2.0-Header` to `Apache-2.0`.

Update the config to match this change