### PR TITLE
kokoro: use Python 3.12 on Linux

### DIFF
--- a/kokoro/linux/build-docker.sh
+++ b/kokoro/linux/build-docker.sh
@@ -27,6 +27,7 @@ BUILD_TYPE="Debug"
 
 using cmake-3.17.2
 using ninja-1.10.0
+using python-3.12
 
 if [ ! -z "$COMPILER" ]; then
     using "$COMPILER"


### PR DESCRIPTION
Bug: crbug.com/350048185