### PR TITLE
CI bots: run git-sync-deps in treeless mode

### DIFF
--- a/kokoro/linux/build-docker.sh
+++ b/kokoro/linux/build-docker.sh
@@ -58,7 +58,7 @@ then
 fi
 
 cd $ROOT_DIR
-./utils/git-sync-deps
+./utils/git-sync-deps --treeless
 
 mkdir build
 cd $ROOT_DIR/build

--- a/kokoro/macos/build.sh
+++ b/kokoro/macos/build.sh
@@ -32,7 +32,7 @@ chmod +x ninja
 export PATH="$PWD:$PATH"
 
 cd $SRC
-./utils/git-sync-deps
+./utils/git-sync-deps --treeless
 
 mkdir build
 cd $SRC/build

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -25,7 +25,7 @@ set VS_VERSION=%2
 set PATH=C:\python36;%PATH%
 
 cd %SRC%
-python utils\git-sync-deps
+python utils\git-sync-deps --treeless
 
 cmake --version
 

--- a/utils/git-sync-deps
+++ b/utils/git-sync-deps
@@ -28,10 +28,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Parse a DEPS file and git checkout all of the dependencies.
+"""
 
-Args:
-  An optional list of deps_os values.
-
+EXTRA_HELP = """
 Environment Variables:
   GIT_EXECUTABLE: path to "git" binary; if unset, will look for one of
   ['git', 'git.exe', 'git.bat'] in your default path.
@@ -52,6 +51,7 @@ Git Config:
 """
 
 
+import argparse
 import os
 import re
 import subprocess
@@ -59,12 +59,14 @@ import sys
 import threading
 from builtins import bytes
 
-
 def git_executable():
   """Find the git executable.
 
   Returns:
-      A string suitable for passing to subprocess functions, or None.
+      A triple:
+        A string suitable for passing to subprocess functions, or None.
+        The major version number
+        The minor version number
   """
   envgit = os.environ.get('GIT_EXECUTABLE')
   searchlist = ['git', 'git.exe', 'git.bat']
@@ -72,30 +74,36 @@ def git_executable():
     searchlist.insert(0, envgit)
   with open(os.devnull, 'w') as devnull:
     for git in searchlist:
+      major=None
+      minor=None
       try:
-        subprocess.call([git, '--version'], stdout=devnull)
+        version_info = subprocess.check_output([git, '--version']).decode('utf-8')
+        match = re.search("^git version (\d+)\.(\d+)",version_info)
+        print("Using {}".format(version_info))
+        if match:
+          major = int(match.group(1))
+          minor = int(match.group(2))
+        else:
+          continue
       except (OSError,):
         continue
-      return git
-  return None
+      return (git,major,minor)
+  return (None,0,0)
 
 
 DEFAULT_DEPS_PATH = os.path.normpath(
   os.path.join(os.path.dirname(__file__), os.pardir, 'DEPS'))
 
+def get_deps_os_str(deps_file):
+  parsed_deps = parse_file_to_dict(deps_file)
+  parts = []
+  if 'deps_os' in parsed_deps:
+    for deps_os in parsed_deps['deps_os']:
+      parts.append(' [{}]]'.format(deps_os))
+  return "\n".join(parts)
 
-def usage(deps_file_path = None):
-  sys.stderr.write(
-    'Usage: run to grab dependencies, with optional platform support:\n')
-  sys.stderr.write('  %s %s' % (sys.executable, __file__))
-  if deps_file_path:
-    parsed_deps = parse_file_to_dict(deps_file_path)
-    if 'deps_os' in parsed_deps:
-      for deps_os in parsed_deps['deps_os']:
-        sys.stderr.write(' [%s]' % deps_os)
-  sys.stderr.write('\n\n')
-  sys.stderr.write(__doc__)
-
+def looks_like_raw_commit(commit):
+  return re.match('^[a-f0-9]{40}$', commit) is not None
 
 def git_repository_sync_is_disabled(git, directory):
   try:
@@ -125,14 +133,14 @@ def is_git_toplevel(git, directory):
 
 def status(directory, checkoutable):
   def truncate(s, length):
-    return s if len(s) <= length else s[:(length - 3)] + '...'
+    return s if len(s) <= length else '...' + s[-(length - 3):]
   dlen = 36
   directory = truncate(directory, dlen)
   checkoutable = truncate(checkoutable, 40)
   sys.stdout.write('%-*s @ %s\n' % (dlen, directory, checkoutable))
 
 
-def git_checkout_to_directory(git, repo, checkoutable, directory, verbose):
+def git_checkout_to_directory(git, repo, checkoutable, directory, verbose, treeless):
   """Checkout (and clone if needed) a Git repository.
 
   Args:
@@ -147,13 +155,22 @@ def git_checkout_to_directory(git, repo, checkoutable, directory, verbose):
     directory (string) the path into which the repository
               should be checked out.
 
