### PR TITLE
Add a workflow to automatically roll DEPS

### DIFF
--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -1,0 +1,66 @@
+# Copyright 2023 The Shaderc Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,s either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Update dependencies
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-dependencies:
+    permissions:
+      contents: write
+      pull-requests: write
+    name: Update dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Checkout the depot tools they are needed by roll_deps.sh
+      - name: Checkout depot tools
+        run: git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+
+      - name: Update PATH
+        run: echo "$(pwd)/depot_tools" >> $GITHUB_PATH
+
+      - name: Download dependencies
+        run: python3 utils/git-sync-deps
+
+      - name: Setup git user information
+        run: |
+          git config user.name "GitHub Actions[bot]"
+          git config user.email "<>"
+          git checkout -b roll_deps
+
+      - name: Update dependencies
+        run: |
+          utils/roll-deps
+          if [[ `git diff HEAD..origin/main --name-only | wc -l` == 0 ]]; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+        id: update_dependencies
+      - name: Push changes and create PR
+        if: steps.update_dependencies.outputs.changed == 'true'
+        run: |
+          git push --force --set-upstream origin roll_deps
+          gh pr create --label 'kokoro:run' --base main -f
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -61,6 +61,6 @@ jobs:
         if: steps.update_dependencies.outputs.changed == 'true'
         run: |
           git push --force --set-upstream origin roll_deps
-          gh pr create --label 'kokoro:run' --base main -f
+          gh pr create --label 'kokoro:run' --base main -f || true
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/utils/roll-deps
+++ b/utils/roll-deps
@@ -18,18 +18,23 @@
 #
 # Depends on roll-dep from depot_path being in PATH.
 
-effcee_dir="third_party/effcee/"
-effcee_trunk="origin/main"
-glslang_dir="third_party/glslang/"
-glslang_trunk="origin/main"
-googletest_dir="third_party/googletest/"
-googletest_trunk="origin/master"
-re2_dir="third_party/re2/"
-re2_trunk="origin/main"
-spirv_headers_dir="third_party/spirv-headers/"
-spirv_headers_trunk="origin/main"
-spirv_tools_dir="third_party/spirv-tools/"
-spirv_tools_trunk="origin/main"
+set -eo pipefail
+
+function ExitIfIsInterestingError() {
+  local return_code=$1
+  if [[ ${return_code} -ne 0 && ${return_code} -ne 2 ]]; then
+    exit ${return_code}
+  fi
+  return 0
+}
+
+dependencies=("third_party/effcee/"
+              "third_party/glslang/"
+              "third_party/googletest/"
+              "third_party/re2/"
+              "third_party/spirv-headers/"
+              "third_party/spirv-tools/")
+branch="origin/main"
 
 # This script assumes it's parent directory is the repo root.
 repo_path=$(dirname "$0")/..
@@ -41,13 +46,12 @@ if [[ $(git diff --stat) != '' ]]; then
     exit 1
 fi
 
-old_head=$(git rev-parse HEAD)
+echo "*** Ignore messages about running 'git cl upload' ***"
 
-roll-dep --ignore-dirty-tree --roll-to="${effcee_trunk}" "${effcee_dir}"
-roll-dep --ignore-dirty-tree --roll-to="${glslang_trunk}" "${glslang_dir}"
-roll-dep --ignore-dirty-tree --roll-to="${googletest_trunk}" "${googletest_dir}"
-roll-dep --ignore-dirty-tree --roll-to="${re2_trunk}" "${re2_dir}"
-roll-dep --ignore-dirty-tree --roll-to="${spirv_headers_trunk}" "${spirv_headers_dir}"
-roll-dep --ignore-dirty-tree --roll-to="${spirv_tools_trunk}" "${spirv_tools_dir}"
+set +e
 
-git rebase --interactive "${old_head}"
+for dep in ${dependencies[@]}; do
+  echo "Rolling $dep"
+  roll-dep --ignore-dirty-tree --roll-to="${branch}" "${dep}"
+  ExitIfIsInterestingError $?
+done


### PR DESCRIPTION
Create a GitHub action that syncs all git dependencies, rolls all entries in DEPS to tip-of-tree and commits, then uploads a new GitHub pull request with a trigger to automatically run kokoro tests.

The roll-deps script has been updated to not return an error when there are no new commits for a repository.

Both the autoroll.yml script and changes to utils/roll-deps are modeled after the scripts in KhronosGroup/SPIRV-Tools.