### PR TITLE
Set cmake_policy CMP0128 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,16 @@ cmake_minimum_required(VERSION 3.17.2)
 project(shaderc)
 enable_testing()
 
+# Avoid a bug in CMake 3.22.1. By default it will set -std=c++11 for
+# targets in test/*, when those tests need -std=c++17.
+# https://github.com/google/shaderc/issues/1350
+# The bug is fixed in CMake 3.22.2
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.22.1")
+  if (${CMAKE_VERSION} VERSION_LESS "3.22.2")
+    cmake_policy(SET CMP0128 NEW)
+  endif()
+endif()
+
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "")
   message(STATUS "No build type selected, default to Debug")
   set(CMAKE_BUILD_TYPE "Debug")


### PR DESCRIPTION
Work around a problem in CMake 3.22.1 in setting -std=c++17. Instead -std=c++11 is in effect for targets in test/*, but those targets require C++17.

Fixes compiling SPIRV-Tools test targets in with certain Clang and CMake combinations.  Fixes a problem when trying to refresh shader-tools in the Android NDK.

Fixes: #1350