### PR TITLE
libshaderc_util: assert pos <= size() in string_piece::substr

### DIFF
--- a/libshaderc_util/include/libshaderc_util/string_piece.h
+++ b/libshaderc_util/include/libshaderc_util/string_piece.h
@@ -75,6 +75,7 @@ class string_piece {
 
   // Returns a string_piece that points to a substring in the original string.
   string_piece substr(size_t pos, size_t len = npos) const {
+    assert(pos <= size());
     assert(len == npos || pos + len <= size());
     return string_piece(begin_ + pos, len == npos ? end_ : begin_ + pos + len);
   }


### PR DESCRIPTION
### Summary

`string_piece::substr(pos, len = npos)` currently only asserts
`len == npos || pos + len <= size()`. When `len == npos` (the default),
the assertion short-circuits and `pos > size()` is silently allowed,
producing a `string_piece` with `begin_ > end_`.

This invalid `string_piece` then cascades to unsound behavior in every
downstream accessor:
- `size()` returns a wrapped value near `SIZE_MAX` due to
  signed-to-unsigned conversion of a negative `ptrdiff_t`.
- `empty()` falsely returns `false`.
- `find_first_of` / `find_last_of` iterate for the wrapped size,
  producing out-of-bounds reads.
- `operator<<` passes a negative `std::streamsize` to
  `std::ostream::write`.
- `data()` returns a dangling pointer past the end of the buffer.

Only `lstrip` / `rstrip` currently defend against inversion (lines 200
and 209).

### Relation to prior hardening

Commit cb6f1ef ("Avoid invalid string_view iterators when parsing
`#line` directives") addressed one caller-side occurrence of this
class by tightening a `starts_with` check. This change addresses the
primitive itself, so that any future caller introducing the same
pattern is caught in debug builds.

### Change

A single additional `assert(pos <= size())` before the existing
assertion. No behavior change in release builds. No API change.

### Reference

Reported via Google OSS VRP issue tracker #537914890.builds.