### PR TITLE
Fix comment typo in shaderc.hpp

### DIFF
--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -365,7 +365,7 @@ class CompileOptions {
     shaderc_compile_options_set_invert_y(options_, enable);
   }
 
-  // Sets whether the compiler should generates code for max an min which,
+  // Sets whether the compiler should generate code for max and min which,
   // if given a NaN operand, will return the other operand. Similarly, the
   // clamp builtin will favour the non-NaN operands, as if clamp were
   // implemented as a composition of max and min.


### PR DESCRIPTION
"Sets whether the compiler should generates code for max an min" -> "Sets whether the compiler should generate code for max and min"