### PR TITLE
glslc: main.cc: update help: debug info disclaimer

### DIFF
--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -127,7 +127,6 @@ Options:
                     Valid stages are vertex, vert, fragment, frag, tesscontrol,
                     tesc, tesseval, tese, geometry, geom, compute, and comp.
   -g                Generate source-level debug information.
-                    Currently this option has no effect.
   -h                Display available options.
   --help            Display available options.
   -I <value>        Add directory to include search path.

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -131,7 +131,6 @@ Options:
                     Valid stages are vertex, vert, fragment, frag, tesscontrol,
                     tesc, tesseval, tese, geometry, geom, compute, and comp.
   -g                Generate source-level debug information.
-                    Currently this option has no effect.
   -h                Display available options.
   --help            Display available options.
   -I <value>        Add directory to include search path.


### PR DESCRIPTION
As it appears, the option -g actually has some effect now.