### PR TITLE
Add an API to set descriptor set and binding of default uniform block

### DIFF
--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -506,6 +506,11 @@ SHADERC_EXPORT void shaderc_compile_options_set_invert_y(
 SHADERC_EXPORT void shaderc_compile_options_set_nan_clamp(
     shaderc_compile_options_t options, bool enable);
 
+// Sets the descriptor set and binding for the default uniform block in the
+// relaxed Vulkan rules mode.
+SHADERC_EXPORT void shaderc_compile_options_set_default_uniform_block_set_and_binding(
+    shaderc_compile_options_t options, uint32_t set, uint32_t binding);
+
 // An opaque handle to the results of a call to any shaderc_compile_into_*()
 // function.
 typedef struct shaderc_compilation_result* shaderc_compilation_result_t;

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -579,6 +579,11 @@ void shaderc_compile_options_set_nan_clamp(shaderc_compile_options_t options,
   options->compiler.SetNanClamp(enable);
 }
 
+void shaderc_compile_options_set_default_uniform_block_set_and_binding(
+    shaderc_compile_options_t options, uint32_t set, uint32_t binding) {
+  options->compiler.SetDefaultUniformBlockSetAndBinding(set, binding);
+}
+
 shaderc_compiler_t shaderc_compiler_initialize() {
   shaderc_compiler_t compiler = new (std::nothrow) shaderc_compiler;
   if (compiler) {

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -214,6 +214,8 @@ class Compiler {
         hlsl_16bit_types_enabled_(false),
         invert_y_enabled_(false),
         nan_clamp_(false),
+        default_uniform_block_set_(0),
+        default_uniform_block_binding_(0),
         hlsl_explicit_bindings_() {}
 
   // Requests that the compiler place debug information into the object code,
@@ -337,6 +339,13 @@ class Compiler {
     for (auto stage : stages()) {
       SetHlslRegisterSetAndBindingForStage(stage, reg, set, binding);
     }
+  }
+
+  // Sets the descriptor set and binding for the default uniform block in
+  // the relaxed Vulkan rules mode.
+  void SetDefaultUniformBlockSetAndBinding(uint32_t set, uint32_t binding) {
+    default_uniform_block_set_ = set;
+    default_uniform_block_binding_ = binding;
   }
 
   // Sets an explicit set and binding for the given HLSL register in the given
@@ -562,6 +571,12 @@ class Compiler {
   // builtin will favour the non-NaN operands, as if clamp were implemented
   // as a composition of max and min.
   bool nan_clamp_;
+
+  // Descriptor set for the default uniform block in relaxed Vulkan rules mode.
+  uint32_t default_uniform_block_set_;
+
+  // Binding for the default uniform block in relaxed Vulkan rules mode.
+  uint32_t default_uniform_block_binding_;
 
   // A sequence of triples, each triple representing a specific HLSL register
   // name, and the set and binding numbers it should be mapped to, but in

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -312,6 +312,8 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   }
   shader.setInvertY(invert_y_enabled_);
   shader.setNanMinMaxClamp(nan_clamp_);
+  shader.setGlobalUniformSet(default_uniform_block_set_);
+  shader.setGlobalUniformBinding(default_uniform_block_binding_);
 
   const EShMessages rules =
       GetMessageRules(target_env_, source_language_, hlsl_offsets_,


### PR DESCRIPTION
This is for the relaxed Vulkan rules mode.