### PR TITLE
Support Vulkan 1.3, finalize v2021.4, start v2022.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,12 @@
 Revision history for Shaderc
 
-v2021.4-dev 2021-11-11
- - Support targeting SPIR-V 1.6
+v2021.4 2022-01-27
+ - Support Vulkan 1.3
+ - Support targeting SPIR-V 1.6, which is the default for Vulkan 1.3
  - Updated copyright check: Excludes Glslang generated files when
    building in source tree
+ - Fix Android.mk rules for building libshaderc_combined, to adapt to more
+   recent NDKs that have removed the GNU binutils.
 
 v2021.3 2021-11-11
  - Add build switch to disable copyright check

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Revision history for Shaderc
 
+v2022.0-dev 2022-01-27
+- Start v2022.0 development
+
 v2021.4 2022-01-27
  - Support Vulkan 1.3
  - Support targeting SPIR-V 1.6, which is the default for Vulkan 1.3

--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': '9b20b25138bfe916173c9341075b996be14baa69',
+  'glslang_revision': '9ebd8ff6c1d2c401cff3037cd798814001c92947',
   'googletest_revision': '389cb68b87193358358ae87cc56d257fd0d80189',
   're2_revision': '7107ebc4fbf7205151d8d2a57b2fc6e7853125d4',
