### PR TITLE
no-hlsl: don't invoke setEnvTargetHlslFunctionality1

### DIFF
--- a/kokoro/ndk-build-nohlsl/build.sh
+++ b/kokoro/ndk-build-nohlsl/build.sh
@@ -16,5 +16,5 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$( cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd )"
 
-SHADERC_ENABLE_HLSL=OFF
+SHADERC_ENABLE_HLSL=0
 exec ${ROOT_DIR}/kokoro/scripts/ndk-build/build.sh $SHADERC_ENABLE_HLSL

--- a/kokoro/ndk-build/build.sh
+++ b/kokoro/ndk-build/build.sh
@@ -16,5 +16,5 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$( cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd )"
 
-SHADERC_ENABLE_HLSL=ON
+SHADERC_ENABLE_HLSL=1
 exec ${ROOT_DIR}/kokoro/scripts/ndk-build/build.sh $SHADERC_ENABLE_HLSL

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -308,9 +308,11 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
                       target_client_info.client_version);
   shader.setEnvTarget(target_client_info.target_language,
                       target_client_info.target_language_version);
+#if SHADERC_ENABLE_HLSL
   if (hlsl_functionality1_enabled_) {
     shader.setEnvTargetHlslFunctionality1();
   }
+#endif
   if (vulkan_rules_relaxed_) {
     glslang::EShSource language = glslang::EShSourceNone;
     switch (source_language_) {
@@ -520,9 +522,11 @@ std::tuple<bool, std::string, std::string> Compiler::PreprocessShader(
   }
   shader.setEnvClient(target_client_info.client,
                       target_client_info.client_version);
+#if SHADERC_ENABLE_HLSL
   if (hlsl_functionality1_enabled_) {
     shader.setEnvTargetHlslFunctionality1();
   }
+#endif
   shader.setInvertY(invert_y_enabled_);
   shader.setNanMinMaxClamp(nan_clamp_);
 


### PR DESCRIPTION
Also in kokoro scripts:
- ndk-build expects 0 or non-zero for SHADERC_ENABLE_HLSL
- fix executable perm on ndk-build-nohlsl/build.sh