### PR TITLE
kokoro: add VS2022 scripts

### DIFF
--- a/kokoro/windows/build.bat
+++ b/kokoro/windows/build.bat
@@ -20,6 +20,7 @@ set BUILD_ROOT=%cd%
 set SRC=%cd%\github\shaderc
 set BUILD_TYPE=%1
 set VS_VERSION=%2
+set ARCH=%3
 
 :: Force usage of python 3.12
 set PATH=C:\python312;%PATH%
@@ -38,8 +39,9 @@ cd %SRC%\build
 :: set up msvc build env
 :: #########################################
 if %VS_VERSION% == 2019 (
-  call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
-  echo "Using VS 2019..."
+  call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
+) else if %VS_VERSION% == 2022 (
+  call "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvarsall.bat" %ARCH%
 )
 
 :: #########################################

--- a/kokoro/windows/build_2019_amd64_debug.bat
+++ b/kokoro/windows/build_2019_amd64_debug.bat
@@ -1,0 +1,23 @@
+:: Copyright (C) 2023 Google Inc.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::     http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+::
+:: Windows Build Script.
+
+@echo on
+
+:: Find out the directory of the common build script.
+set SCRIPT_DIR=%~dp0
+
+:: Call with correct parameter
+call %SCRIPT_DIR%\build.bat Debug 2019 amd64

--- a/kokoro/windows/build_2019_amd64_release.bat
+++ b/kokoro/windows/build_2019_amd64_release.bat
@@ -1,0 +1,23 @@
+:: Copyright (C) 2023 Google Inc.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::     http://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+::
+:: Windows Build Script.
+
+@echo on
+
+:: Find out the directory of the common build script.
+set SCRIPT_DIR=%~dp0
+
+:: Call with correct parameter
+call %SCRIPT_DIR%\build.bat RelWithDebInfo 2019 amd64

--- a/kokoro/windows/build_2022_amd64_debug.bat
+++ b/kokoro/windows/build_2022_amd64_debug.bat
@@ -1,4 +1,4 @@
-:: Copyright (C) 2023 Google Inc.
+:: Copyright (C) 2025 Google Inc.
 ::
 :: Licensed under the Apache License, Version 2.0 (the "License");
 :: you may not use this file except in compliance with the License.
@@ -20,4 +20,4 @@
 set SCRIPT_DIR=%~dp0
 
 :: Call with correct parameter
-call %SCRIPT_DIR%\build.bat RelWithDebInfo 2019
+call %SCRIPT_DIR%\build.bat Debug 2022 amd64

--- a/kokoro/windows/build_2022_amd64_release.bat
+++ b/kokoro/windows/build_2022_amd64_release.bat
@@ -1,4 +1,4 @@
-:: Copyright (C) 2023 Google Inc.
+:: Copyright (C) 2025 Google Inc.
 ::
 :: Licensed under the Apache License, Version 2.0 (the "License");
 :: you may not use this file except in compliance with the License.
@@ -20,4 +20,4 @@
 set SCRIPT_DIR=%~dp0
 
 :: Call with correct parameter
-call %SCRIPT_DIR%\build.bat Debug 2019
+call %SCRIPT_DIR%\build.bat RelWithDebInfo 2022 amd64

--- a/kokoro/windows/continuous_debug_2019.cfg
+++ b/kokoro/windows/continuous_debug_2019.cfg
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Continuous build configuration.
-build_file: "shaderc/kokoro/windows/build_debug_2019.bat"
+build_file: "shaderc/kokoro/windows/build_2019_amd64_debug.bat"
 
 action {
   define_artifacts {

--- a/kokoro/windows/continuous_release_2019.cfg
+++ b/kokoro/windows/continuous_release_2019.cfg
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Continuous build configuration.
-build_file: "shaderc/kokoro/windows/build_release_2019.bat"
+build_file: "shaderc/kokoro/windows/build_2019_amd64_release.bat"
 
 action {
   define_artifacts {

--- a/kokoro/windows/presubmit_debug_2019.cfg
+++ b/kokoro/windows/presubmit_debug_2019.cfg
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 # Presubmit build configuration.
-build_file: "shaderc/kokoro/windows/build_debug_2019.bat"
+build_file: "shaderc/kokoro/windows/build_2019_amd64_debug.bat"

--- a/kokoro/windows/vs2022_amd64_debug_continuous.cfg
+++ b/kokoro/windows/vs2022_amd64_debug_continuous.cfg
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Google Inc.
+# Copyright (C) 2025 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,5 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Presubmit build configuration.
-build_file: "shaderc/kokoro/windows/build_2019_amd64_release.bat"
+# Continuous build configuration.
+build_file: "shaderc/kokoro/windows/build_2022_amd64_debug.bat"
+
+action {
+  define_artifacts {
+    regex: "install.zip"
+  }
+}

--- a/kokoro/windows/vs2022_amd64_debug_presubmit.cfg
+++ b/kokoro/windows/vs2022_amd64_debug_presubmit.cfg
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Google Inc.
+# Copyright (C) 2025 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,4 +13,10 @@
 # limitations under the License.
 
 # Presubmit build configuration.
-build_file: "shaderc/kokoro/windows/build_2019_amd64_release.bat"
+build_file: "shaderc/kokoro/windows/build_2022_amd64_debug.bat"
+
+action {
+  define_artifacts {
+    regex: "install.zip"
+  }
+}

--- a/kokoro/windows/vs2022_amd64_release_continuous.cfg
+++ b/kokoro/windows/vs2022_amd64_release_continuous.cfg
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Google Inc.
+# Copyright (C) 2025 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,5 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Presubmit build configuration.
-build_file: "shaderc/kokoro/windows/build_2019_amd64_release.bat"
+# Continuous build configuration.
+build_file: "shaderc/kokoro/windows/build_2022_amd64_release.bat"
+
+action {
+  define_artifacts {
+    regex: "install.zip"
+  }
+}

--- a/kokoro/windows/vs2022_amd64_release_presubmit.cfg
+++ b/kokoro/windows/vs2022_amd64_release_presubmit.cfg
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Google Inc.
+# Copyright (C) 2025 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,4 +13,10 @@
 # limitations under the License.
 
 # Presubmit build configuration.
-build_file: "shaderc/kokoro/windows/build_2019_amd64_release.bat"
+build_file: "shaderc/kokoro/windows/build_2022_amd64_release.bat"
+
+action {
+  define_artifacts {
+    regex: "install.zip"
+  }
+}


### PR DESCRIPTION
Refactor how files and scripts are named.

Add an %ARCH% argument to the build script, in anticipation of adding arm64 builds later.