### PR TITLE
Fix MSVC runtime library linking in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,6 @@
 
 cmake_minimum_required(VERSION 3.17.2)
 
-if (POLICY CMP00091)
-  # Enable MSVC Runtime Library Property
-  cmake_policy(SET CMP0091 NEW)
-endif()
-
 project(shaderc)
 enable_testing()
 
@@ -114,17 +109,12 @@ add_custom_target(add-copyright
 if(MSVC)
   option(SHADERC_ENABLE_SHARED_CRT
           "Use the shared CRT instead of the static CRT"
-          ${SHADERC_ENABLE_SHARED_CRT})
-  if (NOT SHADERC_ENABLE_SHARED_CRT)
-    # Link executables statically by replacing /MD with /MT everywhere.
-    foreach(flag_var
-        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-      if(${flag_var} MATCHES "/MD")
-        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-      endif(${flag_var} MATCHES "/MD")
-    endforeach(flag_var)
-  endif(NOT SHADERC_ENABLE_SHARED_CRT)
+		  OFF)
+  if (SHADERC_ENABLE_SHARED_CRT)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+  else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  endif()
 endif(MSVC)
 
 


### PR DESCRIPTION
3.15 no longer appends /MD to the C_FLAGS and CXX_FLAGS by default when using the policy CMP0091 with the new behavior. This breaks any existing CMake code which searched for "/MD" to replace it with "/MT", as the flags no longer contain /MD. The fix is to use the new property MSVC_RUNTIME_LIBRARY so that all targets are configured correctly.

Fixes #1337 