### PR TITLE
build: move from c++11 to c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 option(SHADERC_ENABLE_WERROR_COMPILE "Enable passing -Werror to compiler, if available" ON)
 
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
 
 include(GNUInstallDirs)
 include(cmake/setup_build.cmake)


### PR DESCRIPTION
The Khronos ecosystem is moving forward from c++11 to c++17. SPIRV-Tools will update to C++17 soon, hence we need Shaderc to also bump.

See https://github.com/KhronosGroup/SPIRV-Tools/pull/4983