### PR TITLE
Explicitly construct a `string_piece` when comparing to `char*`

### DIFF
--- a/libshaderc_util/include/libshaderc_util/string_piece.h
+++ b/libshaderc_util/include/libshaderc_util/string_piece.h
@@ -332,7 +332,7 @@ inline std::ostream& operator<<(std::ostream& os, const string_piece& piece) {
 }
 
 inline bool operator==(const char* first, const string_piece second) {
-  return second == first;
+  return second == string_piece(first);
 }
 
 inline bool operator!=(const char* first, const string_piece second) {


### PR DESCRIPTION
In C++20, `operator==` candidates include rewritten candidates with reversed operand order, so this function creates infinite recursion just flipping operands back and forth. In C++17, it relies on implicit construction of a `string_piece`.

This is backwards and forwards compatible.