### PR TITLE
Expose setting relaxed Vulkan rules from glslang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ third_party/tint
 android_test/libs
 android_test/include
 .DS_Store
+.vscode/

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -489,6 +489,12 @@ SHADERC_EXPORT void shaderc_compile_options_set_hlsl_functionality1(
 SHADERC_EXPORT void shaderc_compile_options_set_hlsl_16bit_types(
     shaderc_compile_options_t options, bool enable);
 
+// Enables or disables relaxed Vulkan rules.
+//
+// This allows most OpenGL shaders to compile under Vulkan semantics.
+SHADERC_EXPORT void shaderc_compile_options_set_vulkan_rules_relaxed(
+    shaderc_compile_options_t options, bool enable);
+
 // Sets whether the compiler should invert position.Y output in vertex shader.
 SHADERC_EXPORT void shaderc_compile_options_set_invert_y(
     shaderc_compile_options_t options, bool enable);

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -353,6 +353,13 @@ class CompileOptions {
     shaderc_compile_options_set_hlsl_16bit_types(options_, enable);
   }
 
+  // Enables or disables relaxed Vulkan rules.
+  //
+  // This allows most OpenGL shaders to compile under Vulkan semantics.
+  void SetVulkanRulesRelaxed(bool enable) {
+    shaderc_compile_options_set_vulkan_rules_relaxed(options_, enable);
+  }
+
   // Sets whether the compiler should invert position.Y output in vertex shader.
   void SetInvertY(bool enable) {
     shaderc_compile_options_set_invert_y(options_, enable);

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -564,6 +564,11 @@ void shaderc_compile_options_set_hlsl_16bit_types(
   options->compiler.EnableHlsl16BitTypes(enable);
 }
 
+void shaderc_compile_options_set_vulkan_rules_relaxed(
+    shaderc_compile_options_t options, bool enable) {
+  options->compiler.SetVulkanRulesRelaxed(enable);
+}
+
 void shaderc_compile_options_set_invert_y(
     shaderc_compile_options_t options, bool enable) {
   options->compiler.EnableInvertY(enable);

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -233,6 +233,11 @@ class Compiler {
   // Enables or disables HLSL 16-bit types.
   void EnableHlsl16BitTypes(bool enable);
 
+  // Enables or disables relaxed Vulkan rules.
+  //
+  // This allows most OpenGL shaders to compile under Vulkan semantics.
+  void SetVulkanRulesRelaxed(bool enable);
+
   // Enables or disables invert position.Y output in vertex shader.
   void EnableInvertY(bool enable);
 
@@ -544,6 +549,10 @@ class Compiler {
 
   // True if the compiler should support 16-bit HLSL types.
   bool hlsl_16bit_types_enabled_;
+
+  // True if the compiler should relax Vulkan rules to allow OGL shaders to
+  // compile.
+  bool vulkan_rules_relaxed_ = false;
 
   // True if the compiler should invert position.Y output in vertex shader.
   bool invert_y_enabled_;

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -295,7 +295,7 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
     shader.setEnvTargetHlslFunctionality1();
   }
   if (vulkan_rules_relaxed_) {
-    glslang::EShSource language;
+    glslang::EShSource language = glslang::EShSourceNone;
     switch(source_language_) {
       case SourceLanguage::GLSL:
         language = glslang::EShSourceGlsl;

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -294,6 +294,22 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   if (hlsl_functionality1_enabled_) {
     shader.setEnvTargetHlslFunctionality1();
   }
+  if (vulkan_rules_relaxed_) {
+    glslang::EShSource language;
+    switch(source_language_) {
+      case SourceLanguage::GLSL:
+        language = glslang::EShSourceGlsl;
+        break;
+      case SourceLanguage::HLSL:
+        language = glslang::EShSourceHlsl;
+        break;
+    }
+    // This option will only be used if the Vulkan client is used.
+    // If new versions of GL_KHR_vulkan_glsl come out, it would make sense to
+    // let callers specify which version to use. For now, just use 100.
+    shader.setEnvInput(language, used_shader_stage, glslang::EShClientVulkan, 100);
+    shader.setEnvInputVulkanRulesRelaxed();
+  }
   shader.setInvertY(invert_y_enabled_);
   shader.setNanMinMaxClamp(nan_clamp_);
 
@@ -450,6 +466,10 @@ void Compiler::EnableHlslLegalization(bool hlsl_legalization_enabled) {
 
 void Compiler::EnableHlslFunctionality1(bool enable) {
   hlsl_functionality1_enabled_ = enable;
+}
+
+void Compiler::SetVulkanRulesRelaxed(bool enable) {
+  vulkan_rules_relaxed_ = enable;
 }
 
 void Compiler::EnableHlsl16BitTypes(bool enable) {


### PR DESCRIPTION
This exposes https://github.com/KhronosGroup/GLSL/blob/master/extensions/ext/GL_EXT_vulkan_glsl_relaxed.txt, which allows for compilation of many OpenGL GLSL shaders to Vulkan SPIRV.

Adds a simple test.