### PR TITLE
CMakeLists: enable CMAKE_MSVC_RUNTIME_LIBRARY property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 2.8.12)
+
+# Enable MSVC Runtime Library Property
+cmake_policy(SET CMP0091 NEW)
+
 project(shaderc)
 enable_testing()
 


### PR DESCRIPTION
Support for different MSVC Runtime Library options.
Example (when doing cmake setup):
cmake -S ... -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL

May also need to pass additional params to cmake setup:
-DLLVM_USE_CRT_RELEASE=MD
etc.

This is used by glslang (3rd party lib) to configure the MSVC Runtime Library