### PR TITLE
.gitignore: ignore android_test/app/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ third_party/spirv-tools
 third_party/spirv-headers
 third_party/spirv-cross
 third_party/tint
+android_test/app
 android_test/libs
 android_test/include
 .DS_Store


### PR DESCRIPTION
Those files are generated during the ndk-build test