### PR TITLE
Fix expectations: Glslang orders decorations on an object by enum

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -7,7 +7,7 @@ vars = {
 
   'abseil_revision': '1315c900e1ddbb08a23e06eeb9a06450052ccb5e',
   'effcee_revision': 'd74d33d93043952a99ae7cd7458baf6bc8df1da0',
-  'glslang_revision': '2d8b71fc63578a93726c05e0565c3ef064bdc1ba',
+  'glslang_revision': '5939e32b87487fa9c72ab336ebfcc5ae26d9ab6d',
   'googletest_revision': '1d17ea141d2c11b8917d2c7d029f1c4e2b9769b2',
   're2_revision': '4a8cee3dd3c3d81b6fe8b867811e193d5819df07',
   'spirv_headers_revision': '2acb319af38d43be3ea76bfabf3998e5281d8d12',

--- a/glslc/test/option_fresource_set_binding.py
+++ b/glslc/test/option_fresource_set_binding.py
@@ -38,10 +38,10 @@ class FRegisterSetBindingForFragRespected(expect.ValidAssemblyFileWithSubstr):
                   '-fresource-set-binding', 'frag',
                   't4', '9', '16',
                   't5', '17', '18']
-    expected_assembly_substr = """OpDecorate %t4 DescriptorSet 9
-               OpDecorate %t4 Binding 16
-               OpDecorate %t5 DescriptorSet 17
-               OpDecorate %t5 Binding 18"""
+    expected_assembly_substr = """OpDecorate %t4 Binding 16
+               OpDecorate %t4 DescriptorSet 9
+               OpDecorate %t5 Binding 18
+               OpDecorate %t5 DescriptorSet 17"""
 
 
 @inside_glslc_testsuite('OptionFRegisterSetBinding')
@@ -52,10 +52,10 @@ class FRegisterSetBindingForFragRespectedJustOneTriple(expect.ValidAssemblyFileW
     glslc_args = ['-S', '-x', 'hlsl', shader,
                   '-fresource-set-binding', 'frag',
                   't4', '9', '16']
-    expected_assembly_substr = """OpDecorate %t4 DescriptorSet 9
-               OpDecorate %t4 Binding 16
-               OpDecorate %t5 DescriptorSet 0
-               OpDecorate %t5 Binding 5"""
+    expected_assembly_substr = """OpDecorate %t4 Binding 16
+               OpDecorate %t4 DescriptorSet 9
+               OpDecorate %t5 Binding 5
+               OpDecorate %t5 DescriptorSet 0"""
 
 
 @inside_glslc_testsuite('OptionFRegisterSetBinding')
@@ -67,10 +67,10 @@ class FRegisterSetBindingForWrongStageIgnored(expect.ValidAssemblyFileWithSubstr
                   '-fresource-set-binding', 'vert',
                   't4', '9', '16',
                   't5', '17', '18']
-    expected_assembly_substr = """OpDecorate %t4 DescriptorSet 0
-               OpDecorate %t4 Binding 4
-               OpDecorate %t5 DescriptorSet 0
-               OpDecorate %t5 Binding 5"""
+    expected_assembly_substr = """OpDecorate %t4 Binding 4
+               OpDecorate %t4 DescriptorSet 0
+               OpDecorate %t5 Binding 5
+               OpDecorate %t5 DescriptorSet 0"""
 
 
 @inside_glslc_testsuite('OptionFRegisterSetBinding')
@@ -82,10 +82,10 @@ class FRegisterSetBindingForAllRespected(expect.ValidAssemblyFileWithSubstr):
                   '-fresource-set-binding',
                   't4', '9', '16',
                   't5', '17', '18']
-    expected_assembly_substr = """OpDecorate %t4 DescriptorSet 9
-               OpDecorate %t4 Binding 16
-               OpDecorate %t5 DescriptorSet 17
-               OpDecorate %t5 Binding 18"""
+    expected_assembly_substr = """OpDecorate %t4 Binding 16
+               OpDecorate %t4 DescriptorSet 9
+               OpDecorate %t5 Binding 18
+               OpDecorate %t5 DescriptorSet 17"""
 
 
 @inside_glslc_testsuite('OptionFRegisterSetBinding')


### PR DESCRIPTION
React to https://github.com/KhronosGroup/glslang/pull/3635 which deduplicates decorations on an object.  It has the side effect of ordering decorations on an object by the decoration enum.