### PR TITLE
Fix shaderc util test to pass the correct shader_stage

### DIFF
--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -276,7 +276,7 @@ TEST_F(CompilerTest, RespectTargetEnvOnOpenGLShader) {
 }
 
 TEST_F(CompilerTest, RespectTargetEnvOnOpenGLShaderWhenDeducingStage) {
-  const EShLanguage stage = EShLangCount;
+  const EShLanguage stage = EShLangVertex;
 
   compiler_.SetTargetEnv(Compiler::TargetEnv::OpenGLCompat);
   EXPECT_TRUE(


### PR DESCRIPTION
Found this bug while browsing through the test code. It is passing incorrect shader kind for the test using vertex shader.