### PR TITLE
Fix warning missing-field-initializers

### DIFF
--- a/glslc/src/file_includer.cc
+++ b/glslc/src/file_includer.cc
@@ -22,7 +22,7 @@
 namespace glslc {
 
 shaderc_include_result* MakeErrorIncludeResult(const char* message) {
-  return new shaderc_include_result{"", 0, message, strlen(message)};
+  return new shaderc_include_result{"", 0, message, strlen(message), 0};
 }
 
 FileIncluder::~FileIncluder() = default;


### PR DESCRIPTION
Small fix to solve missing-field-initializers warning on GCC 9