### PR TITLE
tighten github actions

### DIFF
--- a/.github/workflows/autoroll.yml
+++ b/.github/workflows/autoroll.yml
@@ -30,7 +30,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
 
       # Checkout the depot tools they are needed by roll_deps.sh
       - name: Checkout depot tools


### PR DESCRIPTION
- pin actions/checkout to a specific hash
- drop credentials for actions/checkout

crbug.com/529861263