### PR TITLE
Add support for 16-bit HLSL types

### DIFF
--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -70,6 +70,8 @@ Options:
   -fhlsl_functionality1, -fhlsl-functionality1
                     Enable extension SPV_GOOGLE_hlsl_functionality1 for HLSL
                     compilation.
+  -fhlsl-16bit-types
+                    Enable 16-bit type support for HLSL.
   -finvert-y        Invert position.Y output in vertex shader.
   -fhlsl-iomap      Use HLSL IO mappings for bindings.
   -fhlsl-offsets    Use HLSL offset rules for packing members of blocks.
@@ -322,6 +324,8 @@ int main(int argc, char** argv) {
     } else if (arg == "-fhlsl_functionality1" ||
                arg == "-fhlsl-functionality1") {
       compiler.options().SetHlslFunctionality1(true);
+    } else if (arg == "-fhlsl-16bit-types") {
+      compiler.options().SetHlsl16BitTypes(true);
     } else if (arg == "-finvert-y") {
       compiler.options().SetInvertY(true);
     } else if (arg == "-fnan-clamp") {

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -461,6 +461,10 @@ SHADERC_EXPORT void shaderc_compile_options_set_hlsl_register_set_and_binding(
 SHADERC_EXPORT void shaderc_compile_options_set_hlsl_functionality1(
     shaderc_compile_options_t options, bool enable);
 
+// Sets whether 16-bit types are supported in HLSL or not.
+SHADERC_EXPORT void shaderc_compile_options_set_hlsl_16bit_types(
+    shaderc_compile_options_t options, bool enable);
+
 // Sets whether the compiler should invert position.Y output in vertex shader.
 SHADERC_EXPORT void shaderc_compile_options_set_invert_y(
     shaderc_compile_options_t options, bool enable);

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -342,6 +342,11 @@ class CompileOptions {
     shaderc_compile_options_set_hlsl_functionality1(options_, enable);
   }
 
+  // Sets whether 16-bit types are supported in HLSL or not.
+  void SetHlsl16BitTypes(bool enable) {
+    shaderc_compile_options_set_hlsl_16bit_types(options_, enable);
+  }
+
   // Sets whether the compiler should invert position.Y output in vertex shader.
   void SetInvertY(bool enable) {
     shaderc_compile_options_set_invert_y(options_, enable);

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -552,6 +552,11 @@ void shaderc_compile_options_set_hlsl_functionality1(
   options->compiler.EnableHlslFunctionality1(enable);
 }
 
+void shaderc_compile_options_set_hlsl_16bit_types(
+    shaderc_compile_options_t options, bool enable) {
+  options->compiler.EnableHlsl16BitTypes(enable);
+}
+
 void shaderc_compile_options_set_invert_y(
     shaderc_compile_options_t options, bool enable) {
   options->compiler.EnableInvertY(enable);

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -210,6 +210,7 @@ class Compiler {
         hlsl_offsets_(false),
         hlsl_legalization_enabled_(true),
         hlsl_functionality1_enabled_(false),
+        hlsl_16bit_types_enabled_(false),
         invert_y_enabled_(false),
         nan_clamp_(false),
         hlsl_explicit_bindings_() {}
@@ -227,6 +228,9 @@ class Compiler {
 
   // Enables or disables extension SPV_GOOGLE_hlsl_functionality1
   void EnableHlslFunctionality1(bool enable);
+
+  // Enables or disables HLSL 16-bit types.
+  void EnableHlsl16BitTypes(bool enable);
 
   // Enables or disables invert position.Y output in vertex shader.
   void EnableInvertY(bool enable);
@@ -527,6 +531,9 @@ class Compiler {
 
   // True if the compiler should support extension SPV_GOOGLE_hlsl_functionality1.
   bool hlsl_functionality1_enabled_;
+
+  // True if the compiler should support 16-bit HLSL types.
+  bool hlsl_16bit_types_enabled_;
 
   // True if the compiler should invert position.Y output in vertex shader.
   bool invert_y_enabled_;


### PR DESCRIPTION
glslang allows the use of 16-bit types in HLSL shaders with the `EShMsgHlslEnable16BitTypes` flag or the `--hlsl-enable-16bit-types` glslangValidator argument.

This PR exposes the functionality as a compile option in the shaderc header and adds a corresponding command-line argument.