### PR TITLE
Guard CMake policy CMP0091

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,10 @@
 
 cmake_minimum_required(VERSION 2.8.12)
 
-# Enable MSVC Runtime Library Property
-cmake_policy(SET CMP0091 NEW)
+if (POLICY CMP00091)
+  # Enable MSVC Runtime Library Property
+  cmake_policy(SET CMP0091 NEW)
+endif()
 
 project(shaderc)
 enable_testing()


### PR DESCRIPTION
That policy appeared in CMake 3.15

Fixes CI breaks introduced by #1247