### PR TITLE
Add -fmax-id-bound flag

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ vars = {
   'googletest_revision': '1d17ea141d2c11b8917d2c7d029f1c4e2b9769b2',
   're2_revision': '4a8cee3dd3c3d81b6fe8b867811e193d5819df07',
   'spirv_headers_revision': '54ae32bce772b29a253b18583b86ab813ed1887c',
-  'spirv_tools_revision': 'f1aa20b5c19eb7632c0d3255ff67c9e5cd18b405',
+  'spirv_tools_revision': '1a2d8ddb1244e06c3830cac2b65a1027cbcf9e95',
 }
 
 deps = {

--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -338,6 +338,15 @@ int main(int argc, char** argv) {
       compiler.options().SetNanClamp(true);
     } else if (arg.starts_with("-fpreserve-bindings")) {
       compiler.options().SetPreserveBindings(true);
+    } else if (arg.starts_with("-fmax-id-bound=")) {
+      const string_piece value_str = arg.substr(std::strlen("-fmax-id-bound="));
+      uint32_t bound = 0;
+      if (!shaderc_util::ParseUint32(value_str.str(), &bound)) {
+        std::cerr << "glslc: error: invalid value '" << value_str << "' in '"
+                  << arg << "'" << std::endl;
+        return 1;
+      }
+      compiler.options().SetMaxIdBound(bound);
     } else if (((u_kind = shaderc_uniform_kind_image),
                 (arg == "-fimage-binding-base")) ||
                ((u_kind = shaderc_uniform_kind_texture),

--- a/glslc/test/option_fmax_id_bound.py
+++ b/glslc/test/option_fmax_id_bound.py
@@ -1,0 +1,50 @@
+# Copyright 2025 The Shaderc Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import expect
+from glslc_test_framework import inside_glslc_testsuite
+from placeholder import FileShader
+
+COMPUTE_SHADER = """#version 450
+#extension GL_EXT_control_flow_attributes : require
+
+layout(local_size_x=1) in;
+
+layout(binding=0) buffer Out { uint x; } g_out;
+
+void main() {
+    uint x = 0;
+    [[unroll]]
+    for (int i = 0; i < 100; ++i) {
+        x = x + uint(i);
+    }
+    g_out.x = x;
+}
+"""
+
+@inside_glslc_testsuite('OptionFMaxIdBound')
+class TestFMaxIdBoundLow(expect.ErrorMessageSubstr):
+    """Tests that compilation fails with a low -fmax-id-bound."""
+
+    shader = FileShader(COMPUTE_SHADER, ".comp")
+    glslc_args = ['-c', shader, '-fmax-id-bound=300', '-O']
+    expected_error_substr = [" ID overflow. Try running compact-ids"]
+
+
+@inside_glslc_testsuite('OptionFMaxIdBound')
+class TestFMaxIdBoundHigh(expect.ValidObjectFile):
+    """Tests that compilation passes with a high -fmax-id-bound."""
+
+    shader = FileShader(COMPUTE_SHADER, ".comp")
+    glslc_args = ['-c', shader, '-fmax-id-bound=200000', '-O']

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -463,6 +463,9 @@ SHADERC_EXPORT void shaderc_compile_options_set_binding_base_for_stage(
 SHADERC_EXPORT void shaderc_compile_options_set_preserve_bindings(
     shaderc_compile_options_t options, bool preserve_bindings);
 
+SHADERC_EXPORT void shaderc_compile_options_set_max_id_bound(
+    shaderc_compile_options_t options, uint32_t max_id_bound);
+
 // Sets whether the compiler should automatically assign locations to
 // uniform variables that don't have explicit locations in the shader source.
 SHADERC_EXPORT void shaderc_compile_options_set_auto_map_locations(

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -317,6 +317,10 @@ class CompileOptions {
     shaderc_compile_options_set_preserve_bindings(options_, preserve_bindings);
   }
 
+  void SetMaxIdBound(uint32_t max_id_bound) {
+    shaderc_compile_options_set_max_id_bound(options_, max_id_bound);
+  }
+
   // Sets whether the compiler automatically assigns locations to
   // uniform variables that don't have explicit locations.
   void SetAutoMapLocations(bool auto_map) {

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -540,6 +540,11 @@ void shaderc_compile_options_set_preserve_bindings(
   options->compiler.SetPreserveBindings(preserve_bindings);
 }
 
+void shaderc_compile_options_set_max_id_bound(shaderc_compile_options_t options,
+                                              uint32_t max_id_bound) {
+  options->compiler.SetMaxIdBound(max_id_bound);
+}
+
 void shaderc_compile_options_set_auto_map_locations(
     shaderc_compile_options_t options, bool auto_map) {
   options->compiler.SetAutoMapLocations(auto_map);

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -319,6 +319,8 @@ class Compiler {
     preserve_bindings_ = preserve_bindings;
   }
 
+  void SetMaxIdBound(uint32_t max_id_bound) { max_id_bound_ = max_id_bound; }
+
   // Sets whether the compiler automatically assigns locations to
   // uniform variables that don't have explicit locations.
   void SetAutoMapLocations(bool auto_map) { auto_map_locations_ = auto_map; }
@@ -533,6 +535,8 @@ class Compiler {
 
   // True if the compiler should preserve all bindings, even when unused.
   bool preserve_bindings_;
+
+  uint32_t max_id_bound_ = 0x3FFFFF;
 
   // True if the compiler should use HLSL IO mapping rules when compiling HLSL.
   bool hlsl_iomap_;

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -370,6 +370,7 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   if (!opt_passes.empty()) {
     spvtools::OptimizerOptions opt_options;
     opt_options.set_preserve_bindings(preserve_bindings_);
+    opt_options.set_max_id_bound(max_id_bound_);
 
     std::string opt_errors;
     if (!SpirvToolsOptimize(target_env_, target_env_version_, opt_passes,


### PR DESCRIPTION
Add an option for shaderc to be able to set the max id bound used in the
compiler. This is useful for user who are hitting the limit, but are
able to use a higher value.

See https://github.com/KhronosGroup/SPIRV-Tools/issues/6260.
