### PR TITLE
Fix ndk-build libshader_combined target for newer NDK

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -52,8 +52,8 @@ $(1)/combine.ar: $(addprefix $(1)/, $(ALL_LIBS))
 
 $(1)/libshaderc_combined.a: $(addprefix $(1)/, $(ALL_LIBS)) $(1)/combine.ar
 	@echo "[$(TARGET_ARCH_ABI)] Combine: libshaderc_combined.a <= $(ALL_LIBS)"
-	@cd $(1) && $(2)ar -M < combine.ar && cd $(ROOT_SHADERC_PATH)
-	@$(2)objcopy --strip-debug $(1)/libshaderc_combined.a
+	@cd $(1) && $(TARGET_AR) -M < combine.ar && cd $(ROOT_SHADERC_PATH)
+	@$(TARGET_STRIP) --strip-debug $(1)/libshaderc_combined.a
 
 $(NDK_APP_LIBS_OUT)/$(APP_STL)/$(TARGET_ARCH_ABI)/libshaderc.a: \
 		$(1)/libshaderc_combined.a
@@ -73,4 +73,4 @@ endef
 
 libshaderc_combined: $(SHADERC_HEADERS_IN_OUT_DIR)
 
-$(eval $(call gen_libshaderc,$(TARGET_OUT),$(TOOLCHAIN_PREFIX)))
+$(eval $(call gen_libshaderc,$(TARGET_OUT)))

--- a/kokoro/ndk-build/build.sh
+++ b/kokoro/ndk-build/build.sh
@@ -44,13 +44,21 @@ cd $SRC/build
 
 # Invoke the build.
 BUILD_SHA=${KOKORO_GITHUB_COMMIT:-$KOKORO_GITHUB_PULL_REQUEST_COMMIT}
-echo $(date): Starting ndk-build ...
-$ANDROID_NDK/ndk-build \
-  -C $SRC/android_test \
-  NDK_APP_OUT=`pwd` \
-  V=1 \
-  SPVTOOLS_LOCAL_PATH=$SRC/third_party/spirv-tools \
-  SPVHEADERS_LOCAL_PATH=$SRC/third_party/spirv-headers \
-  -j 8
+
+function do_ndk_build () {
+  echo $(date): Starting ndk-build $@...
+  $ANDROID_NDK/ndk-build \
+    -C $SRC/android_test \
+    NDK_APP_OUT=`pwd` \
+    V=1 \
+    SPVTOOLS_LOCAL_PATH=$SRC/third_party/spirv-tools \
+    SPVHEADERS_LOCAL_PATH=$SRC/third_party/spirv-headers \
+    -j 8 $@
+}
+
+do_ndk_build
+
+# Check that libshaderc_combined builds
+do_ndk_build libshaderc_combined
 
 echo $(date): ndk-build completed.


### PR DESCRIPTION
The GNU binutils have been removed from more recent NDKs.
Use the TARGET_AR and TARGET_STRIP make variables to name
the 'ar' and 'strip' executables, rather than guessing their paths.

Update the ndk-build kokoro build script to test the libshaderc_build
target.