### PR TITLE
Add NonSemantic.Shader.DebugInfo.100 options for Nvidia Nsight and/or RenderDoc source debugging

### DIFF
--- a/glslc/src/main.cc
+++ b/glslc/src/main.cc
@@ -134,6 +134,10 @@ Options:
                     rgen, anyhit, rahit, closest, rchit, miss, rmiss, intersect,
                     rint, callable, rcall, task, and mesh.
   -g                Generate source-level debug information.
+  -gV               Generate non-semantic debug information
+                    (NonSemantic.Shader.DebugInfo.100).
+  -gVS              Generate non-semantic debug information with embedded
+                    source. Implies -gV.
   -h                Display available options.
   --help            Display available options.
   -I <value>        Add directory to include search path.
@@ -645,6 +649,10 @@ int main(int argc, char** argv) {
       }
     } else if (arg == "-g") {
       compiler.options().SetGenerateDebugInfo();
+    } else if (arg == "-gV") {
+      compiler.options().SetGenerateNonSemanticDebugInfo();
+    } else if (arg == "-gVS") {
+      compiler.options().SetGenerateNonSemanticDebugSource();
     } else if (arg.starts_with("-O")) {
       if (arg == "-O") {
         compiler.options().SetOptimizationLevel(

--- a/glslc/test/option_dash_gV.py
+++ b/glslc/test/option_dash_gV.py
@@ -1,0 +1,30 @@
+# Copyright 2026 The Shaderc Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import expect
+from glslc_test_framework import inside_glslc_testsuite
+from placeholder import FileShader
+
+
+def empty_es_310_shader():
+    return '#version 310 es\n void main() {}\n'
+
+
+@inside_glslc_testsuite('OptionGV')
+class TestDashGVAcceptedAndEmitsNonSemantic(expect.ValidAssemblyFileWithSubstr):
+    """Tests that -gV compiles and emits NonSemantic debug info."""
+
+    shader = FileShader(empty_es_310_shader(), '.vert')
+    glslc_args = ['-S', '-gV', shader]
+    expected_assembly_substr = 'NonSemantic.Shader.DebugInfo.100'

--- a/glslc/test/option_dash_gVS.py
+++ b/glslc/test/option_dash_gVS.py
@@ -12,20 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+
 import expect
+from environment import File, Directory
 from glslc_test_framework import inside_glslc_testsuite
-from placeholder import FileShader
 
+MINIMAL_SHADER = '#version 310 es\nvoid main() {}\n'
 
-def debug_info_sample_shader():
-    return '#version 140\n void main() { vec4 debug_info_sample; }\n'
+EMPTY_SHADER_IN_CWD = Directory('.', [File('shader.vert', MINIMAL_SHADER)])
+
+# -gVS emits the NonSemantic import and a DebugSource carrying a second
+# operand (the embedded source OpString), which -gV alone does not.
+NONSEMANTIC_SOURCE_RE = re.compile(
+    r'OpExtInstImport "NonSemantic\.Shader\.DebugInfo\.100"'
+    r'[\s\S]*DebugSource %\w+ %\w+')
 
 
 @inside_glslc_testsuite('OptionGVS')
-class TestDashGVSEmitsNonSemanticWithSource(expect.ValidAssemblyFileWithSubstr):
+class TestDashGVSEmitsNonSemanticWithSource(expect.ValidFileContents):
     """Tests that -gVS emits NonSemantic debug info with embedded source."""
 
-    shader = FileShader(debug_info_sample_shader(), '.vert')
-    glslc_args = ['-S', '-gVS', shader]
-    expected_assembly_substrings = ['NonSemantic.Shader.DebugInfo.100',
-                                    'debug_info_sample']
+    environment = EMPTY_SHADER_IN_CWD
+    glslc_args = ['-S', '-gVS', 'shader.vert']
+    target_filename = 'shader.vert.spvasm'
+    expected_file_contents = NONSEMANTIC_SOURCE_RE

--- a/glslc/test/option_dash_gVS.py
+++ b/glslc/test/option_dash_gVS.py
@@ -1,0 +1,31 @@
+# Copyright 2026 The Shaderc Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import expect
+from glslc_test_framework import inside_glslc_testsuite
+from placeholder import FileShader
+
+
+def debug_info_sample_shader():
+    return '#version 140\n void main() { vec4 debug_info_sample; }\n'
+
+
+@inside_glslc_testsuite('OptionGVS')
+class TestDashGVSEmitsNonSemanticWithSource(expect.ValidAssemblyFileWithSubstr):
+    """Tests that -gVS emits NonSemantic debug info with embedded source."""
+
+    shader = FileShader(debug_info_sample_shader(), '.vert')
+    glslc_args = ['-S', '-gVS', shader]
+    expected_assembly_substrings = ['NonSemantic.Shader.DebugInfo.100',
+                                    'debug_info_sample']

--- a/glslc/test/parameter_tests.py
+++ b/glslc/test/parameter_tests.py
@@ -138,6 +138,10 @@ Options:
                     rgen, anyhit, rahit, closest, rchit, miss, rmiss, intersect,
                     rint, callable, rcall, task, and mesh.
   -g                Generate source-level debug information.
+  -gV               Generate non-semantic debug information
+                    (NonSemantic.Shader.DebugInfo.100).
+  -gVS              Generate non-semantic debug information with embedded
+                    source. Implies -gV.
   -h                Display available options.
   --help            Display available options.
   -I <value>        Add directory to include search path.

--- a/libshaderc/include/shaderc/shaderc.h
+++ b/libshaderc/include/shaderc/shaderc.h
@@ -319,6 +319,14 @@ SHADERC_EXPORT void shaderc_compile_options_set_source_language(
 SHADERC_EXPORT void shaderc_compile_options_set_generate_debug_info(
     shaderc_compile_options_t options);
 
+// Emits NonSemantic.Shader.DebugInfo.100 (function/call-site info; glslang -gV).
+SHADERC_EXPORT void shaderc_compile_options_set_generate_nonsemantic_debug_info(
+    shaderc_compile_options_t options);
+
+// Additionally embeds source in the NonSemantic debug info (glslang -gVS); implies info.
+SHADERC_EXPORT void shaderc_compile_options_set_generate_nonsemantic_debug_source(
+    shaderc_compile_options_t options);
+
 // Sets the compiler optimization level to the given level. Only the last one
 // takes effect if multiple calls of this function exist.
 SHADERC_EXPORT void shaderc_compile_options_set_optimization_level(

--- a/libshaderc/include/shaderc/shaderc.hpp
+++ b/libshaderc/include/shaderc/shaderc.hpp
@@ -172,6 +172,16 @@ class CompileOptions {
     shaderc_compile_options_set_generate_debug_info(options_);
   }
 
+  // Emits NonSemantic.Shader.DebugInfo.100 (function/call-site info).
+  void SetGenerateNonSemanticDebugInfo() {
+    shaderc_compile_options_set_generate_nonsemantic_debug_info(options_);
+  }
+
+  // Additionally embeds source in the NonSemantic debug info; implies info.
+  void SetGenerateNonSemanticDebugSource() {
+    shaderc_compile_options_set_generate_nonsemantic_debug_source(options_);
+  }
+
   // Sets the compiler optimization level to the given level. Only the last one
   // takes effect if multiple calls of this function exist.
   void SetOptimizationLevel(shaderc_optimization_level level) {

--- a/libshaderc/src/shaderc.cc
+++ b/libshaderc/src/shaderc.cc
@@ -426,6 +426,16 @@ void shaderc_compile_options_set_generate_debug_info(
   options->compiler.SetGenerateDebugInfo();
 }
 
+void shaderc_compile_options_set_generate_nonsemantic_debug_info(
+    shaderc_compile_options_t options) {
+  options->compiler.SetGenerateNonSemanticDebugInfo();
+}
+
+void shaderc_compile_options_set_generate_nonsemantic_debug_source(
+    shaderc_compile_options_t options) {
+  options->compiler.SetGenerateNonSemanticDebugSource();
+}
+
 void shaderc_compile_options_set_optimization_level(
     shaderc_compile_options_t options, shaderc_optimization_level level) {
   auto opt_level = shaderc_util::Compiler::OptimizationLevel::Zero;

--- a/libshaderc/src/shaderc_cpp_test.cc
+++ b/libshaderc/src/shaderc_cpp_test.cc
@@ -491,6 +491,21 @@ TEST_F(CppInterface, GenerateDebugInfoDisassembly) {
               HasSubstr("debug_info_sample"));
 }
 
+TEST_F(CppInterface, GenerateNonSemanticDebugInfoDisassembly) {
+  options_.SetGenerateNonSemanticDebugInfo();
+  EXPECT_THAT(AssemblyOutput(kMinimalDebugInfoShader,
+                             shaderc_glsl_vertex_shader, options_),
+              HasSubstr("NonSemantic.Shader.DebugInfo.100"));
+}
+
+TEST_F(CppInterface, GenerateNonSemanticDebugSourceDisassembly) {
+  options_.SetGenerateNonSemanticDebugSource();
+  const std::string disassembly_text = AssemblyOutput(
+      kMinimalDebugInfoShader, shaderc_glsl_vertex_shader, options_);
+  EXPECT_THAT(disassembly_text, HasSubstr("NonSemantic.Shader.DebugInfo.100"));
+  EXPECT_THAT(disassembly_text, HasSubstr("debug_info_sample"));
+}
+
 TEST_F(CppInterface, GenerateDebugInfoDisassemblyClonedOptions) {
   options_.SetGenerateDebugInfo();
   // Generate debug info mode should be carried to the cloned options.

--- a/libshaderc/src/shaderc_test.cc
+++ b/libshaderc/src/shaderc_test.cc
@@ -647,6 +647,25 @@ TEST_F(CompileStringWithOptionsTest, GenerateDebugInfoDisassembly) {
       HasSubstr("debug_info_sample"));
 }
 
+TEST_F(CompileStringWithOptionsTest, GenerateNonSemanticDebugInfoDisassembly) {
+  shaderc_compile_options_set_generate_nonsemantic_debug_info(options_.get());
+  ASSERT_NE(nullptr, compiler_.get_compiler_handle());
+  EXPECT_THAT(
+      CompilationOutput(kMinimalDebugInfoShader, shaderc_glsl_vertex_shader,
+                        options_.get(), OutputType::SpirvAssemblyText),
+      HasSubstr("NonSemantic.Shader.DebugInfo.100"));
+}
+
+TEST_F(CompileStringWithOptionsTest, GenerateNonSemanticDebugSourceDisassembly) {
+  shaderc_compile_options_set_generate_nonsemantic_debug_source(options_.get());
+  ASSERT_NE(nullptr, compiler_.get_compiler_handle());
+  const std::string disassembly_text =
+      CompilationOutput(kMinimalDebugInfoShader, shaderc_glsl_vertex_shader,
+                        options_.get(), OutputType::SpirvAssemblyText);
+  EXPECT_THAT(disassembly_text, HasSubstr("NonSemantic.Shader.DebugInfo.100"));
+  EXPECT_THAT(disassembly_text, HasSubstr("debug_info_sample"));
+}
+
 TEST_F(CompileStringWithOptionsTest, CompileAndOptimizeWithLevelZero) {
   shaderc_compile_options_set_optimization_level(
       options_.get(), shaderc_optimization_level_zero);

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -479,7 +479,7 @@ class Compiler {
       const std::string& preprocessed_shader) const;
 
   // Neutralizes any queued kStripDebugInfo pass so requested debug info survives optimization.
-  void UnstripDebugInfoPasses();
+  void RemoveStripDebugInfoPass();
 
   // Version to use when force_version_profile_ is true.
   int default_version_;

--- a/libshaderc_util/include/libshaderc_util/compiler.h
+++ b/libshaderc_util/include/libshaderc_util/compiler.h
@@ -195,6 +195,8 @@ class Compiler {
         warnings_as_errors_(false),
         suppress_warnings_(false),
         generate_debug_info_(false),
+        generate_nonsemantic_debug_info_(false),
+        generate_nonsemantic_debug_source_(false),
         enabled_opt_passes_(),
         target_env_(TargetEnv::Vulkan),
         target_env_version_(TargetEnvVersion::Default),
@@ -219,6 +221,12 @@ class Compiler {
   // Requests that the compiler place debug information into the object code,
   // such as identifier names and line numbers.
   void SetGenerateDebugInfo();
+
+  // Requests NonSemantic.Shader.DebugInfo.100 (function/call-site info).
+  void SetGenerateNonSemanticDebugInfo();
+
+  // Requests embedded source in the NonSemantic debug info; implies info.
+  void SetGenerateNonSemanticDebugSource();
 
   // Sets the optimization level to the given level. Only the last one takes
   // effect if multiple calls of this method exist.
@@ -470,6 +478,9 @@ class Compiler {
   std::pair<int, EProfile> GetVersionProfileFromSourceCode(
       const std::string& preprocessed_shader) const;
 
+  // Neutralizes any queued kStripDebugInfo pass so requested debug info survives optimization.
+  void UnstripDebugInfoPasses();
+
   // Version to use when force_version_profile_ is true.
   int default_version_;
   // Profile to use when force_version_profile_ is true.
@@ -488,6 +499,13 @@ class Compiler {
   // When true, compilation will generate debug info with the binary SPIR-V
   // output.
   bool generate_debug_info_;
+
+  // When true, emit NonSemantic.Shader.DebugInfo.100 (glslang -gV).
+  bool generate_nonsemantic_debug_info_;
+
+  // When true, also embed source in the NonSemantic debug info (glslang -gVS).
+  // Only takes effect when generate_nonsemantic_debug_info_ is also true.
+  bool generate_nonsemantic_debug_source_;
 
   // Optimization passes to be applied.
   std::vector<PassId> enabled_opt_passes_;

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -363,6 +363,8 @@ std::tuple<bool, std::vector<uint32_t>, size_t> Compiler::Compile(
   std::vector<uint32_t>& spirv = compilation_output_data;
   glslang::SpvOptions options;
   options.generateDebugInfo = generate_debug_info_;
+  options.emitNonSemanticShaderDebugInfo = generate_nonsemantic_debug_info_;
+  options.emitNonSemanticShaderDebugSource = generate_nonsemantic_debug_source_;
   options.disableOptimizer = true;
   options.optimizeSize = false;
   // Note the call to GlslangToSpv also populates compilation_output_data.
@@ -454,13 +456,28 @@ void Compiler::SetForcedVersionProfile(int version, EProfile profile) {
 
 void Compiler::SetWarningsAsErrors() { warnings_as_errors_ = true; }
 
-void Compiler::SetGenerateDebugInfo() {
-  generate_debug_info_ = true;
-  for (size_t i = 0; i < enabled_opt_passes_.size(); ++i) {
-    if (enabled_opt_passes_[i] == PassId::kStripDebugInfo) {
-      enabled_opt_passes_[i] = PassId::kNullPass;
+void Compiler::UnstripDebugInfoPasses() {
+  for (auto& pass : enabled_opt_passes_) {
+    if (pass == PassId::kStripDebugInfo) {
+      pass = PassId::kNullPass;
     }
   }
+}
+
+void Compiler::SetGenerateDebugInfo() {
+  generate_debug_info_ = true;
+  UnstripDebugInfoPasses();
+}
+
+void Compiler::SetGenerateNonSemanticDebugInfo() {
+  generate_nonsemantic_debug_info_ = true;
+  UnstripDebugInfoPasses();
+}
+
+void Compiler::SetGenerateNonSemanticDebugSource() {
+  generate_nonsemantic_debug_info_ = true;
+  generate_nonsemantic_debug_source_ = true;
+  UnstripDebugInfoPasses();
 }
 
 void Compiler::SetOptimizationLevel(Compiler::OptimizationLevel level) {
@@ -469,13 +486,13 @@ void Compiler::SetOptimizationLevel(Compiler::OptimizationLevel level) {
 
   switch (level) {
     case OptimizationLevel::Size:
-      if (!generate_debug_info_) {
+      if (!generate_debug_info_ && !generate_nonsemantic_debug_info_) {
         enabled_opt_passes_.push_back(PassId::kStripDebugInfo);
       }
       enabled_opt_passes_.push_back(PassId::kSizePasses);
       break;
     case OptimizationLevel::Performance:
-      if (!generate_debug_info_) {
+      if (!generate_debug_info_ && !generate_nonsemantic_debug_info_) {
         enabled_opt_passes_.push_back(PassId::kStripDebugInfo);
       }
       enabled_opt_passes_.push_back(PassId::kPerformancePasses);

--- a/libshaderc_util/src/compiler.cc
+++ b/libshaderc_util/src/compiler.cc
@@ -456,7 +456,7 @@ void Compiler::SetForcedVersionProfile(int version, EProfile profile) {
 
 void Compiler::SetWarningsAsErrors() { warnings_as_errors_ = true; }
 
-void Compiler::UnstripDebugInfoPasses() {
+void Compiler::RemoveStripDebugInfoPass() {
   for (auto& pass : enabled_opt_passes_) {
     if (pass == PassId::kStripDebugInfo) {
       pass = PassId::kNullPass;
@@ -466,18 +466,18 @@ void Compiler::UnstripDebugInfoPasses() {
 
 void Compiler::SetGenerateDebugInfo() {
   generate_debug_info_ = true;
-  UnstripDebugInfoPasses();
+  RemoveStripDebugInfoPass();
 }
 
 void Compiler::SetGenerateNonSemanticDebugInfo() {
   generate_nonsemantic_debug_info_ = true;
-  UnstripDebugInfoPasses();
+  RemoveStripDebugInfoPass();
 }
 
 void Compiler::SetGenerateNonSemanticDebugSource() {
   generate_nonsemantic_debug_info_ = true;
   generate_nonsemantic_debug_source_ = true;
-  UnstripDebugInfoPasses();
+  RemoveStripDebugInfoPass();
 }
 
 void Compiler::SetOptimizationLevel(Compiler::OptimizationLevel level) {


### PR DESCRIPTION
### What

Adds two compile options that make shaderc emit NonSemantic.Shader.DebugInfo.100, equivalent to glslang's -gV / -gVS:

- shaderc_compile_options_set_generate_nonsemantic_debug_info, equivalent to -gV
- shaderc_compile_options_set_generate_nonsemantic_debug_source, equivalent to -gVS

Additionally, I have wired up matching CompileOptions::SetGenerateNonSemanticDebugInfo() / SetGenerateNonSemanticDebugSource() in the C++ wrapper.

### Why

set_generate_debug_info only emits OpLine/OpSource (glslang -g). Tools like NVIDIA Nsight Graphics need NonSemantic.Shader.DebugInfo.100 for function- and call-site-level source correlation (Flame Graph, Top-Down/Bottom-Up Calls). shaderc had no way to request it (see #1391), so callers had to drop to glslang or dxc directly. The pull requests makes these new flag independent from generate_debug_info so plain -g stays available as a fallback for shaders that fail to compile withNonSemantic info enabled.

### Usage: a Nsight-ready build

```C
    shaderc_compile_options_t options = shaderc_compile_options_initialize();
    shaderc_compile_options_set_generate_debug_info(options);               // -g:   OpLine/OpSource
    shaderc_compile_options_set_generate_nonsemantic_debug_source(options); // -gVS: NonSemantic + source
    shaderc_compile_options_set_optimization_level(options, shaderc_optimization_level_zero);
```

-g provides the line table, -gVS provides the call graph; Nsight uses both. Optimization must stay at zero. The size/performance passes can mangle or strip NonSemantic info even with the strip-guards in place.

### Notes

- Build against glslang >= 15.0.0; earlier versions point every DebugFunction at the same file, corrupting name/line correlation.
- Some shaders fail to compile with NonSemantic enabled; since the new flags are independent of -g, this is now a non-issue since builds need to opt in.