### PR TITLE
Make Shaderc v2023.7 release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Revision history for Shaderc
 
-v2023.7-rc1 2023-10-12
+v2023.7 2023-10-12
  - Update dependencies
  - Finish converting build instructions and flags to always use C++17
  - Add GitHub CI to test more flows

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,9 @@
 Revision history for Shaderc
 
-v2023.7-dev 2023-08-09
- - Start v2023.7 development
+v2023.7-rc1 2023-10-12
+ - Update dependencies
+ - Finish converting build instructions and flags to always use C++17
+ - Add GitHub CI to test more flows
 
 v2023.6 2023-08-09
  - Update dependencies, including SPIRV-Tools v2023.4.rc2

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Revision history for Shaderc
 
+v2023.8-dev 2023-10-12
+ - Start development
+
 v2023.7 2023-10-12
  - Update dependencies
  - Finish converting build instructions and flags to always use C++17

--- a/DEPS
+++ b/DEPS
@@ -7,11 +7,11 @@ vars = {
 
   'abseil_revision': '5be22f98733c674d532598454ae729253bc53e82',
   'effcee_revision' : '19b4aa87af25cb4ee779a071409732f34bfc305c',
-  'glslang_revision': '2bfacdac91d5d9ba6bab7b4da52eb79c2300cd45',
+  'glslang_revision': '48f9ed8b08be974f4e463ef38136c8f23513b2cf',
   'googletest_revision': 'e47544ad31cb3ceecd04cc13e8fe556f8df9fe0b',
   're2_revision': 'c9cba76063cf4235c1a15dd14a24a4ef8d623761',
-  'spirv_headers_revision': '79743b899fde5c954897b2694291002626358fac',
-  'spirv_tools_revision': '27673a054447e37810a38e7ce8d35a0a88af4a75',
+  'spirv_headers_revision': '4183b260f4cccae52a89efdfcdd43c4897989f42',
+  'spirv_tools_revision': '360d469b9eac54d6c6e20f609f9ec35e3a5380ad',
 }
 
 deps = {


### PR DESCRIPTION

    Start Shaderc v2023.8-dev

commit 468b152c92ffb2e7b2950822aa3456363f46c184
Author: David Neto <dneto@google.com>
Date:   Thu Oct 12 21:22:29 2023 -0400

    Shaderc v2303.7 release

commit fed6f087405fc49800d478824ff30638550048af
Author: David Neto <dneto@google.com>
Date:   Thu Oct 12 21:17:43 2023 -0400

    Make Shaderc v2023.7-rc1 release candidate

commit 0b4ee9ac0f1d8833aee8caf2192986fa75a56a2c
Author: David Neto <dneto@google.com>
Date:   Thu Oct 12 21:12:49 2023 -0400

    Update DEPS
    
    Glslang GitHub top of tree 2023-10-12
    SPIRV-Tools v2023.5.rc1
    SPIRV-Headers GitHub top of tree 2023-10-12

