### PR TITLE
Generate nonsemantic shader debug information

### DIFF
--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -341,6 +341,10 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   options.generateDebugInfo = generate_debug_info_;
   options.disableOptimizer = true;
   options.optimizeSize = false;
+  if (generate_debug_info_) {
+    options.emitNonSemanticShaderDebugInfo = true;
+    options.emitNonSemanticShaderDebugSource = true;
+  }
   // Note the call to GlslangToSpv also populates compilation_output_data.
   glslang::GlslangToSpv(*program.getIntermediate(used_shader_stage), spirv,
                         &options);


### PR DESCRIPTION
Proof of concept fix for #1391.

Possibly `emitNonSemanticShaderDebugInfo` and `emitNonSemanticShaderDebugSource` should be controlled using dedicated command line arguments instead of just `-g`.

This worked for me and allowed me to use RenderDoc source debugging.