### PR TITLE
CMake: Use TARGET_OBJECTS to replace archive acrobatics

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -173,50 +173,10 @@ endmacro()
 # Combines the static library "target" with all of its transitive static
 # library dependencies into a single static library "new_target".
 function(shaderc_combine_static_lib new_target target)
-
   set(all_libs "")
   shaderc_get_transitive_libs(${target} all_libs)
-
-  set(libname
-      ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${new_target}${CMAKE_STATIC_LIBRARY_SUFFIX})
-
-  if (MSVC)
-    string(REPLACE ";" ">;$<TARGET_FILE:" temp_string "${all_libs}")
-    set(lib_target_list "$<TARGET_FILE:${temp_string}>")
-
-    add_custom_command(OUTPUT ${libname}
-      DEPENDS ${all_libs}
-      COMMAND lib.exe ${lib_target_list} /OUT:${libname} /NOLOGO)
-  elseif(APPLE)
-    string(REPLACE ";" ">;$<TARGET_FILE:" temp_string "${all_libs}")
-    set(lib_target_list "$<TARGET_FILE:${temp_string}>")
-
-    add_custom_command(OUTPUT ${libname}
-      DEPENDS ${all_libs}
-      COMMAND libtool -static -o ${libname} ${lib_target_list})
-  else()
-    string(REPLACE ";" "> \naddlib $<TARGET_FILE:" temp_string "${all_libs}")
-    set(start_of_file
-      "create ${libname}\naddlib $<TARGET_FILE:${temp_string}>")
-    set(build_script_file "${start_of_file}\nsave\nend\n")
-
-    file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${new_target}.ar"
-        CONTENT ${build_script_file}
-        CONDITION 1)
-
-    add_custom_command(OUTPUT  ${libname}
-      DEPENDS ${all_libs}
-      COMMAND ${CMAKE_AR} -M < ${new_target}.ar)
-  endif()
-
-  add_custom_target(${new_target}_genfile ALL
-    DEPENDS ${libname})
-
-  # CMake needs to be able to see this as another normal library,
-  # so import the newly created library as an imported library,
-  # and set up the dependencies on the custom target.
-  add_library(${new_target} STATIC IMPORTED)
-  set_target_properties(${new_target}
-    PROPERTIES IMPORTED_LOCATION ${libname})
-  add_dependencies(${new_target} ${new_target}_genfile)
+  add_library(${new_target} STATIC)
+  foreach(lib IN LISTS all_libs)
+    target_sources(${new_target} PRIVATE $<TARGET_OBJECTS:${lib}>)
+  endforeach()
 endfunction()

--- a/libshaderc/CMakeLists.txt
+++ b/libshaderc/CMakeLists.txt
@@ -97,20 +97,7 @@ shaderc_add_tests(
 shaderc_combine_static_lib(shaderc_combined shaderc)
 
 if(SHADERC_ENABLE_INSTALL)
-  # Since shaderc_combined is defined as an imported library, we cannot use the
-  # install() directive to install it. Install it like a normal file.
-  get_target_property(generated_location shaderc_combined LOCATION)
-  string(REGEX MATCH "Visual Studio .*" vs_generator "${CMAKE_GENERATOR}")
-  if (NOT "${vs_generator}" STREQUAL "")
-    # With Visual Studio generators, the LOCATION property is not properly
-    # expanded according to the current build configuration. We need to work
-    # around this problem by manually substitution.
-    string(REPLACE "$(Configuration)" "\${CMAKE_INSTALL_CONFIG_NAME}"
-      install_location "${generated_location}")
-    install(FILES ${install_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  else()
-    install(FILES ${generated_location} DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  endif()
+  install(TARGETS shaderc_combined DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif(SHADERC_ENABLE_INSTALL)
 
 shaderc_add_tests(


### PR DESCRIPTION
Rather than trying to manually merge static libraries into a combined static library, we can instead just let CMake do it for us.

This solves:
- https://github.com/google/shaderc/issues/1367
- https://github.com/google/shaderc/issues/473

I've successfully tested this with the following generators:
- Visual Studio 17 2022
- Unix Makefiles
- Ninja
- Ninja Multi-Config
- CodeBlocks - Ninja
- CodeBlocks - Unix Makefiles
- CodeLite - Ninja
- CodeLite - Unix Makefiles
- Eclipse CDT4 - Ninja
- Eclipse CDT4 - Unix Makefiles
- Kate - Ninja
- Kate - Unix Makefiles
- Sublime Text 2 - Ninja
- Sublime Text 2 - Unix Makefiles