### PR TITLE
Update deps, adjust glslc test

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Revision history for Shaderc
 
 v2022.2-dev 2022-02-03
- - Start v2022.2 development
+ - Update glslc tests for newer Glslang debug output
 
 v2022.1 2022-02-03
  - Update DEPS to include two fixes on top of SPIRV-Tools v2022.1:

--- a/DEPS
+++ b/DEPS
@@ -5,11 +5,11 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'effcee_revision' : '2ec8f8738118cc483b67c04a759fee53496c5659',
-  'glslang_revision': 'c34bb3b6c55f6ab084124ad964be95a699700d34',
+  'glslang_revision': '4c3e00bf960121c9a1729f1935ab7912b7f651a8',
   'googletest_revision': '389cb68b87193358358ae87cc56d257fd0d80189',
   're2_revision': '7107ebc4fbf7205151d8d2a57b2fc6e7853125d4',
-  'spirv_headers_revision': 'b42ba6d92faf6b4938e6f22ddd186dbdacc98d78',
-  'spirv_tools_revision': 'b846f8f1dc2d79f2b5ce27d5ad901f885da1cf82',
+  'spirv_headers_revision': 'b930e734ea198b7aabbbf04ee1562cf6f57962f0',
+  'spirv_tools_revision': 'b930e734ea198b7aabbbf04ee1562cf6f57962f0',
 }
 
 deps = {

--- a/glslc/test/option_dash_cap_O.py
+++ b/glslc/test/option_dash_cap_O.py
@@ -43,6 +43,7 @@ ASSEMBLY_WITH_DEBUG_SOURCE = [
     '               OpName %main "main"\n',
     '       %void = OpTypeVoid\n',
     '          %4 = OpTypeFunction %void\n',
+    '               OpLine %1 2 11\n',
     '       %main = OpFunction %void None %4\n',
     '          %6 = OpLabel\n',
     '               OpReturn\n',


### PR DESCRIPTION
Glslang can now emit OpLine when compiling with debug info
Adjust the glslc test expectations