### PR TITLE
Make release candidate v2023.5-rc1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,11 @@
 Revision history for Shaderc
 
-v2023.5-dev 2022-05-24
+v2023.5-rc1 2022-07-18
+ - Update dependencies
+ - Update to Android NDK r25c
+ - Update Android API level for test project (#1333)
  - For testing, add a dependency on Abseil's C++ library
+ - Fix MSVC runtime library linking in CMake (#1339)
 
 v2023.4 2022-05-24
  - Refresh Glslang, SPIRV-Tools, SPIRV-Headers

--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ vars = {
   'googletest_revision': 'c541e7c11044b1e0303103ef8a47d7a9632c479b',
   're2_revision': 'c9cba76063cf4235c1a15dd14a24a4ef8d623761',
   'spirv_headers_revision': 'f1ba373ef03752ee9f6f2b898bea1213f93e1ef2',
-  'spirv_tools_revision': '6bd5a665ba0529747af3a0bc808732b7e78f48',
+  'spirv_tools_revision': '6c7e1acc5f9921b9a609dce62f30620bd6855764',
 }
 
 deps = {

--- a/utils/update_build_version.py
+++ b/utils/update_build_version.py
@@ -75,7 +75,7 @@ def deduce_software_version(directory):
     # Allow trailing whitespace in the checked-out source code has
     # unexpected carriage returns on a linefeed-only system such as
     # Linux.
-    pattern = re.compile(r'^(v\d+\.\d+(-dev)?) \d\d\d\d-\d\d-\d\d\s*$')
+    pattern = re.compile(r'^(v\d+\.\d+(-dev|[\.-]rc\d+)?) \d\d\d\d-\d\d-\d\d\s*$')
     changes_file = os.path.join(directory, 'CHANGES')
     with open(changes_file, errors='replace') as f:
         for line in f.readlines():


### PR DESCRIPTION
Also teach the build version extractor to understand [\.-]rc\d+ suffices.