### PR TITLE
fix: keep CompileOptions includer alive across copy and move

### DIFF
--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -139,14 +139,17 @@ using PreprocessedSourceCompilationResult = CompilationResult<char>;
 // Contains any options that can have default values for a compilation.
 class CompileOptions {
  public:
-  CompileOptions() { options_ = shaderc_compile_options_initialize(); }
+  CompileOptions() : options_(shaderc_compile_options_initialize()) {}
   ~CompileOptions() { shaderc_compile_options_release(options_); }
-  CompileOptions(const CompileOptions& other) {
-    options_ = shaderc_compile_options_clone(other.options_);
+  CompileOptions(const CompileOptions& other)
+      : options_(shaderc_compile_options_clone(other.options_)),
+        includer_(other.includer_) {
+    if (includer_) RegisterIncluderCallbacks();
   }
-  CompileOptions(CompileOptions&& other) {
-    options_ = other.options_;
+  CompileOptions(CompileOptions&& other)
+      : options_(other.options_), includer_(std::move(other.includer_)) {
     other.options_ = nullptr;
+    if (includer_) RegisterIncluderCallbacks();
   }
 
   // Adds a predefined macro to the compilation options. It behaves the same as
@@ -198,20 +201,12 @@ class CompileOptions {
   // are routed to this includer's methods.
   void SetIncluder(std::unique_ptr<IncluderInterface>&& includer) {
     includer_ = std::move(includer);
-    shaderc_compile_options_set_include_callbacks(
-        options_,
-        [](void* user_data, const char* requested_source, int type,
-           const char* requesting_source, size_t include_depth) {
-          auto* sub_includer = static_cast<IncluderInterface*>(user_data);
-          return sub_includer->GetInclude(
-              requested_source, static_cast<shaderc_include_type>(type),
-              requesting_source, include_depth);
-        },
-        [](void* user_data, shaderc_include_result* include_result) {
-          auto* sub_includer = static_cast<IncluderInterface*>(user_data);
-          return sub_includer->ReleaseInclude(include_result);
-        },
-        includer_.get());
+    if (includer_) {
+      RegisterIncluderCallbacks();
+    } else {
+      shaderc_compile_options_set_include_callbacks(options_, nullptr, nullptr,
+                                                    nullptr);
+    }
   }
 
   // Forces the GLSL language version and profile to a given pair. The version
@@ -378,9 +373,26 @@ class CompileOptions {
   }
 
  private:
+  void RegisterIncluderCallbacks() {
+    shaderc_compile_options_set_include_callbacks(
+        options_,
+        [](void* user_data, const char* requested_source, int type,
+           const char* requesting_source, size_t include_depth) {
+          auto* sub_includer = static_cast<IncluderInterface*>(user_data);
+          return sub_includer->GetInclude(
+              requested_source, static_cast<shaderc_include_type>(type),
+              requesting_source, include_depth);
+        },
+        [](void* user_data, shaderc_include_result* include_result) {
+          auto* sub_includer = static_cast<IncluderInterface*>(user_data);
+          return sub_includer->ReleaseInclude(include_result);
+        },
+        includer_.get());
+  }
+
   CompileOptions& operator=(const CompileOptions& other) = delete;
   shaderc_compile_options_t options_;
-  std::unique_ptr<IncluderInterface> includer_;
+  std::shared_ptr<IncluderInterface> includer_;
 
   friend class Compiler;
 };

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -811,6 +811,38 @@ class TestIncluder : public shaderc::CompileOptions::IncluderInterface {
 
 using IncluderTests = testing::TestWithParam<IncluderTestCase>;
 
+class LifetimeTrackedIncluder
+    : public shaderc::CompileOptions::IncluderInterface {
+ public:
+  LifetimeTrackedIncluder(std::shared_ptr<bool> alive, const FakeFS& fake_fs)
+      : alive_(std::move(alive)), fake_fs_(fake_fs), responses_({}) {
+    *alive_ = true;
+  }
+
+  ~LifetimeTrackedIncluder() override { *alive_ = false; }
+
+  shaderc_include_result* GetInclude(const char* requested_source,
+                                     shaderc_include_type type,
+                                     const char* requesting_source,
+                                     size_t include_depth) override {
+    (void)type;
+    (void)requesting_source;
+    (void)include_depth;
+    responses_.emplace_back(shaderc_include_result{
+        requested_source, strlen(requested_source),
+        fake_fs_.at(std::string(requested_source)).c_str(),
+        fake_fs_.at(std::string(requested_source)).size()});
+    return &responses_.back();
+  }
+
+  void ReleaseInclude(shaderc_include_result*) override {}
+
+ private:
+  std::shared_ptr<bool> alive_;
+  const FakeFS& fake_fs_;
+  std::vector<shaderc_include_result> responses_;
+};
+
 // Parameterized tests for includer.
 TEST_P(IncluderTests, SetIncluder) {
   const IncluderTestCase& test_case = GetParam();
@@ -841,6 +873,58 @@ TEST_P(IncluderTests, SetIncluderClonedOptions) {
   // Checks the existence of the expected string.
   EXPECT_THAT(CompilerOutputAsString(compilation_result),
               HasSubstr(test_case.expected_substring()));
+}
+
+TEST_F(CppInterface, CopiedOptionsKeepIncluderAliveAfterSourceDestroyed) {
+  const FakeFS fs = {
+      {"root",
+       "#version 150\n"
+       "void foo() {}\n"
+       "#include \"path/to/file_1\"\n"},
+      {"path/to/file_1", "content of file_1\n"},
+  };
+  const std::string& shader = fs.at("root");
+  auto alive = std::make_shared<bool>(false);
+  std::unique_ptr<CompileOptions> cloned_options;
+
+  {
+    CompileOptions options;
+    options.SetIncluder(std::unique_ptr<LifetimeTrackedIncluder>(
+        new LifetimeTrackedIncluder(alive, fs)));
+    cloned_options.reset(new CompileOptions(options));
+  }
+
+  ASSERT_TRUE(*alive);
+  const auto compilation_result = compiler_.PreprocessGlsl(
+      shader.c_str(), shaderc_glsl_vertex_shader, "shader", *cloned_options);
+  EXPECT_THAT(CompilerOutputAsString(compilation_result),
+              HasSubstr("content of file_1"));
+}
+
+TEST_F(CppInterface, MovedOptionsKeepIncluderAliveAfterSourceDestroyed) {
+  const FakeFS fs = {
+      {"root",
+       "#version 150\n"
+       "void foo() {}\n"
+       "#include \"path/to/file_1\"\n"},
+      {"path/to/file_1", "content of file_1\n"},
+  };
+  const std::string& shader = fs.at("root");
+  auto alive = std::make_shared<bool>(false);
+  std::unique_ptr<CompileOptions> moved_options;
+
+  {
+    CompileOptions options;
+    options.SetIncluder(std::unique_ptr<LifetimeTrackedIncluder>(
+        new LifetimeTrackedIncluder(alive, fs)));
+    moved_options.reset(new CompileOptions(std::move(options)));
+  }
+
+  ASSERT_TRUE(*alive);
+  const auto compilation_result = compiler_.PreprocessGlsl(
+      shader.c_str(), shaderc_glsl_vertex_shader, "shader", *moved_options);
+  EXPECT_THAT(CompilerOutputAsString(compilation_result),
+              HasSubstr("content of file_1"));
 }
 
 INSTANTIATE_TEST_SUITE_P(CppInterface, IncluderTests,


### PR DESCRIPTION
## Summary
This fixes a use after free in `shaderc::CompileOptions` when a custom includer is configured through `SetIncluder()` and the options object is later copied or moved before preprocessing or compilation reaches `#include`.

## Vulnerability details
`SetIncluder()` stores the includer callback state in two places:
- the C++ wrapper keeps ownership in `CompileOptions::includer_`;
- the underlying C options object stores raw callback function pointers plus `include_user_data`.

Before this change, copying `CompileOptions` only cloned `options_`, and moving it only transferred `options_`. The registered `include_user_data` therefore kept pointing at an includer owned by a different `CompileOptions` instance. Once that source object was destroyed, any later `#include` preprocessing path could call through a dangling pointer and trigger a heap use after free.

Both copy and move paths were affected. A remote shader compilation service that registers a custom includer and passes `CompileOptions` by value could be crashed with a single shader containing `#include`.

## Fix
- store the C++ includer in a `std::shared_ptr` so its lifetime can safely span copied `CompileOptions` objects;
- re-register the include callbacks after copy and move so the underlying C options object always uses the current `include_user_data`;
- clear the callbacks when `SetIncluder(nullptr)` is used;
- add regression tests that prove the includer remains alive after the source `CompileOptions` instance is destroyed and that preprocessing with `#include` still succeeds.

## Verification
- `cmake --build build-test --target check-copyright -j4`
- `./build-test/libshaderc/shaderc_shaderc_cpp_test`