### PR TITLE
Add abseil as a dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ out/
 compile_commands.json
 .ycm_extra_conf.py
 cscope.*
+third_party/abseil_cpp
 third_party/effcee
 third_party/glslang
 third_party/googletest

--- a/DEPS
+++ b/DEPS
@@ -1,18 +1,23 @@
 use_relative_paths = True
 
 vars = {
+  'abseil_git':  'https://github.com/abseil',
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
 
+  'abseil_revision': '79ca5d7aad63973c83a4962a66ab07cd623131ea',
   'effcee_revision' : '66edefd2bb641de8a2f46b476de21f227fc03a28',
   'glslang_revision': '9fbc561947f6b5275289a1985676fb7267273e09',
   'googletest_revision': 'd9c309fdab807b716c2cf4d4a42989b8c34f712a',
-  're2_revision': '3a8436ac436124a57a4e22d5c8713a2d42b381d7',
+  're2_revision': 'c9cba76063cf4235c1a15dd14a24a4ef8d623761',
   'spirv_headers_revision': 'bdbfd019be6952fd8fa9bd5606a8798a7530c853',
   'spirv_tools_revision': 'e7c6084fd1d6d6f5ac393e842728d8be309688ca',
 }
 
 deps = {
+  'third_party/abseil_cpp':
+      Var('abseil_git') + '/abseil-cpp.git@' + Var('abseil_revision'),
+
   'third_party/effcee': Var('google_git') + '/effcee.git@' +
       Var('effcee_revision'),
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -17,6 +17,8 @@ set(SHADERC_RE2_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/re2" CACHE STRING
   "Location of re2 source")
 set(SHADERC_TINT_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/tint" CACHE STRING
   "Location of tint source")
+set(SHADERC_ABSL_DIR "${SHADERC_THIRD_PARTY_ROOT_DIR}/abseil_cpp" CACHE STRING
+  "Location of re2 source")
 
 set( SKIP_GLSLANG_INSTALL ${SHADERC_SKIP_INSTALL} )
 set( SKIP_SPIRV_TOOLS_INSTALL ${SHADERC_SKIP_INSTALL} )
@@ -49,7 +51,13 @@ if (NOT TARGET SPIRV-Tools)
       # Also skip building tests in SPIRV-Tools.
       set(SPIRV_SKIP_TESTS ON CACHE BOOL "Skip building SPIRV-Tools tests")
     elseif(NOT "${SPIRV_SKIP_TESTS}")
-      # SPIRV-Tools requires effcee and re2 to build tests.
+      # SPIRV-Tools requires effcee, re2, and abseil to build tests.
+      # re2 depends on abseil, so abseil must be added first.
+      set(ABSL_INTERNAL_AT_LEAST_CXX17 ON)
+      set(ABSL_PROPAGATE_CXX_STD ON)
+      set(ABSL_ENABLE_INSTALL ON)
+      add_subdirectory(${SHADERC_ABSL_DIR} absl EXCLUDE_FROM_ALL)
+
       # re2 tests take a long time and do not add much value, since re2 is a
       # dependency of a dependency, so not running them.
       set(RE2_BUILD_TESTING OFF CACHE STRING "Run RE2 Tests")


### PR DESCRIPTION
The latest version of RE2 depends on Abseil. This add Abseil as a dep
for shaderc, and updates RE2 to make sure it works.

This is needed to fix the spirv-tools smoke test.
