### PR TITLE
io_shaderc.h: add missing `<fstream>` include

### DIFF
--- a/libshaderc_util/include/libshaderc_util/io_shaderc.h
+++ b/libshaderc_util/include/libshaderc_util/io_shaderc.h
@@ -15,6 +15,7 @@
 #ifndef LIBSHADERC_UTIL_IO_H_
 #define LIBSHADERC_UTIL_IO_H_
 
+#include <fstream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
`gcc-17` cleaned up transitive header inclusion and exposed missing header as a build failure:

```
In file included from /build/source/libshaderc_util/src/io_shaderc.cc:15:
/build/source/libshaderc_util/include/libshaderc_util/io_shaderc.h:54:31: error: 'std::ofstream' has not been declared
   54 |                               std::ofstream* file_stream, std::ostream* err);
      |                               ^~~
```