### PR TITLE
Android.mk: Use $(file ..) instead of raw @echo. Update to NDK 21d

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Shaderc has been shipping in the
 [Android NDK](https://developer.android.com/ndk/index.html) since version r12b.
 (The NDK build uses sources from https://android.googlesource.com/platform/external/shaderc/.
 Those repos are downstream from GitHub.)
-We currently require r18b.
+We currently require r21d.
 
 For licensing terms, please see the [`LICENSE`](LICENSE) file.  If interested in
 contributing to this project, please see [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/kokoro/ndk-build/build.sh
+++ b/kokoro/ndk-build/build.sh
@@ -30,9 +30,9 @@ unzip -q ninja-linux.zip
 export PATH="$PWD:$PATH"
 
 # Get Android NDK.
-wget -q https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip
-unzip -q android-ndk-r18b-linux-x86_64.zip
-export ANDROID_NDK=$PWD/android-ndk-r18b
+wget -q https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
+unzip -q android-ndk-r21d-linux-x86_64.zip
+export ANDROID_NDK=$PWD/android-ndk-r21d
 
 # Get shaderc dependencies.
 cd $SRC


### PR DESCRIPTION
Fixes building of combined.ar on Windows.

Fixes #1321

Additionally:
- Use generate-file-dir macro This saves calling 'mkdir -p' repeatedly for each file.
- Simplify header generation logic
- Avoid a useless eval. Invoke the combined lib rules on TARGET_OUT directly.

Update NDK dependency to Android NDK 21d
- The ndk-build is based on GNU make 4. We need that to support the $(file ...) function