### PR TITLE
Update DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,13 +5,13 @@ vars = {
   'google_git':  'https://github.com/google',
   'khronos_git': 'https://github.com/KhronosGroup',
 
-  'abseil_revision': '34eb767645347f100bdd66fc1e35eee96e357961',
+  'abseil_revision': '5be22f98733c674d532598454ae729253bc53e82',
   'effcee_revision' : '19b4aa87af25cb4ee779a071409732f34bfc305c',
-  'glslang_revision': '9575e33186c74a68831c469f7271edf386ea43a5',
-  'googletest_revision': 'ec4fed93217bc2830959bb8e86798c1d86956949',
+  'glslang_revision': 'd5f3ad6c9a996fcf944a7eac29a818f4583c55b0',
+  'googletest_revision': 'c541e7c11044b1e0303103ef8a47d7a9632c479b',
   're2_revision': 'c9cba76063cf4235c1a15dd14a24a4ef8d623761',
-  'spirv_headers_revision': '3469b164e25cee24435029a569933cb42578db5d',
-  'spirv_tools_revision': '04cdb2d344706052c7a2d359294e830ebac63e74',
+  'spirv_headers_revision': 'f1ba373ef03752ee9f6f2b898bea1213f93e1ef2',
+  'spirv_tools_revision': '6bd5a665ba0529747af3a0bc808732b7e78f48',
 }
 
 deps = {


### PR DESCRIPTION
SPIRV-Tools v2023.4.rc1
   plus PRs 5334, 5326
GitHub main on 2023-07-18 for:
  Glslang
  SPIRV-Headers
  googletest
  abseil