### PR TITLE
Update shaderc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Revision history for Shaderc
 
+v2024.0-dev 2024-01-03
+ - Start development
+
 v2023.8 2024-01-03
  - API: Expose rlaxed Vulkan rules from glslang
  - Update to Glslang 14.0.0

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,11 @@
 Revision history for Shaderc
 
-v2023.8-dev 2023-10-12
- - Start development
+v2023.8 2024-01-03
+ - API: Expose rlaxed Vulkan rules from glslang
+ - Update to Glslang 14.0.0
+ - CMake:
+   - Comply with CMP0148: Use PythonInterp
+   - Use TARGET_OBJECTS to simplify creating the shaderc_shared library.
 
 v2023.7 2023-10-12
  - Update dependencies

--- a/DEPS
+++ b/DEPS
@@ -7,11 +7,11 @@ vars = {
 
   'abseil_revision': '5be22f98733c674d532598454ae729253bc53e82',
   'effcee_revision' : '19b4aa87af25cb4ee779a071409732f34bfc305c',
-  'glslang_revision': '6be56e45e574b375d759b89dad35f780bbd4792f',
+  'glslang_revision': 'a91631b260cba3f22858d6c6827511e636c2458a',
   'googletest_revision': 'e47544ad31cb3ceecd04cc13e8fe556f8df9fe0b',
   're2_revision': 'c9cba76063cf4235c1a15dd14a24a4ef8d623761',
-  'spirv_headers_revision': '4183b260f4cccae52a89efdfcdd43c4897989f42',
-  'spirv_tools_revision': '360d469b9eac54d6c6e20f609f9ec35e3a5380ad',
+  'spirv_headers_revision': '1c6bb2743599e6eb6f37b2969acc0aef812e32e3',
+  'spirv_tools_revision': 'f0cc85efdbbe3a46eae90e0f915dc1509836d0fc',
 }
 
 deps = {


### PR DESCRIPTION
Start Shaderc v2024.0-dev

Finalize Shaderc v2023.8

Update deps
    
    Glslang: 14.0.0
    SPIRV-Headers to 2024-01-01
    SPIRV-Tools v2023.6.rc1

