### PR TITLE
libshaderc_util: make DecodeLineDirective robust to a non-canonical #line prefix

### DIFF
--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -56,7 +56,13 @@ inline std::string GetLineDirective(int line, const string_piece& filename) {
 // canonicalized #line directive.
 std::pair<int, string_piece> DecodeLineDirective(string_piece directive) {
   const string_piece kLineDirective = "#line ";
-  assert(directive.starts_with(kLineDirective));
+  // The caller (GetShaderStageFromSourceCode) only checks for the "#line" prefix
+  // without the trailing space, so `directive` may be one character shorter than
+  // kLineDirective. The precondition that it is a canonical "#line " directive was
+  // enforced only by an assert, which is compiled out in release builds; a line
+  // equal to exactly "#line" would then make substr() below advance past the end.
+  // Verify the full canonical prefix at runtime and bail out otherwise.
+  if (!directive.starts_with(kLineDirective)) return std::make_pair(0, string_piece());
   directive = directive.substr(kLineDirective.size());
 
   const int line = std::atoi(directive.data());


### PR DESCRIPTION
### Description

`Compiler::GetShaderStageFromSourceCode` guards with `starts_with("#line")` — five
characters, no trailing space (`kLineDirective = "#line"`) — and then calls
`DecodeLineDirective`, whose own local `kLineDirective` is `"#line "` (six characters)
and which does `directive.substr(kLineDirective.size())` == `substr(6)`.

`DecodeLineDirective`'s documented precondition (a canonicalized `#line ` directive) is
enforced only by `assert(directive.starts_with(kLineDirective))`, which is compiled out
under `NDEBUG`. A line equal to exactly `"#line"` (five characters) passes the caller's
five-character check but is one character shorter than the six the callee consumes, so in
a release build `string_piece::substr(6)` produces a piece whose `begin_ > end_` (its own
bound is likewise an assert), after which `size()` underflows.

This is latent in practice because glslang's preprocessor rejects a bare `#line` before
this code runs, so it is not a reachable defect via shader input — but the helper should
not silently rely on that. This change verifies the full canonical prefix at runtime and
returns early otherwise, so the release behavior matches the precondition regardless of
the caller. No functional change for well-formed `#line <n>` directives.
