### PR TITLE
Roll dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -4,11 +4,11 @@ vars = {
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
 
-  'effcee_revision' : '35912e1b7778ec2ddcff7e7188177761539e59',
-  'glslang_revision': '1fb2f1d7896627d62a289439a2c3e750e551a7ab',
-  'googletest_revision': 'd9bb8412d60b993365abb53f00b6dad9b2c01b62',
-  're2_revision': '954656f47fe8fb505d4818da1e128417a79ea500',
-  'spirv_headers_revision': 'd13b52222c39a7e9a401b44646f0ca3a640fbd47',
+  'effcee_revision' : '66edefd2bb641de8a2f46b476de21f227fc03a28',
+  'glslang_revision': '2ca0ee3ba4ed94e95f16c3d5b500a0a76b133ed1',
+  'googletest_revision': 'd9c309fdab807b716c2cf4d4a42989b8c34f712a',
+  're2_revision': '3a8436ac436124a57a4e22d5c8713a2d42b381d7',
+  'spirv_headers_revision': '295cf5fb3bfe2454360e82b26bae7fc0de699abe',
   'spirv_tools_revision': '63de608daeb7e91fbea6d7477a50debe7cac57ce',
 }
 


### PR DESCRIPTION
Roll third_party/effcee/ 35912e1b7..66edefd2b (2 commits)

https://github.com/google/effcee/compare/35912e1b7778...66edefd2bb64

$ git log 35912e1b7..66edefd2b --date=short --no-merges --format='%ad %ae %s' 2023-03-02 dneto Avoid hardcoding C++11 requirement at project level 2022-12-20 dneto Update Bazel external dependencies

Created with:
  roll-dep third_party/effcee

Roll third_party/glslang/ 1fb2f1d78..2ca0ee3ba (20 commits)

https://github.com/KhronosGroup/glslang/compare/1fb2f1d78966...2ca0ee3ba4ed

$ git log 1fb2f1d78..2ca0ee3ba --date=short --no-merges --format='%ad %ae %s' 2023-02-19 39247600+mjunix Fix potential NULL dereference 2023-02-19 39247600+mjunix Fix potential NULL dereference 2023-02-15 moritz.heinemann move ResourceLimits from StandAlone to glslang dir (Fix #3064) 2023-02-08 randy.oreilly updated test to test atomic float add and test results 2023-02-04 randy.oreilly change HLSL/hlslParseables.cpp to support InterlockedAdd on F=float types 2020-08-18 jengelh build: set SOVERSION on all libraries 2023-02-02 dneto Use the ninja already in the docker build. 2023-02-02 dneto kokoro: avoid git permissions issue that GN fails on 2023-02-02 neij9650 Add test
2023-02-01 neij9650 Block-decorate Vulkan Structs with RuntimeArrays 2023-02-02 hans GLSL: Fix integer overflow warnings in Constant.cpp 2023-01-30 git HLSL: Add missing relaxed-precision float/int matrix expansions 2023-01-30 jeremy Rename master to main and update news 2023-01-23 neij9650 Move check if useStorageBuffer needs to be set. From TParseContext used only by GLSL, to TParseContextBase inherited by both GLSL and HLSL paths. It caused compilations from HLSL to SPIR-V 1.3+ to use BufferBlock decoration which is no longer valid. 2023-01-20 arcady Reject non-float inputs/outputs with version < 120 2023-01-17 amirmasoudabdol Replace the deprecated $<CONFIGURATION> with $<CONFIG> 2023-01-19 jeremy Update readme with upcoming branch rename 2023-01-18 jeremy Update CHANGES for release 12.0.0 2023-01-18 jeremy Update known_good.json
2023-01-18 jeremy Update appveyor environment

Created with:
  roll-dep third_party/glslang

Roll third_party/googletest/ d9bb8412d..d9c309fda (0 commit)

https://github.com/google/googletest/compare/d9bb8412d60b...d9c309fdab80

$ git log d9bb8412d..d9c309fda --date=short --no-merges --format='%ad %ae %s'

Created with:
  roll-dep third_party/googletest

Roll third_party/re2/ 954656f47..3a8436ac4 (7 commits)

https://github.com/google/re2/compare/954656f47fe8...3a8436ac4361

$ git log 954656f47..3a8436ac4 --date=short --no-merges --format='%ad %ae %s' 2023-02-20 junyer Fuzz `RE2::Set` and `FilteredRE2`. 2023-02-13 junyer Add the `RE2_BUILD_FRAMEWORK` option to build RE2 as a framework. 2023-02-13 junyer Use `PUBLIC_HEADER` to install headers. 2023-02-10 junyer Fix a typographical error.
2023-01-30 raj.khem Use plain int type instead of int32_t 2023-01-25 junyer Improve support for the optional ICU dependency. 2023-01-23 junyer Introduce `bitmap256.cc` for `FindNextSetBit()`.

Created with:
  roll-dep third_party/re2

Roll third_party/spirv-headers/ d13b52222..295cf5fb3 (11 commits)

https://github.com/KhronosGroup/SPIRV-Headers/compare/d13b52222c39...295cf5fb3bfe

$ git log d13b52222..295cf5fb3 --date=short --no-merges --format='%ad %ae %s' 2023-03-01 abhishek2.tiwari update parameter name to match spec in grammar file 2023-02-23 abhishek2.tiwari move FPGAKernelAttributesv2INTEL to capability section in all files 2023-02-08 abhishek2.tiwari correct file entry position for FPGAKernelAttributesv2INTEL 2023-02-07 abhishek2.tiwari add FPGAKernelAttributesv2INTEL to all files 2023-01-27 abhishek2.tiwari address review comment 2023-01-26 abhishek2.tiwari add RegisterMapInterfaceINTEL 2023-01-17 ben.ashbaugh decouple SPV_KHR_shader_clock from the Shader capability 2023-01-04 brox.chen remove MMHostInterfaceAlignment and added parameters 2022-12-09 brox.chen added extension name
2022-11-30 brox.chen added SPRIV_INTEL_argument_interfaces 2022-10-16 qingyuanz NonSemantic.DebugBreak

Created with:
  roll-dep third_party/spirv-headers