### PR TITLE
Update deps to support SPIR-V 1.6, target SPIR-V 1.6 code generation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,9 @@
 Revision history for Shaderc
 
 v2021.4-dev 2021-11-11
- - Start v2021.4 development
+ - Support targeting SPIR-V 1.6
+ - Updated copyright check: Excludes Glslang generated files when
+   building in source tree
 
 v2021.3 2021-11-11
  - Add build switch to disable copyright check

--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': '600c5037baac82a80851d1fb95f3f09d34bb43e8',
+  'glslang_revision': '9b20b25138bfe916173c9341075b996be14baa69',
   'googletest_revision': '389cb68b87193358358ae87cc56d257fd0d80189',
   're2_revision': '7107ebc4fbf7205151d8d2a57b2fc6e7853125d4',
-  'spirv_headers_revision': '814e728b30ddd0f4509233099a3ad96fd4318c07',
-  'spirv_tools_revision': 'ab8eb607750208066e2d57eff6a34dbaf05f5ada',
+  'spirv_headers_revision': 'eddd4dfc930f1374a70797460240a501c7d333f7',
+  'spirv_tools_revision': '7d768812e20296c877a44ce0633d71f952fbf83c',
 }
 
 deps = {

--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -237,7 +237,7 @@ the following:
 * `opengl4.5`: create SPIR-V under OpenGL 4.5 semantics.
 
 Generated code uses SPIR-V 1.0, except for code compiled for Vulkan 1.1, which uses
-SPIR-V 1.3, and code compiled for Vulkan 1.5, which uses SPIR-V 1.5.
+SPIR-V 1.3, and code compiled for Vulkan 1.2, which uses SPIR-V 1.5.
 
 If this option is not specified, a default of `vulkan1.0` is used.
 
@@ -259,6 +259,7 @@ The ``<value>`` can be one of the following:
 * `spv1.3`
 * `spv1.4`
 * `spv1.5`
+* `spv1.6`
 
 ==== `-x`
 

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -170,7 +170,7 @@ Options:
                     the default for vulkan1.1 is spv1.3,
                     the default for vulkan1.2 is spv1.5.
                     Values are:
-                        spv1.0, spv1.1, spv1.2, spv1.3, spv1.4, spv1.5
+                        spv1.0, spv1.1, spv1.2, spv1.3, spv1.4, spv1.5, spv1.6
   --version         Display compiler version information.
   -w                Suppresses all warning messages.
   -Werror           Treat all warnings as errors.
@@ -470,6 +470,8 @@ int main(int argc, char** argv) {
         ver = shaderc_spirv_version_1_4;
       } else if (ver_str == "spv1.5") {
         ver = shaderc_spirv_version_1_5;
+      } else if (ver_str == "spv1.6") {
+        ver = shaderc_spirv_version_1_6;
       } else {
         std::cerr << "glslc: error: invalid value '" << ver_str
                   << "' in '--target-spv=" << ver_str << "'" << std::endl;

--- a/glslc/test/expect.py
+++ b/glslc/test/expect.py
@@ -312,6 +312,22 @@ class ValidObjectFile1_5(SuccessfulReturn, CorrectObjectFilePreamble):
         return True, ''
 
 
+class ValidObjectFile1_6(SuccessfulReturn, CorrectObjectFilePreamble):
+    """Mixin class for checking that every input file generates a valid SPIR-V 1.6
+    object file following the object file naming rule, and there is no output on
+    stdout/stderr."""
+
+    def check_object_file_preamble(self, status):
+        for input_filename in status.input_filenames:
+            object_filename = get_object_filename(input_filename)
+            success, message = self.verify_object_file_preamble(
+                os.path.join(status.directory, object_filename),
+                0x10600)
+            if not success:
+                return False, message
+        return True, ''
+
+
 class ValidObjectFileWithAssemblySubstr(SuccessfulReturn, CorrectObjectFilePreamble):
     """Mixin class for checking that every input file generates a valid object
     file following the object file naming rule, there is no output on

--- a/glslc/test/option_target_spv.py
+++ b/glslc/test/option_target_spv.py
@@ -78,6 +78,13 @@ class TestTargetSpv1p5(expect.ValidObjectFile1_5):
     glslc_args = ['--target-spv=spv1.5', '-c', shader]
 
 
+@inside_glslc_testsuite('OptionTargetSpv')
+class TestTargetSpv1p5(expect.ValidObjectFile1_6):
+    """Tests that compiling to spv1.6 succeeds and generates SPIR-V 1.6 binary."""
+    shader = FileShader(vulkan_vertex_shader(), '.vert')
+    glslc_args = ['--target-spv=spv1.6', '-c', shader]
+
+
 ### Option parsing error cases
 
 @inside_glslc_testsuite('OptionTargetSpv')

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -174,7 +174,7 @@ Options:
                     the default for vulkan1.1 is spv1.3,
                     the default for vulkan1.2 is spv1.5.
                     Values are:
-                        spv1.0, spv1.1, spv1.2, spv1.3, spv1.4, spv1.5
+                        spv1.0, spv1.1, spv1.2, spv1.3, spv1.4, spv1.5, spv1.6
   --version         Display compiler version information.
   -w                Suppresses all warning messages.
   -Werror           Treat all warnings as errors.

--- a/libshaderc/include/shaderc/env.h
+++ b/libshaderc/include/shaderc/env.h
@@ -60,7 +60,8 @@ typedef enum {
   shaderc_spirv_version_1_2 = 0x010200u,
   shaderc_spirv_version_1_3 = 0x010300u,
   shaderc_spirv_version_1_4 = 0x010400u,
-  shaderc_spirv_version_1_5 = 0x010500u
+  shaderc_spirv_version_1_5 = 0x010500u,
+  shaderc_spirv_version_1_6 = 0x010600u
 } shaderc_spirv_version;
 
 #ifdef __cplusplus

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -97,6 +97,7 @@ class Compiler {
     v1_3 = 0x010300u,
     v1_4 = 0x010400u,
     v1_5 = 0x010500u,
+    v1_6 = 0x010600u,
   };
 
   enum class OutputType {

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -766,6 +766,9 @@ GlslangClientInfo GetGlslangClientInfo(
       case Compiler::SpirvVersion::v1_5:
         result.target_language_version = glslang::EShTargetSpv_1_5;
         break;
+      case Compiler::SpirvVersion::v1_6:
+        result.target_language_version = glslang::EShTargetSpv_1_6;
+        break;
       default:
         errs << "error:" << error_tag << ": Unknown SPIR-V version " << std::hex
              << uint32_t(spv_version);

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -389,6 +389,12 @@ TEST_F(CompilerTest, SpirvTargetVersion1_5Succeeds) {
   EXPECT_THAT(errors_, Eq(""));
 }
 
+TEST_F(CompilerTest, SpirvTargetVersion1_6Succeeds) {
+  compiler_.SetTargetSpirv(Compiler::SpirvVersion::v1_6);
+  EXPECT_TRUE(SimpleCompilationSucceeds(kVulkanVertexShader, EShLangVertex));
+  EXPECT_THAT(errors_, Eq(""));
+}
+
 TEST_F(CompilerTest, SpirvTargetBadVersionFails) {
   compiler_.SetTargetSpirv(static_cast<Compiler::SpirvVersion>(0x090900));
   EXPECT_FALSE(SimpleCompilationSucceeds(kVulkanVertexShader, EShLangVertex));


### PR DESCRIPTION
Updates SPIRV-Headers, SPIRV-Tools.
Does not update Glslang or change any internal feature code.

Adds support to target SPIR-V 1.6 code generation.