### PR TITLE
Update effcee, spirv-tools

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -6,12 +6,12 @@ vars = {
   'khronos_git': 'https://github.com/KhronosGroup',
 
   'abseil_revision': '1315c900e1ddbb08a23e06eeb9a06450052ccb5e',
-  'effcee_revision': 'd74d33d93043952a99ae7cd7458baf6bc8df1da0',
+  'effcee_revision': '08da24ec245a274fea3a128ba50068f163390565',
   'glslang_revision': '340bf88f3fdb4f4a25b7071cd2c1205035fc6eaa',
   'googletest_revision': '1d17ea141d2c11b8917d2c7d029f1c4e2b9769b2',
   're2_revision': '4a8cee3dd3c3d81b6fe8b867811e193d5819df07',
   'spirv_headers_revision': '3f17b2af6784bfa2c5aa5dbb8e0e74a607dd8b3b',
-  'spirv_tools_revision': '13b59bf1d84054b8ccd29cdc6b1303f69e8f9e77',
+  'spirv_tools_revision': '8f98634c4a2615e24888c77f425d13ef4893e8dc',
 }
 
 deps = {


### PR DESCRIPTION
Effcee uses the new CMake method for setting the MSVC runtime CMP0091 NEW