### PR TITLE
Build fix for glslang

### DIFF
--- a/glslc/CMakeLists.txt
+++ b/glslc/CMakeLists.txt
@@ -43,7 +43,7 @@ if (SHADERC_ENABLE_WGSL_OUTPUT)
 endif(SHADERC_ENABLE_WGSL_OUTPUT)
 
 target_link_libraries(glslc PRIVATE
-  glslang OSDependent OGLCompiler HLSL glslang SPIRV    # Glslang libraries
+  glslang OSDependent glslang SPIRV    # Glslang libraries
   $<$<BOOL:${SHADERC_ENABLE_WGSL_OUTPUT}>:libtint>      # Tint libraries, optional
   shaderc_util shaderc                                  # internal Shaderc libraries
   ${CMAKE_THREAD_LIBS_INIT})

--- a/libshaderc_util/CMakeLists.txt
+++ b/libshaderc_util/CMakeLists.txt
@@ -46,7 +46,7 @@ add_definitions(-DENABLE_HLSL)
 
 find_package(Threads)
 target_link_libraries(shaderc_util PRIVATE
-  glslang OSDependent OGLCompiler HLSL glslang SPIRV
+  glslang OSDependent glslang SPIRV
   SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
 
 shaderc_add_tests(


### PR DESCRIPTION
The OGLCompilerDLL and HLSL libraries have been deleted from the glslang source, and before that they were just empty stubs.