-    verbose (boolean)
+    verbose (boolean): emit status info to stdout
+
+    treeless (boolean): when true, clone without any trees.
 
   Raises an exception if any calls to git fail.
   """
   if not os.path.isdir(directory):
+    # Use blobless or treeless checkouts for faster downloads.
+    # This defers some work to checkout time.
+    # https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
+    filter = ['--filter=tree:0'] if treeless else ['--filter=blob:none']
+    # If the thing to check out looks like a tag (and not like a commit),
+    # then limit the checkout to that branch.
+    branch = [] if looks_like_raw_commit(checkoutable) else ['--branch={}'.format(checkoutable)]
     subprocess.check_call(
-      [git, 'clone', '--quiet', repo, directory])
+        [git, 'clone', '--quiet', '--single-branch'] + filter + branch + [repo, directory])
 
   if not is_git_toplevel(git, directory):
     # if the directory exists, but isn't a git repo, you will modify
@@ -168,7 +185,7 @@ def git_checkout_to_directory(git, repo, checkoutable, directory, verbose):
 
   with open(os.devnull, 'w') as devnull:
     # If this fails, we will fetch before trying again.  Don't spam user
-    # with error infomation.
+    # with error information.
     if 0 == subprocess.call([git, 'checkout', '--quiet', checkoutable],
                             cwd=directory, stderr=devnull):
       # if this succeeds, skip slow `git fetch`.
@@ -200,7 +217,7 @@ def parse_file_to_dict(path):
   return dictionary
 
 
-def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
+def git_sync_deps(deps_file_path, command_line_os_requests, verbose, treeless):
   """Grab dependencies, with optional platform support.
 
   Args:
@@ -210,10 +227,19 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
         List of strings that should each be a key in the deps_os
         dictionary in the DEPS file.
 
+    verbose (boolean): emit status info to stdout
+
+    treeless (boolean): when true, clone as treeless instead of blobless
+
   Raises git Exceptions.
   """
-  git = git_executable()
+  (git,git_major,git_minor) = git_executable()
   assert git
+
+  # --filter=tree:0 is available in git 2.20 and later
+  if (git_major,git_minor) < (2,20):
+    print("disabling --treeless: git is older than v2.20")
+    treeless = False
 
   deps_file_directory = os.path.dirname(deps_file_path)
   deps_file = parse_file_to_dict(deps_file_path)
@@ -241,7 +267,7 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
     relative_directory = os.path.join(deps_file_directory, directory)
 
     list_of_arg_lists.append(
-      (git, repo, checkoutable, relative_directory, verbose))
+      (git, repo, checkoutable, relative_directory, verbose, treeless))
 
   multithread(git_checkout_to_directory, list_of_arg_lists)
 
@@ -264,17 +290,47 @@ def multithread(function, list_of_arg_lists):
 
 
 def main(argv):
-  deps_file_path = os.environ.get('GIT_SYNC_DEPS_PATH', DEFAULT_DEPS_PATH)
-  verbose = not bool(os.environ.get('GIT_SYNC_DEPS_QUIET', False))
+  argparser = argparse.ArgumentParser(
+          prog = "git-sync-deps",
+          description = "Checkout git-based dependencies as specified by the DEPS file",
+          add_help=False # Because we want to print deps_os with -h option
+          )
+  argparser.add_argument("--help", "-h",
+                         action='store_true',
+                         help="show this help message and exit")
+  argparser.add_argument("--deps",
+                         default = os.environ.get('GIT_SYNC_DEPS_PATH', DEFAULT_DEPS_PATH),
+                         help="location of the the DEPS file")
+  argparser.add_argument("--verbose",
+                         default=not bool(os.environ.get('GIT_SYNC_DEPS_QUIET', False)),
+                         action='store_true',
+                         help="be verbose: print status messages")
+  argparser.add_argument("--treeless",
+                         default=False,
+                         action='store_true',
+                         help="""
+    Clone repos without trees (--filter=tree:0).
+    This is the fastest option for a build machine,
+    when you only need a single commit.
+    Defers getting objects until checking out a commit.
 
-  if '--help' in argv or '-h' in argv:
-    usage(deps_file_path)
-    return 1
+    The default is to clone with trees but without blobs.
 
-  git_sync_deps(deps_file_path, argv, verbose)
-  # subprocess.check_call(
-  #     [sys.executable,
-  #      os.path.join(os.path.dirname(deps_file_path), 'bin', 'fetch-gn')])
+    Only takes effect if using git 2.20 or later.
+
+    See https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/
+                              """)
+  argparser.add_argument("os_requests",nargs="*",
+                         help="OS requests, as keys in the deps_os dictionariy in the DEPS file")
+
+  args = argparser.parse_args()
+  if args.help:
+    print(argparser.format_help())
+    print(EXTRA_HELP)
+    print(get_deps_os_str(args.deps))
+    return 0
+
+  git_sync_deps(args.deps, args.os_requests, args.verbose, args.treeless)
   return 0
 
 


### PR DESCRIPTION
When cloning git repos on the CI bots, clone them without tree information. This should reduce network traffic and running time.