### PR TITLE
Update CMake to 3.17.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.17.2)
 
 if (POLICY CMP00091)
   # Enable MSVC Runtime Library Property

--- a/DEPS
+++ b/DEPS
@@ -8,8 +8,8 @@ vars = {
   'glslang_revision': '728c689574fba7e53305b475cd57f196c1a21226',
   'googletest_revision': 'd9bb8412d60b993365abb53f00b6dad9b2c01b62',
   're2_revision': 'd2836d1b1c34c4e330a85a1006201db474bf2c8a',
-  'spirv_headers_revision': 'c214f6f2d1a7253bb0e9f195c2dc5b0659dc99ef',
-  'spirv_tools_revision': 'd9446130d5165f7fafcb3599252a22e264c7d4bd',
+  'spirv_headers_revision': '34d04647d384e0aed037e7a2662a655fc39841bb',
+  'spirv_tools_revision': '077b09c32a9b8192139bcb74c253cc0ae9d95182',
 }
 
 deps = {


### PR DESCRIPTION
This is the oldest CMake version tested by the Shaderc bots See https://github.com/KhronosGroup/SPIRV-Tools/issues/5040