### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,20 @@ test.vert
 /code $ glslc -c -o - test.vert | spirv-dis
 ```
 
+### Building and installing Shaderc using vcpkg 
+
+Alternatively, you can build and install shaderc using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```sh
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install shaderc
+```
+
+The shaderc port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Bug tracking
 
 We track bugs using GitHub -- click on the "Issues" button on


### PR DESCRIPTION
`shaderc` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `shaderc` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `shaderc`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/shaderc/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