### PR TITLE
build: add switch to disable copyright check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,16 @@ else()
   message(STATUS "Configuring Shaderc to avoid building examples.")
 endif()
 
+option(SHADERC_SKIP_COPYRIGHT_CHECK "Skip copyright check" ${SHADERC_SKIP_COPYRIGHT_CHECK})
+if(NOT ${SHADERC_SKIP_COPYRIGHT_CHECK})
+  set(SHADERC_ENABLE_COPYRIGHT_CHECK ON)
+endif()
+if(${SHADERC_ENABLE_COPYRIGHT_CHECK})
+  message(STATUS "Configuring Shaderc to check copyrights.")
+else()
+  message(STATUS "Configuring Shaderc to avoid checking copyrights.")
+endif()
+
 option(SHADERC_ENABLE_WERROR_COMPILE "Enable passing -Werror to compiler, if available" ON)
 
 set (CMAKE_CXX_STANDARD 11)
@@ -82,11 +92,13 @@ endif()
 
 find_host_package(PythonInterp 3 REQUIRED)
 
-add_custom_target(check-copyright ALL
-  ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
-  --check
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMENT "Check copyright")
+if (SHADERC_ENABLE_COPYRIGHT_CHECK)
+  add_custom_target(check-copyright ALL
+    ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py
+    --check
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Check copyright")
+endif()
 
 add_custom_target(add-copyright
   ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/utils/add_copyright.py


### PR DESCRIPTION
A Vulkan SDK build of shaderc fails on the copyright check:

    C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\Microsoft.
    CppCommon.targets(171,5): error MSB6006: "cmd.exe" exited with co
    de 1. [C:\j\msdk\build\shaderc\repo\src\dbuild32\check-copyright.
    vcxproj]

Analysis in Visual Studio reveals that the problem is:

    20>  .\dbuild\include\glslang\build_info.h  has no copyright mess
    age.
    20>C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\Microso
    ft.CppCommon.targets(171,5): error MSB6006: "cmd.exe" exited with
    code 1.

"build_info.h" does indeed have a copyright message:

    // Copyright (C) 2020 The Khronos Group Inc.

but this fails the copyright check, which is looking solely for:

    Copyright <NNNN> The Shaderc Authors. All rights reserved.

These changes add a SHADERC_SKIP_COPYRIGHT_CHECK option that can be
passed at generation time to disable the copyright check and allows
the build to succeed.

It turns out CMake 3.10 ordered the shaderc build in such a way that
the copyright check occurred at the end of the build, while CMake 3.19
puts the copyright check at the beginning of the build.  So the SDK
*could* be built with CMake 3.10 if the build error was ignored, but
cannot be built with CMake 3.19 even if the build error is ignored.