### PR TITLE
Fix null pointer dereference in DependencyInfoDumpingHandler

### DIFF
--- a/glslc/src/dependency_info.cc
+++ b/glslc/src/dependency_info.cc
@@ -50,6 +50,10 @@ bool DependencyInfoDumpingHandler::DumpDependencyInfo(
     std::ofstream potential_file_stream_for_dep_info_dump;
     std::ostream* dep_file_stream = shaderc_util::GetOutputStream(
         dep_file_name, &potential_file_stream_for_dep_info_dump, &std::cerr);
+    if (!dep_file_stream) {
+      // An error message has already been emitted to the stderr stream.
+      return false;
+    }
     *dep_file_stream << dep_string_stream.str();
     if (dep_file_stream->fail()) {
       std::cerr << "glslc: error: error writing dependent_files info to output "

--- a/glslc/test/option_dash_M.py
+++ b/glslc/test/option_dash_M.py
@@ -752,3 +752,13 @@ class TestErrorMissingDependencyTargetName(expect.StderrMatch):
     glslc_args = ['target', 'shader.vert', '-c', '-MT']
     expected_stderr = ['glslc: error: '
                        'missing dependency info target after \'-MT\'\n']
+
+
+@inside_glslc_testsuite('OptionsCapM')
+class TestErrorDashMFUnwritableFile(expect.ErrorMessageSubstr):
+    """Tests that when we fail to make an output dependency file, glslc
+    fails gracefully and emits an error message instead of crashing."""
+    environment = EMPTY_SHADER_IN_CURDIR
+    bad_file = '/file/should/not/exist/today.d'
+    glslc_args = ['-MD', '-MF', bad_file, 'shader.vert']
+    expected_error_substr = ['cannot open output file']


### PR DESCRIPTION
## Description
This PR fixes a null pointer dereference vulnerability (SIGSEGV) in `DependencyInfoDumpingHandler::DumpDependencyInfo()` that occurs when `glslc` is invoked with the `-MD` flag, and the resulting dependency info output file cannot be opened for writing.

## Root Cause
When attempting to generate the `.d` dependency file in a read-only directory, a non-existent path, or when the disk is full, the utility function `shaderc_util::GetOutputStream()` correctly logs an error and returns `nullptr`. 

However, in `glslc/src/dependency_info.cc`, the stream pointer `dep_file_stream` was dereferenced unconditionally without a null check:
```cpp
*dep_file_stream << dep_string_stream.str();
```
This resulted in an immediate segmentation fault (SIGSEGV) and a process crash.

## Fix
Added a standard null check to verify `dep_file_stream` before writing to it. If it is null, the handler gracefully returns `false`. This aligns perfectly with the identical mitigation pattern previously established in `glslc/src/file_compiler.cc` (e.g. Commit `1d9790184b2e8fb726719deac80caaf6374daed7`).

## Testing
We have reproduced the crash locally and verified that with this patch, `glslc` now correctly exits with a graceful error output (`exit code 1`) instead of crashing when facing unwritable output dependency paths.