### PR TITLE
Update glslang, SPIRV-Tools

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -7,11 +7,11 @@ vars = {
 
   'abseil_revision': '1315c900e1ddbb08a23e06eeb9a06450052ccb5e',
   'effcee_revision': 'd74d33d93043952a99ae7cd7458baf6bc8df1da0',
-  'glslang_revision': 'a0995c49ebcaca2c6d3b03efbabf74f3843decdb',
+  'glslang_revision': '340bf88f3fdb4f4a25b7071cd2c1205035fc6eaa',
   'googletest_revision': '1d17ea141d2c11b8917d2c7d029f1c4e2b9769b2',
   're2_revision': '4a8cee3dd3c3d81b6fe8b867811e193d5819df07',
   'spirv_headers_revision': '3f17b2af6784bfa2c5aa5dbb8e0e74a607dd8b3b',
-  'spirv_tools_revision': '4d2f0b40bfe290dea6c6904dafdf7fd8328ba346',
+  'spirv_tools_revision': '13b59bf1d84054b8ccd29cdc6b1303f69e8f9e77',
 }
 
 deps = {

--- a/kokoro/android-release/build-docker.sh
+++ b/kokoro/android-release/build-docker.sh
@@ -25,7 +25,7 @@ set -e
 # Display commands being run.
 set -x
 
-using cmake-3.17.2
+using cmake-3.31.2
 using ninja-1.10.0
 using ndk-r25c # Sets ANDROID_NDK_HOME, pointing at the NDK's root dir
 

--- a/kokoro/linux/build-docker.sh
+++ b/kokoro/linux/build-docker.sh
@@ -25,7 +25,7 @@ set -x # Display commands being run.
 SKIP_TESTS="False"
 BUILD_TYPE="Debug"
 
-using cmake-3.17.2
+using cmake-3.31.2
 using ninja-1.10.0
 using python-3.12
 

--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -23,6 +23,8 @@ set VS_VERSION=%2
 
 :: Force usage of python 3.6.
 set PATH=C:\python36;%PATH%
+:: Glslang requires cmake 3.27 or later
+set PATH=C:\cmake-3.31.2\bin;%PATH%
 
 cd %SRC%
 python utils\git-sync-deps


### PR DESCRIPTION
SPIRV-Tools fixes
- validation of multi-line debug info.
- assembler: avoid infinite loop when trying to parse version string from comments