### PR TITLE
Update DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -7,11 +7,11 @@ vars = {
 
   'abseil_revision': '5be22f98733c674d532598454ae729253bc53e82',
   'effcee_revision' : 'aea1f4d62ca9ee2f44b5393e98e175e200a22e8e',
-  'glslang_revision': '142052fa30f9eca191aa9dcf65359fcaed09eeec',
+  'glslang_revision': '2b19bf7e1bc0b60cf2fe9d33e5ba6b37dfc1cc83',
   'googletest_revision': 'e47544ad31cb3ceecd04cc13e8fe556f8df9fe0b',
   're2_revision': 'c9cba76063cf4235c1a15dd14a24a4ef8d623761',
-  'spirv_headers_revision': '5e3ad389ee56fca27c9705d093ae5387ce404df4',
-  'spirv_tools_revision': 'dd4b663e13c07fea4fbb3f70c1c91c86731099f7',
+  'spirv_headers_revision': 'ff2afc3afc48dff4eec2a10f0212402a80708e38',
+  'spirv_tools_revision': '70ad4dae7dc2c2d035c288b4e9ada0d7bcc26e9b',
 }
 
 deps = {

--- a/glslc/test/option_fauto_bind_uniforms.py
+++ b/glslc/test/option_fauto_bind_uniforms.py
@@ -80,8 +80,10 @@ float4 main() : SV_Target0 {
    u6[2];
    u7;
    u8;
-   return float4(u8.Consume() + t2.SampleCmp(s2, 1.0, 2.0)) + t1.Sample(s1, 1.0)
-    + t6.Load(1);
+   // SampleCmp disabled due to https://github.com/KhronosGroup/glslang/issues/2444.
+   //return float4(u8.Consume() + t2.SampleCmp(s2, 1.0, 2.0)) + t1.Sample(s1, 1.0)
+   // + t6.Load(1);
+   return float4(u8.Consume()) + t1.Sample(s1, 1.0) + t6.Load(1);
 }
 """
 
@@ -340,7 +342,7 @@ class HlslFSamplerBindingBaseOptionRespected(expect.ValidAssemblyFileWithSubstr)
     shader = FileShader(HLSL_SHADER_WITHOUT_BINDINGS, '.frag')
     glslc_args = ['-S', '-x', 'hlsl', '-fhlsl-iomap', shader,
                   '-fauto-bind-uniforms', '-fsampler-binding-base', '100']
-    expected_assembly_substr = "OpDecorate %s2 Binding 102"
+    expected_assembly_substr = "OpDecorate %s1 Binding 101"
 
 
 @inside_glslc_testsuite('OptionFAutoBindUniforms')
@@ -351,7 +353,7 @@ class HlslFSamplerBindingBaseForFragOptionRespected(expect.ValidAssemblyFileWith
     shader = FileShader(HLSL_SHADER_WITHOUT_BINDINGS, '.frag')
     glslc_args = ['-S', '-x', 'hlsl', '-fhlsl-iomap', shader,
                   '-fauto-bind-uniforms', '-fsampler-binding-base', 'frag', '100']
-    expected_assembly_substr = "OpDecorate %s2 Binding 102"
+    expected_assembly_substr = "OpDecorate %s1 Binding 101"
 
 
 @inside_glslc_testsuite('OptionFAutoBindUniforms')
@@ -362,7 +364,7 @@ class HlslFSamplerBindingBaseForComputeOptionIgnoredWhenCompilingAsFrag(expect.V
     shader = FileShader(HLSL_SHADER_WITHOUT_BINDINGS, '.frag')
     glslc_args = ['-S', '-x', 'hlsl', '-fhlsl-iomap', shader,
                   '-fauto-bind-uniforms', '-fsampler-binding-base', 'compute', '100']
-    expected_assembly_substr = "OpDecorate %s2 Binding 2"
+    expected_assembly_substr = "OpDecorate %s1 Binding 1"
 
 
 @inside_glslc_testsuite('OptionFAutoBindUniforms')


### PR DESCRIPTION
* Roll spirv-tools, spirv-headers, and glslang deps
* Modify glslc tests where that depended on SampleCmp HLSL calls since glslang generates invalid SPIR-V