### PR TITLE
OGLCompiler and HLSL have been removed from glslang

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -19,12 +19,10 @@ include $(ROOT_SHADERC_PATH)/libshaderc_util/Android.mk
 include $(ROOT_SHADERC_PATH)/libshaderc/Android.mk
 
 ALL_LIBS:=libglslang.a \
-	libOGLCompiler.a \
 	libOSDependent.a \
 	libshaderc.a \
 	libshaderc_util.a \
 	libSPIRV.a \
-	libHLSL.a \
 	libSPIRV-Tools.a \
 	libSPIRV-Tools-opt.a
 

--- a/DEPS
+++ b/DEPS
@@ -7,7 +7,7 @@ vars = {
 
   'abseil_revision': '5be22f98733c674d532598454ae729253bc53e82',
   'effcee_revision' : '19b4aa87af25cb4ee779a071409732f34bfc305c',
-  'glslang_revision': '48f9ed8b08be974f4e463ef38136c8f23513b2cf',
+  'glslang_revision': '3f615ad93ea58264fe6f06995178691ec6b556a7',
   'googletest_revision': 'e47544ad31cb3ceecd04cc13e8fe556f8df9fe0b',
   're2_revision': 'c9cba76063cf4235c1a15dd14a24a4ef8d623761',
   'spirv_headers_revision': '4183b260f4cccae52a89efdfcdd43c4897989f42',

--- a/glslc/CMakeLists.txt
+++ b/glslc/CMakeLists.txt
@@ -43,7 +43,7 @@ if (SHADERC_ENABLE_WGSL_OUTPUT)
 endif(SHADERC_ENABLE_WGSL_OUTPUT)
 
 target_link_libraries(glslc PRIVATE
-  glslang OSDependent OGLCompiler HLSL glslang SPIRV    # Glslang libraries
+  glslang SPIRV    # Glslang libraries
   $<$<BOOL:${SHADERC_ENABLE_WGSL_OUTPUT}>:libtint>      # Tint libraries, optional
   shaderc_util shaderc                                  # internal Shaderc libraries
   ${CMAKE_THREAD_LIBS_INIT})

--- a/libshaderc/CMakeLists.txt
+++ b/libshaderc/CMakeLists.txt
@@ -63,7 +63,7 @@ endif(SHADERC_ENABLE_INSTALL)
 
 find_package(Threads)
 set(SHADERC_LIBS
-  glslang OSDependent OGLCompiler glslang ${CMAKE_THREAD_LIBS_INIT}
+  glslang ${CMAKE_THREAD_LIBS_INIT}
   shaderc_util
   SPIRV # from glslang
   SPIRV-Tools

--- a/libshaderc/README.md
+++ b/libshaderc/README.md
@@ -7,8 +7,8 @@ A library for compiling shader strings into SPIR-V.
 There are two main shaderc libraries that are created during a CMake
 compilation. The first is `libshaderc`, which is a static library
 containing just the functionality exposed by libshaderc. It depends
-on other compilation targets `glslang`, `OSDependent`, `OGLCompiler`,
-`shaderc_util`, `SPIRV`, `HLSL`, `SPIRV-Tools`, and `SPIRV-Tools-opt`.
+on other compilation targets `glslang`, `shaderc_util`, `SPIRV`,
+`SPIRV-Tools`, and `SPIRV-Tools-opt`.
 
 The other is `libshaderc_combined`, which is a static library containing
 libshaderc and all of its dependencies.
@@ -38,12 +38,9 @@ platforms `-lpthread` should also be specified.
 counterparts should be linked in the order specified.
   * `build/libshaderc/libshaderc.a`
   * `build/third_party/glslang/glslang/glslang.a`
-  * `build/third_party/glslang/glslang/OSDependent/{Platform}/libOSDependent.a`
-  * `build/third_party/glslang/OGLCompilersDLL/libOGLCompiler.a`
   * `build/third_party/glslang/libglslang.a`
   * `build/shaderc_util/libshaderc_util.a`
   * `build/third_party/glslang/SPIRV/libSPIRV.a`
-  * `build/third_party/glslang/hlsl/libHLSL.a`
   * `build/third_party/spirv-tools/libSPIRV-Tools-opt.a`
   * `build/third_party/spirv-tools/libSPIRV-Tools.a`
 

--- a/libshaderc_util/CMakeLists.txt
+++ b/libshaderc_util/CMakeLists.txt
@@ -46,7 +46,7 @@ add_definitions(-DENABLE_HLSL)
 
 find_package(Threads)
 target_link_libraries(shaderc_util PRIVATE
-  glslang OSDependent OGLCompiler HLSL glslang SPIRV
+  glslang SPIRV
   SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
 
 shaderc_add_tests(


### PR DESCRIPTION
This fixes SPIRV-Tools CI-shaderc-smoketest build failure.