### PR TITLE
Use android ndk r25

### DIFF
--- a/kokoro/android-release/build-docker.sh
+++ b/kokoro/android-release/build-docker.sh
@@ -27,7 +27,7 @@ set -x
 
 using cmake-3.17.2
 using ninja-1.10.0
-using ndk-r21d # Sets ANDROID_NDK_HOME, pointing at the NDK's root dir
+using ndk-r25c # Sets ANDROID_NDK_HOME, pointing at the NDK's root dir
 
 cd $ROOT_DIR
 ./utils/git-sync-deps

--- a/kokoro/ndk-build/build-docker.sh
+++ b/kokoro/ndk-build/build-docker.sh
@@ -40,7 +40,7 @@ function clean_dir() {
 # Get source for dependencies, as specified in the DEPS file
 /usr/bin/python3 utils/git-sync-deps --treeless
 
-using ndk-r21d
+using ndk-r25c
 
 clean_dir "$ROOT_DIR/build"
 cd "$ROOT_DIR/build"


### PR DESCRIPTION
We currently use R21 of the Android NDK for our tests. There have been
to LTS release since that one, and we do not expect people to use it
anymore. Also, it contains Python 2.7, not Python3. The python scripts
in SPIR-V Tools expect Python 3, so we have to update.

We chose the latest LTS release.
