### PR TITLE
Remove redundant gtest compile flags for MinGW

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,11 @@ ctest -C {Release|Debug|MinSizeRel|RelWithDebInfo}
 ```
 
 4c) Or build with MinGW on Linux for Windows:
-(Skip building threaded unit tests due to
-[Googletest bug 606](https://github.com/google/googletest/issues/606))
 
 ```sh
 cd $BUILD_DIR
 cmake -GNinja -DCMAKE_BUILD_TYPE={Debug|Release|RelWithDebInfo} $SOURCE_DIR \
-   -DCMAKE_TOOLCHAIN_FILE=$SOURCE_DIR/cmake/linux-mingw-toolchain.cmake \
-   -Dgtest_disable_pthreads=ON
+   -DCMAKE_TOOLCHAIN_FILE=$SOURCE_DIR/cmake/linux-mingw-toolchain.cmake
 ninja
 ```
 

--- a/kokoro/linux/build-docker.sh
+++ b/kokoro/linux/build-docker.sh
@@ -53,7 +53,7 @@ then
   ADDITIONAL_CMAKE_FLAGS="-DDISABLE_EXCEPTIONS=ON -DDISABLE_RTTI=ON"
 elif [ $CONFIG = "RELEASE_MINGW" ]
 then
-  ADDITIONAL_CMAKE_FLAGS="-Dgtest_disable_pthreads=ON -DCMAKE_TOOLCHAIN_FILE=$ROOT_DIR/cmake/linux-mingw-toolchain.cmake"
+  ADDITIONAL_CMAKE_FLAGS="-DCMAKE_TOOLCHAIN_FILE=$ROOT_DIR/cmake/linux-mingw-toolchain.cmake"
   SKIP_TESTS="True"
 fi
 


### PR DESCRIPTION
When compiling with MinGW, we no longer need to use -Dgtest_disable_pthreads=ON.

See https://github.com/google/googletest/pull/856
and https://github.com/google/googletest/pull/721