### PR TITLE
Don't use friendly names for SPIR-V validation errors

### DIFF
--- a/libshaderc_util/src/spirv_tools_wrapper.cc
+++ b/libshaderc_util/src/spirv_tools_wrapper.cc
@@ -126,6 +126,11 @@ bool SpirvToolsOptimize(Compiler::TargetEnv env,
   val_opts.SetRelaxLogicalPointer(true);
   // This uses relaxed rules for pre-legalized HLSL.
   val_opts.SetBeforeHlslLegalization(true);
+  // Don't use friendly names when printing validation errors.
+  // It incurs a high startup cost whether or not there is an
+  // error. Validation failures are compiler bugs, and so they
+  // should be rare anyway.
+  val_opts.SetFriendlyNames(false);
 
   // Set additional optimizer options.
   optimizer_options.set_validator_options(val_opts);


### PR DESCRIPTION
Setting up friendly names requires parsing the entire module
which costs a lot of time due to (1) scanning the whole module,
and (2) creating string names for many IDs.

This is a followup to https://github.com/KhronosGroup/SPIRV-Tools/issues/5802
There, Blender was suffering long shader suite build times due to
serialization on locale. But secondarily we noticed there was a lot
of string manipulation when setting up the validator, all because
the friendly name mapper is on by default for the optimizer.

Turn off friendly names in the optimizer's use of the validator.
The validation errors are only emitted when there is a compiler
bug, so they should be rare.  Don't make every compilation pay
the cost.