### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ On Linux, the following tools should be installed:
 
 On Linux, if cross compiling to Windows:
 - [`mingw`](http://www.mingw.org): A GCC-based cross compiler targeting Windows
-    so that generated executables use the Micrsoft C runtime libraries.
+    so that generated executables use the Microsoft C runtime libraries.
 
 On Windows, the following tools should be installed and available on your path:
 


### PR DESCRIPTION
README.md contained "**Micrsoft** C runtime libraries" instead of "**Microsoft** C runtime libraries".