### PR TITLE
Add explicit copy constructor for string_piece

### DIFF
--- a/libshaderc_util/include/libshaderc_util/string_piece.h
+++ b/libshaderc_util/include/libshaderc_util/string_piece.h
@@ -57,6 +57,8 @@ class string_piece {
     end_ = other.end_;
   }
 
+  string_piece& operator=(const string_piece& other) = default;
+
   // Clears the string_piece removing any reference to the original string.
   void clear() {
     begin_ = nullptr;


### PR DESCRIPTION
Implicit copy constructors are deprecated and can cause build warnings
or errors with some compilers.
