### PR TITLE
Add linux-headers package to Docker to provide missing futex.h

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --update \
     build-base \
     cmake \
     git \
+    linux-headers \
     ninja \
     python3 \
     py-pip \


### PR DESCRIPTION
The subproject `third_party/abseil_cpp` fails to build due to a missing system header <linux/futex.h>, likely due to changes introduced in newer Alpine base images.

This adds the `linux-headers` package to the docker build to provide the missing header and correct the build.