### PR TITLE
Add option to preserve bindings

### DIFF
--- a/glslc/README.asciidoc
+++ b/glslc/README.asciidoc
@@ -437,6 +437,13 @@ layout(location = 1) in vec4 x;
 }
 ----
 
+[[option-fpreserve-bindings
+==== `-fpreserve-bindings`
+
+Directs the optimizer to preserve bindings declarations, even when those
+bindings are known to be unused.
+
+
 === Warning and Error Options
 
 ==== `-w`

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -87,6 +87,9 @@ Options:
                     a NaN operand, the other operand is returned. Similarly,
                     the clamp builtin will favour the non-NaN operands, as if
                     clamp were implemented as a composition of max and min.
+  -fpreserve-bindings
+                    Preserve all binding declarations, even if those bindings
+                    are not used.
   -fresource-set-binding [stage] <reg0> <set0> <binding0>
                         [<reg1> <set1> <binding1>...]
                     Explicitly sets the descriptor set and binding for
@@ -330,6 +333,8 @@ int main(int argc, char** argv) {
       compiler.options().SetInvertY(true);
     } else if (arg == "-fnan-clamp") {
       compiler.options().SetNanClamp(true);
+    } else if (arg.starts_with("-fpreserve-bindings")) {
+      compiler.options().SetPreserveBindings(true);
     } else if (((u_kind = shaderc_uniform_kind_image),
                 (arg == "-fimage-binding-base")) ||
                ((u_kind = shaderc_uniform_kind_texture),

--- a/glslc/test/option_fpreserve_bindings.py
+++ b/glslc/test/option_fpreserve_bindings.py
@@ -1,0 +1,70 @@
+# Copyright 2023 The Shaderc Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import expect
+from glslc_test_framework import inside_glslc_testsuite
+from placeholder import FileShader
+
+# A GLSL shader with unused bindings.
+GLSL_SHADER_WITH_UNUSED_BINDINGS = """#version 450
+  layout(binding=0) buffer InputA { vec4 x[]; } inputA;
+  layout(binding=1) buffer InputB { vec4 x[]; } inputB;
+  layout(binding=2) buffer Output { vec4 x[]; } outputO;
+
+  void main() {}
+  """
+
+
+@inside_glslc_testsuite('OptionFPreserveBindings')
+class TestFPreserveBindingsInputA(expect.ValidAssemblyFileWithSubstr):
+    """Tests that the compiler preserves bindings when optimizations are
+    enabled."""
+
+    shader = FileShader(GLSL_SHADER_WITH_UNUSED_BINDINGS, '.comp')
+    glslc_args = ['-S', '-O', shader, '-fpreserve-bindings']
+    # Check the first buffer.
+    expected_assembly_substr = "Binding 0"
+
+
+@inside_glslc_testsuite('OptionFPreserveBindings')
+class TestFPreserveBindingsInputB(expect.ValidAssemblyFileWithSubstr):
+    """Tests that the compiler preserves bindings when optimizations are
+    enabled."""
+
+    shader = FileShader(GLSL_SHADER_WITH_UNUSED_BINDINGS, '.comp')
+    glslc_args = ['-S', '-O', shader, '-fpreserve-bindings']
+    # Check the first buffer.
+    expected_assembly_substr = "Binding 1"
+
+
+@inside_glslc_testsuite('OptionFPreserveBindings')
+class TestFPreserveBindingsOutputO(expect.ValidAssemblyFileWithSubstr):
+    """Tests that the compiler preserves bindings when optimizations are
+    enabled."""
+
+    shader = FileShader(GLSL_SHADER_WITH_UNUSED_BINDINGS, '.comp')
+    glslc_args = ['-S', '-O', shader, '-fpreserve-bindings']
+    # Check the first buffer.
+    expected_assembly_substr = "Binding 2"
+
+
+@inside_glslc_testsuite('OptionFPreserveBindings')
+class TestFNoPreserveBindings(expect.ValidAssemblyFileWithoutSubstr):
+    """Tests that the compiler removes bindings when -fpreserve-bindings is not
+    set."""
+
+    shader = FileShader(GLSL_SHADER_WITH_UNUSED_BINDINGS, '.comp')
+    glslc_args = ['-S', '-O', shader]
+    # Check that all binding decorations are gone.
+    unexpected_assembly_substr = "OpDecorate"

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -91,6 +91,9 @@ Options:
                     a NaN operand, the other operand is returned. Similarly,
                     the clamp builtin will favour the non-NaN operands, as if
                     clamp were implemented as a composition of max and min.
+  -fpreserve-bindings
+                    Preserve all binding declarations, even if those bindings
+                    are not used.
   -fresource-set-binding [stage] <reg0> <set0> <binding0>
                         [<reg1> <set1> <binding1>...]
                     Explicitly sets the descriptor set and binding for

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -439,6 +439,11 @@ SHADERC_EXPORT void shaderc_compile_options_set_binding_base_for_stage(
     shaderc_compile_options_t options, shaderc_shader_kind shader_kind,
     shaderc_uniform_kind kind, uint32_t base);
 
+// Sets whether the compiler should preserve all bindings, even when those
+// bindings are not used.
+SHADERC_EXPORT void shaderc_compile_options_set_preserve_bindings(
+    shaderc_compile_options_t options, bool preserve_bindings);
+
 // Sets whether the compiler should automatically assign locations to
 // uniform variables that don't have explicit locations in the shader source.
 SHADERC_EXPORT void shaderc_compile_options_set_auto_map_locations(

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -311,6 +311,12 @@ class CompileOptions {
                                                        kind, base);
   }
 
+  // Sets whether the compiler should preserve all bindings, even when those
+  // bindings are not used.
+  void SetPreserveBindings(bool preserve_bindings) {
+    shaderc_compile_options_set_preserve_bindings(options_, preserve_bindings);
+  }
+
   // Sets whether the compiler automatically assigns locations to
   // uniform variables that don't have explicit locations.
   void SetAutoMapLocations(bool auto_map) {

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "shaderc/shaderc.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
@@ -527,6 +529,11 @@ void shaderc_compile_options_set_binding_base_for_stage(
     shaderc_uniform_kind kind, uint32_t base) {
   options->compiler.SetAutoBindingBaseForStage(GetStage(shader_kind),
                                                GetUniformKind(kind), base);
+}
+
+void shaderc_compile_options_set_preserve_bindings(
+    shaderc_compile_options_t options, bool preserve_bindings) {
+  options->compiler.SetPreserveBindings(preserve_bindings);
 }
 
 void shaderc_compile_options_set_auto_map_locations(

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -206,6 +206,7 @@ class Compiler {
         auto_combined_image_sampler_(false),
         auto_binding_base_(),
         auto_map_locations_(false),
+        preserve_bindings_(false),
         hlsl_iomap_(false),
         hlsl_offsets_(false),
         hlsl_legalization_enabled_(true),
@@ -305,6 +306,12 @@ class Compiler {
   void SetAutoBindingBaseForStage(Stage stage, UniformKind kind,
                                   uint32_t base) {
     auto_binding_base_[static_cast<int>(stage)][static_cast<int>(kind)] = base;
+  }
+
+  // Sets whether the compiler should preserve all bindings, even when those
+  // bindings are not used.
+  void SetPreserveBindings(bool preserve_bindings) {
+    preserve_bindings_ = preserve_bindings;
   }
 
   // Sets whether the compiler automatically assigns locations to
@@ -517,6 +524,9 @@ class Compiler {
   // True if the compiler should automatically map uniforms that don't
   // have explicit locations.
   bool auto_map_locations_;
+
+  // True if the compiler should preserve all bindings, even when unused.
+  bool preserve_bindings_;
 
   // True if the compiler should use HLSL IO mapping rules when compiling HLSL.
   bool hlsl_iomap_;

--- a/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
+++ b/libshaderc_util/include/libshaderc_util/spirv_tools_wrapper.h
@@ -60,6 +60,7 @@ enum class PassId {
 bool SpirvToolsOptimize(Compiler::TargetEnv env,
                         Compiler::TargetEnvVersion version,
                         const std::vector<PassId>& enabled_passes,
+                        spvtools::OptimizerOptions& optimizer_options,
                         std::vector<uint32_t>* binary, std::string* errors);
 
 }  // namespace shaderc_util

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -29,6 +29,7 @@
 #include "libshaderc_util/spirv_tools_wrapper.h"
 #include "libshaderc_util/string_piece.h"
 #include "libshaderc_util/version_profile.h"
+#include "spirv-tools/libspirv.hpp"
 
 namespace {
 using shaderc_util::string_piece;
@@ -348,9 +349,12 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
                     enabled_opt_passes_.end());
 
   if (!opt_passes.empty()) {
+    spvtools::OptimizerOptions opt_options;
+    opt_options.set_preserve_bindings(preserve_bindings_);
+
     std::string opt_errors;
-    if (!SpirvToolsOptimize(target_env_, target_env_version_,
-                            opt_passes, &spirv, &opt_errors)) {
+    if (!SpirvToolsOptimize(target_env_, target_env_version_, opt_passes,
+                            opt_options, &spirv, &opt_errors)) {
       *error_stream << "shaderc: internal error: compilation succeeded but "
                        "failed to optimize: "
                     << opt_errors << "\n";

--- a/libshaderc_util/src/spirv_tools_wrapper.cc
+++ b/libshaderc_util/src/spirv_tools_wrapper.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <sstream>
 
+#include "spirv-tools/libspirv.hpp"
 #include "spirv-tools/optimizer.hpp"
 
 namespace shaderc_util {
@@ -108,6 +109,7 @@ bool SpirvToolsAssemble(Compiler::TargetEnv env,
 bool SpirvToolsOptimize(Compiler::TargetEnv env,
                         Compiler::TargetEnvVersion version,
                         const std::vector<PassId>& enabled_passes,
+                        spvtools::OptimizerOptions& optimizer_options,
                         std::vector<uint32_t>* binary, std::string* errors) {
   errors->clear();
   if (enabled_passes.empty()) return true;
@@ -125,9 +127,9 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
   // This uses relaxed rules for pre-legalized HLSL.
   val_opts.SetBeforeHlslLegalization(true);
 
-  spvtools::OptimizerOptions opt_opts;
-  opt_opts.set_validator_options(val_opts);
-  opt_opts.set_run_validator(true);
+  // Set additional optimizer options.
+  optimizer_options.set_validator_options(val_opts);
+  optimizer_options.set_run_validator(true);
 
   spvtools::Optimizer optimizer(GetSpirvToolsTargetEnv(env, version));
 
@@ -159,7 +161,8 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
     }
   }
 
-  if (!optimizer.Run(binary->data(), binary->size(), binary, opt_opts)) {
+  if (!optimizer.Run(binary->data(), binary->size(), binary,
+                     optimizer_options)) {
     *errors = oss.str();
     return false;
   }


### PR DESCRIPTION
The new option `-fpreserve-bindings` matches the spirv-option `-preserve-bindings`.

Fixes: https://github.com/google/shaderc/issues/1300