### PR TITLE
Fix: Add missing <memory> header in shaderc_private.h

### DIFF
--- a/libshaderc/src/shaderc_private.h
+++ b/libshaderc/src/shaderc_private.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "shaderc/shaderc.h"
 


### PR DESCRIPTION
Adding the missing <memory> header to resolve a compilation error when building with MinGW64 on Windows.

<details>
<summary><b>Click here to expand the error log</b></summary> Error:
PS C:\Users\Akash\Music\shaderc lib\shaderc\build> ninja [1075/1158] Building CXX object libshaderc/CMakeFiles/shaderc_shaderc_private_test.dir/src/shaderc_private_test.cc.obj FAILED: [code=1] libshaderc/CMakeFiles/shaderc_shaderc_private_test.dir/src/shaderc_private_test.cc.obj C:\msys64\mingw64\bin\c++.exe -DSHADERC_ENABLE_HLSL=1 -I"C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc/include" -I"C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc_util/include" -I"C:/Users/Akash/Music/shaderc lib/shaderc/third_party/glslang" -I"C:/Users/Akash/Music/shaderc lib/shaderc/third_party/spirv-tools/include" -I"C:/Users/Akash/Music/shaderc lib/shaderc/third_party/spirv-headers/include" -isystem "C:/Users/Akash/Music/shaderc lib/shaderc/third_party/googletest/googlemock/include" -isystem "C:/Users/Akash/Music/shaderc lib/shaderc/third_party/googletest/googletest/include" -isystem "C:/Users/Akash/Music/shaderc lib/shaderc/third_party/googletest/googlemock" -isystem "C:/Users/Akash/Music/shaderc lib/shaderc/third_party/googletest/googletest" -Wimplicit-fallthrough -O3 -DNDEBUG -Wextra-semi -Wall -Werror -fvisibility=hidden -DSHADERC_DISABLE_THREADED_TESTS -Wno-noexcept-type -MD -MT libshaderc/CMakeFiles/shaderc_shaderc_private_test.dir/src/shaderc_private_test.cc.obj -MF libshaderc\CMakeFiles\shaderc_shaderc_private_test.dir\src\shaderc_private_test.cc.obj.d -o libshaderc/CMakeFiles/shaderc_shaderc_private_test.dir/src/shaderc_private_test.cc.obj -c "C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc/src/shaderc_private_test.cc" In file included from C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc/src/shaderc_private_test.cc:15: C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc/src/shaderc_private.h:93:8: error: 'unique_ptr' in namespace 'std' does not name a template type
   93 |   std::unique_ptr<shaderc_util::GlslangInitializer> initializer;
      |        ^~~~~~~~~~
C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc/src/shaderc_private.h:27:1: note: 'std::unique_ptr' is defined in header '<memory>'; this is probably fixable by adding '#include <memory>'
   26 | #include "spirv-tools/libspirv.h"
  +++ |+#include <memory>
   27 |
[1076/1158] Building CXX object libshaderc/CMakeFiles/shad...ed_shaderc_private_test.dir/src/shaderc_private_test.cc.ob
FAILED: [code=1] libshaderc/CMakeFiles/shaderc_shared_shaderc_private_test.dir/src/shaderc_private_test.cc.obj
C:\msys64\mingw64\bin\c++.exe -DSHADERC_ENABLE_HLSL=1 -DSHADERC_SHAREDLIB -I"C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc/include" -I"C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc_util/include" -I"C:/Users/Akash/Music/shaderc lib/shaderc/third_party/glslang" -I"C:/Users/Akash/Music/shaderc lib/shaderc/third_party/spirv-tools/include" -I"C:/Users/Akash/Music/shaderc lib/shaderc/third_party/spirv-headers/include" -isystem "C:/Users/Akash/Music/shaderc lib/shaderc/third_party/googletest/googlemock/include" -isystem "C:/Users/Akash/Music/shaderc lib/shaderc/third_party/googletest/googletest/include" -isystem "C:/Users/Akash/Music/shaderc lib/shaderc/third_party/googletest/googlemock" -isystem "C:/Users/Akash/Music/shaderc lib/shaderc/third_party/googletest/googletest" -Wimplicit-fallthrough -O3 -DNDEBUG -Wextra-semi -Wall -Werror -fvisibility=hidden -DSHADERC_DISABLE_THREADED_TESTS -Wno-noexcept-type -MD -MT libshaderc/CMakeFiles/shaderc_shared_shaderc_private_test.dir/src/shaderc_private_test.cc.obj -MF libshaderc\CMakeFiles\shaderc_shared_shaderc_private_test.dir\src\shaderc_private_test.cc.obj.d -o libshaderc/CMakeFiles/shaderc_shared_shaderc_private_test.dir/src/shaderc_private_test.cc.obj -c "C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc/src/shaderc_private_test.cc"
In file included from C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc/src/shaderc_private_test.cc:15:
C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc/src/shaderc_private.h:93:8: error: 'unique_ptr' in namespace 'std' does not name a template type
   93 |   std::unique_ptr<shaderc_util::GlslangInitializer> initializer;
      |        ^~~~~~~~~~
C:/Users/Akash/Music/shaderc lib/shaderc/libshaderc/src/shaderc_private.h:27:1: note: 'std::unique_ptr' is defined in header '<memory>'; this is probably fixable by adding '#include <memory>'
   26 | #include "spirv-tools/libspirv.h"
  +++ |+#include <memory>
   27 |
[1084/1158] Building CXX object third_party/spirv-tools/test/opt/CMakeFiles/test_opt.dir/fold_test.cpp.obj
ninja: build stopped: subcommand failed.
</details>

Environment:

-OS: Windows 11
-Compiler:  CXX GCC 15.1.0 (via MSYS2/MinGW64)
-Build System: Ninja
-Build Configuration:Release mode

Verification:
I have applied this change locally and verified that the project now builds successfully using ninja.