### PR TITLE
Avoid invalid string_view iterators when parsing #line directives

### DIFF
--- a/libshaderc_util/include/libshaderc_util/string_piece.h
+++ b/libshaderc_util/include/libshaderc_util/string_piece.h
@@ -32,9 +32,10 @@ class string_piece {
   typedef const char* iterator;
   static const size_t npos = -1;
 
-  string_piece() {}
+  constexpr string_piece() {}
 
-  string_piece(const char* begin, const char* end) : begin_(begin), end_(end) {
+  constexpr string_piece(const char* begin, const char* end)
+      : begin_(begin), end_(end) {
     assert((begin == nullptr) == (end == nullptr) &&
            "either both begin and end must be nullptr or neither must be");
   }

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -34,6 +34,10 @@
 namespace {
 using shaderc_util::string_piece;
 
+constexpr const char* kLineDirectivePrefixCstr = "#line ";
+constexpr string_piece kLineDirectivePrefix(kLineDirectivePrefixCstr,
+                                            kLineDirectivePrefixCstr + 6);
+
 // For use with glslang parsing calls.
 const bool kNotForwardCompatible = false;
 
@@ -45,7 +49,8 @@ inline bool LineDirectiveIsForNextLine(int version, EProfile profile) {
 
 // Returns a #line directive whose arguments are line and filename.
 inline std::string GetLineDirective(int line, const string_piece& filename) {
-  return "#line " + std::to_string(line) + " \"" + filename.str() + "\"\n";
+  return kLineDirectivePrefix.str() + std::to_string(line) + " \"" +
+         filename.str() + "\"\n";
 }
 
 // Given a canonicalized #line directive (starting exactly with "#line", using
@@ -55,9 +60,8 @@ inline std::string GetLineDirective(int line, const string_piece& filename) {
 // empty string_piece. Behavior is undefined if the directive parameter is not a
 // canonicalized #line directive.
 std::pair<int, string_piece> DecodeLineDirective(string_piece directive) {
-  const string_piece kLineDirective = "#line ";
-  assert(directive.starts_with(kLineDirective));
-  directive = directive.substr(kLineDirective.size());
+  assert(directive.starts_with(kLineDirectivePrefix));
+  directive = directive.substr(kLineDirectivePrefix.size());
 
   const int line = std::atoi(directive.data());
   const size_t space_loc = directive.find_first_of(' ');
@@ -619,7 +623,6 @@ std::string Compiler::CleanupPreamble(const string_piece& preprocessed_shader,
 std::pair<EShLanguage, std::string> Compiler::GetShaderStageFromSourceCode(
     string_piece filename, const std::string& preprocessed_shader) const {
   const string_piece kPragmaShaderStageDirective = "#pragma shader_stage";
-  const string_piece kLineDirective = "#line";
 
   int version;
   EProfile profile;
@@ -648,7 +651,7 @@ std::pair<EShLanguage, std::string> Compiler::GetShaderStageFromSourceCode(
     }
 
     // Update logical line number for the next line.
-    if (current_line.starts_with(kLineDirective)) {
+    if (current_line.starts_with(kLineDirectivePrefix)) {
       string_piece name;
       std::tie(logical_line_no, name) = DecodeLineDirective(current_line);
       if (!name.empty()) filename = name;


### PR DESCRIPTION
Thanks to the implied bug report in
https://github.com/google/shaderc/pull/1578