-  'spirv_headers_revision': 'eddd4dfc930f1374a70797460240a501c7d333f7',
-  'spirv_tools_revision': '7d768812e20296c877a44ce0633d71f952fbf83c',
+  'spirv_headers_revision': 'b42ba6d92faf6b4938e6f22ddd186dbdacc98d78',
+  'spirv_tools_revision': 'b1877de5cd776117050bd42f08d04b52bce16099',
 }
 
 deps = {

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -159,6 +159,7 @@ Options:
                         vulkan1.0       # The default
                         vulkan1.1
                         vulkan1.2
+                        vulkan1.3
                         vulkan          # Same as vulkan1.0
                         opengl4.5
                         opengl          # Same as opengl4.5
@@ -169,6 +170,7 @@ Options:
                     For example, default for vulkan1.0 is spv1.0, and
                     the default for vulkan1.1 is spv1.3,
                     the default for vulkan1.2 is spv1.5.
+                    the default for vulkan1.3 is spv1.6.
                     Values are:
                         spv1.0, spv1.1, spv1.2, spv1.3, spv1.4, spv1.5, spv1.6
   --version         Display compiler version information.
@@ -438,6 +440,9 @@ int main(int argc, char** argv) {
       } else if (target_env_str == "vulkan1.2") {
         target_env = shaderc_target_env_vulkan;
         version = shaderc_env_version_vulkan_1_2;
+      } else if (target_env_str == "vulkan1.3") {
+        target_env = shaderc_target_env_vulkan;
+        version = shaderc_env_version_vulkan_1_3;
       } else if (target_env_str == "opengl") {
         target_env = shaderc_target_env_opengl;
       } else if (target_env_str == "opengl4.5") {

--- a/glslc/test/option_target_env.py
+++ b/glslc/test/option_target_env.py
@@ -131,6 +131,16 @@ class TestTargetEnvEqVulkan1_2WithVulkan1_1ShaderSucceeds(expect.ValidObjectFile
     glslc_args = ['--target-env=vulkan1.2', '-c', shader]
 
 @inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqVulkan1_2WithVulkan1_0ShaderSucceeds(expect.ValidObjectFile1_6):
+    shader = FileShader(vulkan_vertex_shader(), '.vert')
+    glslc_args = ['--target-env=vulkan1.3', '-c', shader]
+
+@inside_glslc_testsuite('OptionTargetEnv')
+class TestTargetEnvEqVulkan1_2WithVulkan1_1ShaderSucceeds(expect.ValidObjectFile1_6):
+    shader = FileShader(vulkan_compute_subgroup_shader(), '.comp')
+    glslc_args = ['--target-env=vulkan1.3', '-c', shader]
+
+@inside_glslc_testsuite('OptionTargetEnv')
 class TestTargetEnvEqOpenGL4_5WithOpenGLShaderSucceeds(expect.ValidObjectFile):
     shader = FileShader(opengl_vertex_shader(), '.vert')
     glslc_args = ['--target-env=opengl4.5', '-c', shader]

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -163,6 +163,7 @@ Options:
                         vulkan1.0       # The default
                         vulkan1.1
                         vulkan1.2
+                        vulkan1.3
                         vulkan          # Same as vulkan1.0
                         opengl4.5
                         opengl          # Same as opengl4.5
@@ -173,6 +174,7 @@ Options:
                     For example, default for vulkan1.0 is spv1.0, and
                     the default for vulkan1.1 is spv1.3,
                     the default for vulkan1.2 is spv1.5.
+                    the default for vulkan1.3 is spv1.6.
                     Values are:
                         spv1.0, spv1.1, spv1.2, spv1.3, spv1.4, spv1.5, spv1.6
   --version         Display compiler version information.

--- a/libshaderc/include/shaderc/env.h
+++ b/libshaderc/include/shaderc/env.h
@@ -40,6 +40,7 @@ typedef enum {
   shaderc_env_version_vulkan_1_0 = ((1u << 22)),
   shaderc_env_version_vulkan_1_1 = ((1u << 22) | (1 << 12)),
   shaderc_env_version_vulkan_1_2 = ((1u << 22) | (2 << 12)),
+  shaderc_env_version_vulkan_1_3 = ((1u << 22) | (3 << 12)),
   // For OpenGL, use the number from #version in shaders.
   // TODO(dneto): Currently no difference between OpenGL 4.5 and 4.6.
   // See glslang/Standalone/Standalone.cpp

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -305,6 +305,10 @@ shaderc_util::Compiler::TargetEnvVersion GetCompilerTargetEnvVersion(
       version_number) {
     return Compiler::TargetEnvVersion::Vulkan_1_2;
   }
+  if (static_cast<uint32_t>(Compiler::TargetEnvVersion::Vulkan_1_3) ==
+      version_number) {
+    return Compiler::TargetEnvVersion::Vulkan_1_3;
+  }
   if (static_cast<uint32_t>(Compiler::TargetEnvVersion::OpenGL_4_5) ==
       version_number) {
     return Compiler::TargetEnvVersion::OpenGL_4_5;

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -85,6 +85,7 @@ class Compiler {
     Vulkan_1_0 = ((1 << 22)),              // Vulkan 1.0
     Vulkan_1_1 = ((1 << 22) | (1 << 12)),  // Vulkan 1.1
     Vulkan_1_2 = ((1 << 22) | (2 << 12)),  // Vulkan 1.2
+    Vulkan_1_3 = ((1 << 22) | (3 << 12)),  // Vulkan 1.2
     // For OpenGL, use the numbering from #version in shaders.
     OpenGL_4_5 = 450,
   };

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -720,6 +720,9 @@ GlslangClientInfo GetGlslangClientInfo(
       } else if (env_version == Compiler::TargetEnvVersion::Vulkan_1_2) {
         result.client_version = glslang::EShTargetVulkan_1_2;
         result.target_language_version = glslang::EShTargetSpv_1_5;
+      } else if (env_version == Compiler::TargetEnvVersion::Vulkan_1_3) {
+        result.client_version = glslang::EShTargetVulkan_1_3;
+        result.target_language_version = glslang::EShTargetSpv_1_6;
       } else {
         errs << "error:" << error_tag << ": Invalid target client version "
              << static_cast<uint32_t>(env_version) << " for Vulkan environment "

--- a/libshaderc_util/src/compiler_test.cc
+++ b/libshaderc_util/src/compiler_test.cc
@@ -165,7 +165,7 @@ void main() { o = clamp(i, vec4(0.5), vec4(1.0)); }
 std::string Disassemble(const std::vector<uint32_t> binary) {
   std::string result;
   shaderc_util::SpirvToolsDisassemble(Compiler::TargetEnv::Vulkan,
-                                      Compiler::TargetEnvVersion::Vulkan_1_2,
+                                      Compiler::TargetEnvVersion::Vulkan_1_3,
                                       binary, &result);
   return result;
 }

--- a/libshaderc_util/src/spirv_tools_wrapper.cc
+++ b/libshaderc_util/src/spirv_tools_wrapper.cc
@@ -37,6 +37,8 @@ spv_target_env GetSpirvToolsTargetEnv(Compiler::TargetEnv env,
           return SPV_ENV_VULKAN_1_1;
         case Compiler::TargetEnvVersion::Vulkan_1_2:
           return SPV_ENV_VULKAN_1_2;
+        case Compiler::TargetEnvVersion::Vulkan_1_3:
+          return SPV_ENV_VULKAN_1_3;
         default:
           break;
       }


### PR DESCRIPTION
commit 51d94f91e1b9d66da9c96b8d946bc34e4189f0df

    Start v2022.0 development

commit b2a8f99b6753abab2bf8d60a6d4f89f39d4c5694

    Finalize v2021.4

commit 9c288704fed0afd4ec9a61b858fa826a4acd8c4c

    Support Vulkan 1.3
    
    When compiling to Vulkan 1.3, SPIR-V 1.6 is generated by default.
    
    Update DEPS to point to dependencies supporting Vulkan 1.3
     SPIRV-Toosl v2022.1
     Glslang as of 2022-01-27
